### PR TITLE
Add PR checks command

### DIFF
--- a/.changeset/add-pr-checks-command.md
+++ b/.changeset/add-pr-checks-command.md
@@ -1,0 +1,5 @@
+---
+"@pilatos/bitbucket-cli": minor
+---
+
+Add a pull request checks command to show CI/CD status.

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ bb pr list
 
 ## Features
 
-| Category             | Commands                                                                                                                         |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Authentication**   | `login`, `logout`, `status`, `token`                                                                                             |
-| **Repositories**     | `clone`, `create`, `list`, `view`, `delete`                                                                                      |
-| **Pull Requests**    | `create`, `list`, `view`, `edit`, `merge`, `approve`, `decline`, `ready`, `checkout`, `diff`, `comment`, `comments`, `reviewers` |
-| **Configuration**    | `get`, `set`, `list`                                                                                                             |
-| **Shell Completion** | `install`, `uninstall`                                                                                                           |
+| Category             | Commands                                                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Authentication**   | `login`, `logout`, `status`, `token`                                                                                                                   |
+| **Repositories**     | `clone`, `create`, `list`, `view`, `delete`                                                                                                            |
+| **Pull Requests**    | `create`, `list`, `view`, `activity`, `checks`, `edit`, `merge`, `approve`, `decline`, `ready`, `checkout`, `diff`, `comment`, `comments`, `reviewers` |
+| **Configuration**    | `get`, `set`, `list`                                                                                                                                   |
+| **Shell Completion** | `install`, `uninstall`                                                                                                                                 |
 
 **Global Options:**
 
@@ -140,6 +140,7 @@ bb pr list
 # Review and merge
 bb pr view 42
 bb pr activity 42
+bb pr checks 42
 bb pr approve 42
 bb pr merge 42
 

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -224,6 +224,43 @@ bb pr activity 42 --json
 
 ---
 
+## `bb pr checks`
+
+Show CI/CD checks and build status for a pull request.
+
+```bash
+bb pr checks <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Pull request ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# View checks for PR #42
+bb pr checks 42
+
+# View checks in a specific repository
+bb pr checks 42 -w myworkspace -r myrepo
+
+# Get checks as JSON
+bb pr checks 42 --json
+```
+
+---
+
 ## `bb pr merge`
 
 Merge a pull request.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -96,6 +96,7 @@ bb pr list
     ```bash
     bb pr create -t "Add feature"
     bb pr view 42
+    bb pr checks 42
     bb pr approve 42
     bb pr merge 42 --squash
     ```

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -17,7 +17,12 @@ const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 
 // Import generated API classes
-import { PullrequestsApi, RepositoriesApi, UsersApi } from './generated/api.js';
+import {
+  PullrequestsApi,
+  RepositoriesApi,
+  UsersApi,
+  CommitStatusesApi,
+} from './generated/api.js';
 
 // Auth commands
 import { LoginCommand } from './commands/auth/login.command.js';
@@ -51,6 +56,7 @@ import { DeleteCommentPRCommand } from './commands/pr/comments.delete.command.js
 import { AddReviewerPRCommand } from './commands/pr/reviewers.add.command.js';
 import { RemoveReviewerPRCommand } from './commands/pr/reviewers.remove.command.js';
 import { ListReviewersPRCommand } from './commands/pr/reviewers.list.command.js';
+import { ChecksPRCommand } from './commands/pr/checks.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -92,6 +98,14 @@ export function bootstrap(): Container {
     );
     const axiosInstance = createApiClient(configService);
     return new UsersApi(undefined, undefined, axiosInstance);
+  });
+
+  container.register(ServiceTokens.CommitStatusesApi, () => {
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const axiosInstance = createApiClient(configService);
+    return new CommitStatusesApi(undefined, undefined, axiosInstance);
   });
 
   container.register(ServiceTokens.ContextService, () => {
@@ -478,6 +492,19 @@ export function bootstrap(): Container {
       ServiceTokens.OutputService
     );
     return new ListReviewersPRCommand(pullrequestsApi, contextService, output);
+  });
+
+  container.register(ServiceTokens.ChecksPRCommand, () => {
+    const commitStatusesApi = container.resolve<CommitStatusesApi>(
+      ServiceTokens.CommitStatusesApi
+    );
+    const contextService = container.resolve<ContextService>(
+      ServiceTokens.ContextService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new ChecksPRCommand(commitStatusesApi, contextService, output);
   });
 
   // Register config commands

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import type { ReadyPRCommand } from './commands/pr/ready.command.js';
 import type { CheckoutPRCommand } from './commands/pr/checkout.command.js';
 import type { DiffPRCommand } from './commands/pr/diff.command.js';
 import type { ActivityPRCommand } from './commands/pr/activity.command.js';
+import type { ChecksPRCommand } from './commands/pr/checks.command.js';
 import type { CommentPRCommand } from './commands/pr/comment.command.js';
 import type { ListCommentsPRCommand } from './commands/pr/comments.list.command.js';
 import type { EditCommentPRCommand } from './commands/pr/comments.edit.command.js';
@@ -77,6 +78,7 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
         'list',
         'view',
         'activity',
+        'checks',
         'edit',
         'merge',
         'approve',
@@ -386,6 +388,25 @@ prCmd
     try {
       const cmd = container.resolve<ActivityPRCommand>(
         ServiceTokens.ActivityPRCommand
+      );
+      const context = createContext(cli);
+      await cmd.execute(
+        withGlobalOptions({ id, ...options }, context),
+        context
+      );
+    } catch {
+      process.exit(1);
+    }
+  });
+
+prCmd
+  .command('checks <id>')
+  .description('Show CI/CD checks and build status for a pull request')
+  .option('--json', 'Output as JSON')
+  .action(async (id, options) => {
+    try {
+      const cmd = container.resolve<ChecksPRCommand>(
+        ServiceTokens.ChecksPRCommand
       );
       const context = createContext(cli);
       await cmd.execute(

--- a/src/commands/pr/checks.command.ts
+++ b/src/commands/pr/checks.command.ts
@@ -1,0 +1,193 @@
+/**
+ * PR checks command implementation
+ */
+
+import chalk from 'chalk';
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type {
+  CommitStatusesApi,
+  Commitstatus,
+  PaginatedCommitstatuses,
+} from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+
+export interface ChecksPROptions extends GlobalOptions {
+  json?: boolean;
+}
+
+export class ChecksPRCommand extends BaseCommand<
+  { id: string } & ChecksPROptions,
+  void
+> {
+  public readonly name = 'checks';
+  public readonly description =
+    'Show CI/CD checks and build status for a pull request';
+
+  constructor(
+    private readonly commitStatusesApi: CommitStatusesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & ChecksPROptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    const prId = parseInt(options.id, 10);
+
+    try {
+      const response =
+        await this.commitStatusesApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdStatusesGet(
+          {
+            workspace: repoContext.workspace,
+            repoSlug: repoContext.repoSlug,
+            pullRequestId: prId,
+          }
+        );
+
+      const data = response.data as PaginatedCommitstatuses;
+      const statuses = data?.values ? Array.from(data.values) : [];
+
+      const useJson = options.json || context.globalOptions.json;
+
+      if (useJson) {
+        this.output.json({
+          pullRequestId: prId,
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          statuses: statuses.map((status) => this.formatStatusForJson(status)),
+        });
+        return;
+      }
+
+      if (statuses.length === 0) {
+        this.output.info('No CI/CD checks found for this pull request');
+        return;
+      }
+
+      this.renderHeader(prId, statuses.length);
+      this.renderStatuses(statuses);
+    } catch (error) {
+      this.handleError(error, context);
+      throw error;
+    }
+  }
+
+  private formatStatusForJson(status: Commitstatus): Record<string, unknown> {
+    return {
+      key: status.key,
+      name: status.name,
+      state: status.state,
+      description: status.description,
+      url: status.url,
+      refname: status.refname,
+      createdOn: status.created_on,
+      updatedOn: status.updated_on,
+      uuid: status.uuid,
+    };
+  }
+
+  private renderHeader(prId: number, count: number): void {
+    this.output.text('');
+    this.output.text(
+      `${chalk.bold(`Pull Request #${prId}`)} - ${count} check${count === 1 ? '' : 's'}`
+    );
+    this.output.text(chalk.gray('-'.repeat(60)));
+  }
+
+  private renderStatuses(statuses: Commitstatus[]): void {
+    const rows = statuses.map((status) => {
+      const stateIcon = this.getStateIcon(status.state);
+      const stateLabel = this.getStateLabel(status.state);
+      const name = status.name ?? status.key ?? 'Unknown';
+      const description = status.description ?? '-';
+
+      return [
+        `${stateIcon} ${stateLabel}`,
+        chalk.bold(name),
+        this.truncate(description, 40),
+        status.updated_on ? this.output.formatDate(status.updated_on) : '-',
+      ];
+    });
+
+    this.output.table(['STATUS', 'NAME', 'DESCRIPTION', 'UPDATED'], rows);
+
+    // Show summary
+    const summary = this.getSummary(statuses);
+    this.output.text('');
+    this.output.text(
+      `${chalk.green('OK')} ${summary.successful} successful, ${chalk.red('FAIL')} ${summary.failed} failed, ${chalk.yellow('RUN')} ${summary.pending} pending`
+    );
+    this.output.text('');
+  }
+
+  private getStateIcon(state?: string): string {
+    switch (state?.toUpperCase()) {
+      case 'SUCCESSFUL':
+        return chalk.green('OK');
+      case 'FAILED':
+        return chalk.red('FAIL');
+      case 'INPROGRESS':
+        return chalk.yellow('RUN');
+      case 'STOPPED':
+        return chalk.gray('STOP');
+      default:
+        return chalk.gray('?');
+    }
+  }
+
+  private getStateLabel(state?: string): string {
+    switch (state?.toUpperCase()) {
+      case 'SUCCESSFUL':
+        return 'passed';
+      case 'FAILED':
+        return 'failed';
+      case 'INPROGRESS':
+        return 'running';
+      case 'STOPPED':
+        return 'stopped';
+      default:
+        return state?.toLowerCase() ?? 'unknown';
+    }
+  }
+
+  private getSummary(statuses: Commitstatus[]): {
+    successful: number;
+    failed: number;
+    pending: number;
+  } {
+    return statuses.reduce(
+      (acc, status) => {
+        const state = status.state?.toUpperCase();
+        if (state === 'SUCCESSFUL') {
+          acc.successful++;
+        } else if (state === 'FAILED') {
+          acc.failed++;
+        } else if (state === 'INPROGRESS') {
+          acc.pending++;
+        }
+        return acc;
+      },
+      { successful: 0, failed: 0, pending: 0 }
+    );
+  }
+
+  private truncate(text: string, maxLength: number): string {
+    if (text.length <= maxLength) {
+      return text;
+    }
+    return text.substring(0, maxLength - 3) + '...';
+  }
+}

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -137,6 +137,7 @@ export const ServiceTokens = {
   PullrequestsApi: 'PullrequestsApi',
   RepositoriesApi: 'RepositoriesApi',
   UsersApi: 'UsersApi',
+  CommitStatusesApi: 'CommitStatusesApi',
 
   // Commands - Auth
   LoginCommand: 'LoginCommand',
@@ -163,6 +164,7 @@ export const ServiceTokens = {
   CheckoutPRCommand: 'CheckoutPRCommand',
   DiffPRCommand: 'DiffPRCommand',
   ActivityPRCommand: 'ActivityPRCommand',
+  ChecksPRCommand: 'ChecksPRCommand',
   CommentPRCommand: 'CommentPRCommand',
   ListCommentsPRCommand: 'ListCommentsPRCommand',
   EditCommentPRCommand: 'EditCommentPRCommand',


### PR DESCRIPTION
## Summary
- add `bb pr checks` to display PR CI/CD statuses
- wire commit status API client and CLI completion
- cover docs and tests for the new command

## Testing
- bun test

## Related
- https://github.com/0pilatos0/bitbucket-cli/issues/49