### PR TITLE
docs: add contribution guidelines and changeset enforcement

### DIFF
--- a/.changeset/contribution-docs.md
+++ b/.changeset/contribution-docs.md
@@ -1,0 +1,8 @@
+---
+"bitbucket-cli": patch
+---
+
+Add contribution guidelines and changeset enforcement
+
+- Added CONTRIBUTING.md with development setup, workflow, and release process
+- Added GitHub Action to require changesets on PRs (skips docs-only changes)

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,66 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Check for changeset
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changesets
+        id: changesets
+        run: |
+          CHANGESETS=$(ls .changeset/*.md 2>/dev/null | grep -v README.md | wc -l | tr -d ' ')
+          echo "count=$CHANGESETS" >> $GITHUB_OUTPUT
+
+      - name: Get changed files
+        id: changed
+        run: |
+          FILES=$(git diff --name-only origin/main...HEAD)
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Check if only docs/config files changed
+          DOCS_ONLY=true
+          for file in $FILES; do
+            case "$file" in
+              *.md|.github/*|docs/*|.changeset/*)
+                ;;
+              *)
+                DOCS_ONLY=false
+                break
+                ;;
+            esac
+          done
+          echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+
+      - name: Require changeset
+        if: steps.changesets.outputs.count == '0' && steps.changed.outputs.docs_only == 'false'
+        run: |
+          echo "::error::Missing changeset. Please run 'bun changeset' and commit the generated file."
+          echo ""
+          echo "Changesets are required for PRs that modify source code."
+          echo "See CONTRIBUTING.md for details."
+          echo ""
+          echo "Changed files:"
+          echo "${{ steps.changed.outputs.files }}"
+          exit 1
+
+      - name: Changeset found
+        if: steps.changesets.outputs.count != '0'
+        run: |
+          echo "Changeset found! Ready for review."
+
+      - name: Docs-only change
+        if: steps.changesets.outputs.count == '0' && steps.changed.outputs.docs_only == 'true'
+        run: |
+          echo "Docs/config-only change detected. Changeset not required."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to Bitbucket CLI
+
+Thanks for your interest in contributing! This guide will help you get started.
+
+## Development Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/0pilatos0/bitbucket-cli.git
+   cd bitbucket-cli
+   ```
+
+2. **Install dependencies**
+   ```bash
+   bun install
+   ```
+
+3. **Run in development mode**
+   ```bash
+   bun run dev
+   ```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `bun run dev` | Run CLI in development mode |
+| `bun run build` | Build for production |
+| `bun run test` | Run tests |
+| `bun run lint` | Type-check with TypeScript |
+
+## Making Changes
+
+### 1. Create a branch
+
+```bash
+git checkout -b feat/your-feature
+# or
+git checkout -b fix/your-fix
+```
+
+### 2. Make your changes
+
+- Follow existing code patterns
+- Add tests for new functionality
+- Ensure all tests pass: `bun run test`
+- Ensure types are correct: `bun run lint`
+
+### 3. Add a changeset
+
+**This is required for all PRs that affect the package.**
+
+```bash
+bun changeset
+```
+
+This will prompt you to:
+1. Select the type of change (patch, minor, major)
+2. Write a summary of your changes
+
+A changeset file will be created in `.changeset/` - commit this with your PR.
+
+#### When to use each version type
+
+- **patch** - Bug fixes, documentation updates, small improvements
+- **minor** - New features, new commands, non-breaking enhancements
+- **major** - Breaking changes (rarely used before v1.0)
+
+#### Skipping changesets
+
+Only skip changesets for changes that don't affect users:
+- CI/workflow changes
+- README updates
+- Test-only changes
+
+### 4. Submit a Pull Request
+
+- Fill out the PR template
+- Link any related issues
+- Wait for CI to pass
+- Request review if needed
+
+## Code Style
+
+- Use TypeScript
+- Follow the command pattern in `src/commands/`
+- Use dependency injection via the container
+- Return `Result<T, Error>` for operations that can fail
+- Keep functions small and focused
+
+## Architecture
+
+```
+src/
+├── commands/       # CLI commands (one per file)
+├── core/           # DI container, interfaces
+├── repositories/   # API data access
+├── services/       # Business logic
+└── types/          # TypeScript types
+```
+
+## Release Process
+
+Releases are automated via changesets:
+
+1. PRs with changesets get merged to `main`
+2. A "Version Packages" PR is automatically created
+3. Merging that PR triggers:
+   - Version bump
+   - CHANGELOG update
+   - GitHub Package publish
+   - GitHub Release creation
+
+## Questions?
+
+Open an issue if you have questions or need help getting started.


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md with development setup, code style, and release process
- Add changeset-check workflow to enforce changesets on PRs
- Docs-only changes skip the changeset requirement

Closes #2

## Test plan

- [ ] Verify changeset check passes on this PR
- [ ] Test that PRs without changesets show an error (for code changes)