### PR TITLE
Add draft pull request workflow

### DIFF
--- a/.changeset/pr-draft-support.md
+++ b/.changeset/pr-draft-support.md
@@ -1,0 +1,5 @@
+---
+"@pilatos/bitbucket-cli": minor
+---
+
+Add draft pull request support, including a ready command and draft indicators.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ bb pr list
 |----------|----------|
 | **Authentication** | `login`, `logout`, `status`, `token` |
 | **Repositories** | `clone`, `create`, `list`, `view`, `delete` |
-| **Pull Requests** | `create`, `list`, `view`, `edit`, `merge`, `approve`, `decline`, `checkout`, `diff`, `comment`, `comments` |
+| **Pull Requests** | `create`, `list`, `view`, `edit`, `merge`, `approve`, `decline`, `ready`, `checkout`, `diff`, `comment`, `comments` |
 | **Configuration** | `get`, `set`, `list` |
 | **Shell Completion** | `install`, `uninstall` |
 
@@ -140,6 +140,16 @@ bb pr list
 bb pr view 42
 bb pr approve 42
 bb pr merge 42
+```
+
+### Draft Pull Requests
+
+```bash
+# Create a draft PR for early feedback
+bb pr create --title "WIP: Add new feature" --draft
+
+# Mark it ready for review when done
+bb pr ready 123
 ```
 
 ### Scripting with JSON

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -24,6 +24,7 @@ bb pr create [options]
 | `-w, --workspace <workspace>` | Workspace |
 | `-r, --repo <repo>` | Repository |
 | `--close-source-branch` | Close source branch after merge |
+| `--draft` | Create the pull request as draft |
 | `--json` | Output as JSON |
 
 ### Examples
@@ -37,6 +38,9 @@ bb pr create -t "Add login page" -b "Implements user login functionality" -d dev
 
 # Create a PR that will close the source branch after merging
 bb pr create -t "Hotfix: Critical bug" --close-source-branch
+
+# Create a draft PR
+bb pr create -t "WIP: Add feature" --draft
 ```
 
 ---
@@ -134,6 +138,10 @@ bb pr list --json
 # List more results
 bb pr list --limit 50
 ```
+
+### Notes
+
+- Draft PRs are shown with a `[DRAFT]` prefix in the title
 
 ---
 
@@ -278,6 +286,40 @@ bb pr decline 42
 
 # Decline PR in specific repository
 bb pr decline 42 -w myworkspace -r myrepo
+```
+
+---
+
+## `bb pr ready`
+
+Mark a draft pull request as ready for review.
+
+```bash
+bb pr ready <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Pull request ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# Mark draft PR as ready
+bb pr ready 42
+
+# Mark draft PR in specific repository
+bb pr ready 42 -w myworkspace -r myrepo
 ```
 
 ---

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -138,7 +138,7 @@ bb completion install
 Restart your shell, then try:
 
 ```bash
-bb pr <Tab>      # Shows: approve, checkout, create, decline, diff, list, merge, view
+bb pr <Tab>      # Shows: approve, checkout, create, decline, diff, list, merge, ready, view
 bb pr create -<Tab>  # Shows available flags
 ```
 

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -109,6 +109,7 @@ Returns the created repository object (same schema as `bb repo view`).
     "title": "Add new feature",
     "description": "This PR adds...",
     "state": "OPEN",
+    "draft": false,
     "created_on": "2024-12-20T09:00:00.000000+00:00",
     "updated_on": "2024-12-28T14:30:00.000000+00:00",
     "author": {
@@ -162,6 +163,7 @@ Returns the created repository object (same schema as `bb repo view`).
 | `state` | string | `OPEN`, `MERGED`, `DECLINED`, `SUPERSEDED` |
 | `created_on` | string | ISO 8601 timestamp |
 | `updated_on` | string | ISO 8601 timestamp |
+| `draft` | boolean | Draft status (true = draft) |
 | `author` | object | PR author details |
 | `source.branch.name` | string | Source branch name |
 | `destination.branch.name` | string | Target branch name |

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -37,6 +37,7 @@ import { EditPRCommand } from "./commands/pr/edit.command.js";
 import { MergePRCommand } from "./commands/pr/merge.command.js";
 import { ApprovePRCommand } from "./commands/pr/approve.command.js";
 import { DeclinePRCommand } from "./commands/pr/decline.command.js";
+import { ReadyPRCommand } from "./commands/pr/ready.command.js";
 import { CheckoutPRCommand } from "./commands/pr/checkout.command.js";
 import { DiffPRCommand } from "./commands/pr/diff.command.js";
 import { CommentPRCommand } from "./commands/pr/comment.command.js";
@@ -204,6 +205,13 @@ export function bootstrap(): Container {
     const contextService = container.resolve<ContextService>(ServiceTokens.ContextService);
     const output = container.resolve<OutputService>(ServiceTokens.OutputService);
     return new DeclinePRCommand(prRepo, contextService, output);
+  });
+
+  container.register(ServiceTokens.ReadyPRCommand, () => {
+    const prRepo = container.resolve<PullRequestRepository>(ServiceTokens.PullRequestRepository);
+    const contextService = container.resolve<ContextService>(ServiceTokens.ContextService);
+    const output = container.resolve<OutputService>(ServiceTokens.OutputService);
+    return new ReadyPRCommand(prRepo, contextService, output);
   });
 
   container.register(ServiceTokens.CheckoutPRCommand, () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import type { EditPRCommand } from "./commands/pr/edit.command.js";
 import type { MergePRCommand } from "./commands/pr/merge.command.js";
 import type { ApprovePRCommand } from "./commands/pr/approve.command.js";
 import type { DeclinePRCommand } from "./commands/pr/decline.command.js";
+import type { ReadyPRCommand } from "./commands/pr/ready.command.js";
 import type { CheckoutPRCommand } from "./commands/pr/checkout.command.js";
 import type { DiffPRCommand } from "./commands/pr/diff.command.js";
 import type { CommentPRCommand } from "./commands/pr/comment.command.js";
@@ -65,7 +66,19 @@ if (process.argv.includes("--get-yargs-completions") || process.env.COMP_LINE) {
     } else if (env.prev === "repo") {
       completions.push("clone", "create", "list", "view", "delete");
     } else if (env.prev === "pr") {
-      completions.push("create", "list", "view", "edit", "merge", "approve", "decline", "checkout", "diff", "comments");
+      completions.push(
+        "create",
+        "list",
+        "view",
+        "edit",
+        "merge",
+        "approve",
+        "decline",
+        "ready",
+        "checkout",
+        "diff",
+        "comments"
+      );
     } else if (env.prev === "config") {
       completions.push("get", "set", "list");
     } else if (env.prev === "completion") {
@@ -245,6 +258,7 @@ prCmd
   .option("-s, --source <branch>", "Source branch (default: current branch)")
   .option("-d, --destination <branch>", "Destination branch (default: main)")
   .option("--close-source-branch", "Close source branch after merge")
+  .option("--draft", "Create the pull request as draft")
   .action(async (options) => {
     const cmd = container.resolve<CreatePRCommand>(ServiceTokens.CreatePRCommand);
     const context = createContext(cli);
@@ -327,6 +341,18 @@ prCmd
   .description("Decline a pull request")
   .action(async (id, options) => {
     const cmd = container.resolve<DeclinePRCommand>(ServiceTokens.DeclinePRCommand);
+    const context = createContext(cli);
+    const result = await cmd.execute(withGlobalOptions({ id, ...options }, context), context);
+    if (!result.success) {
+      process.exit(1);
+    }
+  });
+
+prCmd
+  .command("ready <id>")
+  .description("Mark a draft pull request as ready for review")
+  .action(async (id, options) => {
+    const cmd = container.resolve<ReadyPRCommand>(ServiceTokens.ReadyPRCommand);
     const context = createContext(cli);
     const result = await cmd.execute(withGlobalOptions({ id, ...options }, context), context);
     if (!result.success) {

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -22,6 +22,7 @@ export interface CreatePROptions extends GlobalOptions {
   source?: string;
   destination?: string;
   closeSourceBranch?: boolean;
+  draft?: boolean;
 }
 
 export class CreatePRCommand extends BaseCommand<CreatePROptions, BitbucketPullRequest> {
@@ -93,6 +94,10 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, BitbucketPullR
 
     if (options.closeSourceBranch) {
       request.close_source_branch = true;
+    }
+
+    if (options.draft) {
+      request.draft = true;
     }
 
     // Create pull request

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -66,12 +66,15 @@ export class ListPRsCommand extends BaseCommand<
         return;
       }
 
-      const rows = data.values.map((pr) => [
-        `#${pr.id}`,
-        this.truncate(pr.title, 50),
-        pr.author.display_name,
-        `${pr.source.branch.name} → ${pr.destination.branch.name}`,
-      ]);
+      const rows = data.values.map((pr) => {
+        const title = pr.draft ? `[DRAFT] ${pr.title}` : pr.title;
+        return [
+          `#${pr.id}`,
+          this.truncate(title, 50),
+          pr.author.display_name,
+          `${pr.source.branch.name} → ${pr.destination.branch.name}`,
+        ];
+      });
 
       this.output.table(["ID", "TITLE", "AUTHOR", "BRANCHES"], rows);
     });

--- a/src/commands/pr/ready.command.ts
+++ b/src/commands/pr/ready.command.ts
@@ -1,0 +1,64 @@
+/**
+ * Ready PR command implementation
+ */
+
+import { BaseCommand } from "../../core/base-command.js";
+import type { CommandContext } from "../../core/interfaces/commands.js";
+import type {
+  IPullRequestRepository,
+  IContextService,
+  IOutputService,
+} from "../../core/interfaces/services.js";
+import { Result } from "../../types/result.js";
+import type { BBError } from "../../types/errors.js";
+import type { BitbucketPullRequest, UpdatePullRequestRequest } from "../../types/api.js";
+import type { GlobalOptions } from "../../types/config.js";
+
+export interface ReadyPROptions extends GlobalOptions {}
+
+export class ReadyPRCommand extends BaseCommand<
+  { id: string } & ReadyPROptions,
+  BitbucketPullRequest
+> {
+  public readonly name = "ready";
+  public readonly description = "Mark a draft pull request as ready for review";
+
+  constructor(
+    private readonly prRepository: IPullRequestRepository,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & ReadyPROptions,
+    context: CommandContext
+  ): Promise<Result<BitbucketPullRequest, BBError>> {
+    const repoContextResult = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    if (!repoContextResult.success) {
+      this.handleResult(repoContextResult, context);
+      return repoContextResult;
+    }
+
+    const { workspace, repoSlug } = repoContextResult.value;
+    const prId = parseInt(options.id, 10);
+
+    const request: UpdatePullRequestRequest = {
+      draft: false,
+    };
+
+    const result = await this.prRepository.update(workspace, repoSlug, prId, request);
+
+    this.handleResult(result, context, (pr) => {
+      this.output.success(`Marked pull request #${prId} as ready for review`);
+      this.output.text(`  ${pr.title}`);
+    });
+
+    return result;
+  }
+}

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -55,8 +55,9 @@ export class ViewPRCommand extends BaseCommand<
 
     this.handleResult(result, context, (pr) => {
       const stateColor = this.getStateColor(pr.state);
+      const draftLabel = pr.draft ? chalk.yellow("[DRAFT]") : "";
       this.output.text(
-        `${chalk.bold(`#${pr.id}`)} ${pr.title} ${stateColor(`[${pr.state}]`)}`
+        `${chalk.bold(`#${pr.id}`)} ${pr.title} ${stateColor(`[${pr.state}]`)}${draftLabel ? ` ${draftLabel}` : ""}`
       );
       this.output.text("");
 

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -158,6 +158,7 @@ export const ServiceTokens = {
   MergePRCommand: "MergePRCommand",
   ApprovePRCommand: "ApprovePRCommand",
   DeclinePRCommand: "DeclinePRCommand",
+  ReadyPRCommand: "ReadyPRCommand",
   CheckoutPRCommand: "CheckoutPRCommand",
   DiffPRCommand: "DiffPRCommand",
   CommentPRCommand: "CommentPRCommand",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -72,6 +72,7 @@ export interface BitbucketPullRequest {
   title: string;
   description: string;
   state: PullRequestState;
+  draft?: boolean;
   author: BitbucketUser;
   source: {
     branch: { name: string };
@@ -164,6 +165,7 @@ export interface CreatePullRequestRequest {
   destination: {
     branch: { name: string };
   };
+  draft?: boolean;
   close_source_branch?: boolean;
   reviewers?: Array<{ uuid: string }>;
 }
@@ -177,6 +179,8 @@ export interface MergePullRequestRequest {
 export interface UpdatePullRequestRequest {
   title?: string;
   description?: string;
+  draft?: boolean;
+  reviewers?: Array<{ uuid: string }>;
 }
 
 export interface DiffStatFile {

--- a/tests/repositories/pullrequest.repository.test.ts
+++ b/tests/repositories/pullrequest.repository.test.ts
@@ -346,6 +346,24 @@ describe("PullRequestRepository", () => {
 
       expect(result.success).toBe(true);
     });
+
+    it("should update draft status", async () => {
+      const updatedPR = { ...mockPullRequest, draft: false };
+      const responses = new Map([
+        ["PUT:/repositories/workspace/repo/pullrequests/1", Result.ok(updatedPR)],
+      ]);
+      const httpClient = createMockHttpClient(responses);
+      const repository = new PullRequestRepository(httpClient);
+
+      const result = await repository.update("workspace", "repo", 1, {
+        draft: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(
+        httpClient.capturedBodies.get("PUT:/repositories/workspace/repo/pullrequests/1")
+      ).toEqual({ draft: false });
+    });
   });
 
   describe("merge", () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -136,6 +136,7 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     },
     table(headers: string[], rows: string[][]) {
       logs.push(`table:${headers.join(",")}`);
+      logs.push(`table-rows:${JSON.stringify(rows)}`);
     },
     success(message: string) {
       logs.push(`success:${message}`);
@@ -242,6 +243,7 @@ export const mockPullRequest: BitbucketPullRequest = {
   title: "Test PR",
   description: "Test description",
   state: "OPEN",
+  draft: false,
   author: mockUser,
   source: {
     branch: { name: "feature-branch" },


### PR DESCRIPTION
## Summary
- add draft flag support in PR create/list/view and API types
- add `bb pr ready` command to mark drafts ready for review
- update tests, docs, and changeset for draft PR usage

## Testing
- bun run test
- bun run lint