### PR TITLE
fix(docs): update Starlight social config format to object

### DIFF
--- a/.changeset/starlight-social-config.md
+++ b/.changeset/starlight-social-config.md
@@ -1,0 +1,5 @@
+---
+"@pilatos/bitbucket-cli": patch
+---
+
+Fix Starlight social config format in documentation site. Changed from array format to object format to match newer Starlight version requirements.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -20,13 +20,9 @@ export default defineConfig({
           },
         },
       ],
-      social: [
-        {
-          icon: "github",
-          label: "GitHub",
-          href: "https://github.com/0pilatos0/bitbucket-cli",
-        },
-      ],
+      social: {
+        github: "https://github.com/0pilatos0/bitbucket-cli",
+      },
       sidebar: [
         {
           label: "Getting Started",


### PR DESCRIPTION
## Summary

Fixes #69 - Documentation site build fails due to Starlight social config format change.

## Changes

Changed the `social` configuration in `docs/astro.config.mjs` from the deprecated array format to the new object format required by newer versions of Starlight.

### Before (array format):
```javascript
social: [
  {
    icon: "github",
    label: "GitHub",
    href: "https://github.com/0pilatos0/bitbucket-cli",
  },
],
```

### After (object format):
```javascript
social: {
  github: "https://github.com/0pilatos0/bitbucket-cli",
},
```

## Testing

- [x] Configuration format updated
- [x] Changeset added (patch level)

## Related Issue

Closes #69