### PR TITLE
Fix approve/decline PR commands failing with Bad Request error

### DIFF
--- a/.changeset/fix-approve-decline-body.md
+++ b/.changeset/fix-approve-decline-body.md
@@ -1,0 +1,14 @@
+---
+"@pilatos/bitbucket-cli": patch
+---
+
+Fix approve/decline PR commands failing with Bad Request error
+
+Bug fix for issue #41:
+
+- Fixed `approve()` method to send empty JSON object `{}` as request body
+- Fixed `decline()` method to send empty JSON object `{}` as request body
+- Enhanced mock HTTP client to capture and verify request bodies in tests
+- Added tests to verify approve/decline send correct body format
+
+The Bitbucket Cloud API requires POST requests to approve/decline endpoints to have a request body. Previously, the body was `undefined`, causing 400 Bad Request errors.

--- a/src/repositories/pullrequest.repository.ts
+++ b/src/repositories/pullrequest.repository.ts
@@ -86,7 +86,8 @@ export class PullRequestRepository implements IPullRequestRepository {
     id: number
   ): Promise<Result<BitbucketApproval, BBError>> {
     return this.httpClient.post<BitbucketApproval>(
-      this.buildPath(workspace, repoSlug, `/${id}/approve`)
+      this.buildPath(workspace, repoSlug, `/${id}/approve`),
+      {}
     );
   }
 
@@ -96,7 +97,8 @@ export class PullRequestRepository implements IPullRequestRepository {
     id: number
   ): Promise<Result<BitbucketPullRequest, BBError>> {
     return this.httpClient.post<BitbucketPullRequest>(
-      this.buildPath(workspace, repoSlug, `/${id}/decline`)
+      this.buildPath(workspace, repoSlug, `/${id}/decline`),
+      {}
     );
   }
 

--- a/tests/repositories/pullrequest.repository.test.ts
+++ b/tests/repositories/pullrequest.repository.test.ts
@@ -361,6 +361,18 @@ describe("PullRequestRepository", () => {
         expect(result.value.user.username).toBe("testuser");
       }
     });
+
+    it("should send empty JSON object as body", async () => {
+      const responses = new Map([
+        ["POST:/repositories/workspace/repo/pullrequests/1/approve", Result.ok(mockApproval)],
+      ]);
+      const httpClient = createMockHttpClient(responses);
+      const repository = new PullRequestRepository(httpClient);
+
+      await repository.approve("workspace", "repo", 1);
+
+      expect(httpClient.capturedBodies.get("POST:/repositories/workspace/repo/pullrequests/1/approve")).toEqual({});
+    });
   });
 
   describe("decline", () => {
@@ -378,6 +390,19 @@ describe("PullRequestRepository", () => {
       if (result.success) {
         expect(result.value.state).toBe("DECLINED");
       }
+    });
+
+    it("should send empty JSON object as body", async () => {
+      const declinedPR = { ...mockPullRequest, state: "DECLINED" as const };
+      const responses = new Map([
+        ["POST:/repositories/workspace/repo/pullrequests/1/decline", Result.ok(declinedPR)],
+      ]);
+      const httpClient = createMockHttpClient(responses);
+      const repository = new PullRequestRepository(httpClient);
+
+      await repository.decline("workspace", "repo", 1);
+
+      expect(httpClient.capturedBodies.get("POST:/repositories/workspace/repo/pullrequests/1/decline")).toEqual({});
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -160,8 +160,11 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
 
 export function createMockHttpClient<T>(
   responses: Map<string, Result<T, BBError>>
-): IHttpClient {
+): IHttpClient & { capturedBodies: Map<string, unknown> } {
+  const capturedBodies = new Map<string, unknown>();
+  
   return {
+    capturedBodies,
     async get<R>(path: string): Promise<Result<R, BBError>> {
       const result = responses.get(`GET:${path}`);
       return (result as Result<R, BBError>) ?? Result.err({ code: 2002, message: "Not found" } as BBError);
@@ -170,11 +173,13 @@ export function createMockHttpClient<T>(
       const result = responses.get(`GET:${path}`);
       return (result as Result<string, BBError>) ?? Result.err({ code: 2002, message: "Not found" } as BBError);
     },
-    async post<R>(path: string): Promise<Result<R, BBError>> {
+    async post<R>(path: string, body?: unknown): Promise<Result<R, BBError>> {
+      capturedBodies.set(`POST:${path}`, body);
       const result = responses.get(`POST:${path}`);
       return (result as Result<R, BBError>) ?? Result.err({ code: 2001, message: "Failed" } as BBError);
     },
-    async put<R>(path: string): Promise<Result<R, BBError>> {
+    async put<R>(path: string, body?: unknown): Promise<Result<R, BBError>> {
+      capturedBodies.set(`PUT:${path}`, body);
       const result = responses.get(`PUT:${path}`);
       return (result as Result<R, BBError>) ?? Result.err({ code: 2001, message: "Failed" } as BBError);
     },


### PR DESCRIPTION
## Summary
Fixes #41 - The `bb pr approve` and `bb pr decline` commands were failing with "Bad Request" errors when attempting to approve or decline a pull request.

## Root Cause
The HTTP client was sending `undefined` as request body when making POST requests to approve/decline endpoints. According to Bitbucket Cloud API documentation, POST requests to approve/decline endpoints require an empty JSON object `{}` as request body.

## Changes

### Fixed Repository Methods
- **`approve()` method**: Now passes `{}` as body parameter
- **`decline()` method**: Now passes `{}` as body parameter

### Enhanced Test Infrastructure
- Modified `createMockHttpClient()` in `tests/setup.ts` to capture request bodies
- Added `capturedBodies` map to verify what's being sent to API endpoints

### Added Test Coverage
- Test: "approve should send empty JSON object as body"
- Test: "decline should send empty JSON object as body"

## Verification
- ✅ All 429 tests passing
- ✅ TypeScript linting passes
- ✅ Changeset added for patch release (1.1.0 → 1.1.1)

## Impact
- **Severity**: HIGH fix for critical functionality
- **Affected Commands**: `bb pr approve <id>` and `bb pr decline <id>`
- **Breaking Changes**: None