### PR TITLE
fix: ensure publish workflow triggers after release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,5 +89,24 @@ jobs:
         with:
           tag_name: v${{ steps.package.outputs.version }}
           generate_release_notes: true
+          draft: false
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set publish flag
+        if: steps.changesets.outputs.has_changesets == 'false' && steps.tag.outputs.exists == 'false'
+        id: publish
+        run: echo "should_publish=true" >> $GITHUB_OUTPUT
+
+    outputs:
+      should_publish: ${{ steps.publish.outputs.should_publish }}
+
+  publish:
+    name: Publish to npm
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## Summary

- Fixes the issue where the publish workflow wasn't triggering after release creation
- Uses `workflow_call` to directly invoke publish.yml from release.yml, bypassing GitHub's security restriction that prevents `GITHUB_TOKEN` events from triggering other workflows
- Removes unreliable `release` event trigger from publish.yml
- Maintains trusted publisher (OIDC) compatibility since publish.yml still executes as itself

## Changes

**publish.yml:**
- Removed `release: types: [published]` trigger
- Added `workflow_call` trigger for invocation from release.yml
- Kept `workflow_dispatch` for manual triggers

**release.yml:**
- Added `draft: false` and `prerelease: false` to release action
- Added job output to signal when publishing should occur
- Added new `publish` job that calls publish.yml via `workflow_call`

## Test plan

- [ ] Merge a PR with a changeset to trigger the release workflow
- [ ] Verify the "Version Packages" PR is created
- [ ] Merge the "Version Packages" PR
- [ ] Verify the release workflow creates a GitHub release
- [ ] Verify the publish workflow is triggered and publishes to npm

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)