### PR TITLE
fix: validate changesets added in PR, not pre-existing ones

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Check for changesets
         id: changesets
         run: |
-          CHANGESETS=$(ls .changeset/*.md 2>/dev/null | grep -v README.md | wc -l | tr -d ' ')
-          echo "count=$CHANGESETS" >> $GITHUB_OUTPUT
+          # Count only changesets added in this PR, not pre-existing ones
+          NEW_CHANGESETS=$(git diff --name-only origin/main...HEAD | grep '\.changeset/.*\.md$' | grep -v README.md | wc -l | tr -d ' ')
+          echo "count=$NEW_CHANGESETS" >> $GITHUB_OUTPUT
 
       - name: Get changed files
         id: changed
@@ -58,7 +59,7 @@ jobs:
       - name: Changeset found
         if: steps.changesets.outputs.count != '0'
         run: |
-          echo "Changeset found! Ready for review."
+          echo "New changeset found in this PR! Ready for review."
 
       - name: Docs-only change
         if: steps.changesets.outputs.count == '0' && steps.changed.outputs.docs_only == 'true'


### PR DESCRIPTION
## Summary
- Fixes a critical flaw in the changeset validation workflow where it counts all existing `.changeset/*.md` files instead of only those added in the current PR
- Replaces `ls .changeset/*.md` with `git diff --name-only origin/main...HEAD` to detect newly-added changeset files
- This ensures PRs that modify source code without adding a changeset will now correctly fail the check

Fixes #9

## Test plan
- [x] Verified locally that the new `git diff` command correctly counts only changesets added in the current branch
- [x] Confirmed the old `ls` approach incorrectly counted 4 pre-existing changesets
- [x] All existing tests pass (344 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)