### PR TITLE
feat: add --mine flag to bb pr list for filtering PRs assigned to current user

### DIFF
--- a/.changeset/pr-list-mine-flag.md
+++ b/.changeset/pr-list-mine-flag.md
@@ -1,0 +1,12 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `--mine` flag to `bb pr list` for filtering PRs assigned to current user
+
+- New `--mine` flag filters pull requests to show only those where the authenticated user is listed as a reviewer
+- User UUID is automatically fetched and cached for optimal performance
+- Works in combination with existing `--state` and `--limit` flags
+- Example usage: `bb pr list --mine` or `bb pr list --mine --state OPEN`
+
+Closes #79

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -116,6 +116,7 @@ bb pr list [options]
 | `-r, --repo <repo>` | Repository |
 | `-s, --state <state>` | Filter by state: OPEN, MERGED, DECLINED, SUPERSEDED (default: OPEN) |
 | `--limit <number>` | Maximum number of PRs (default: 25) |
+| `--mine` | Show only PRs where you are a reviewer |
 
 ### Examples
 
@@ -137,11 +138,18 @@ bb pr list --json
 
 # List more results
 bb pr list --limit 50
+
+# List PRs where you are a reviewer
+bb pr list --mine
+
+# List open PRs where you are a reviewer
+bb pr list --mine --state OPEN
 ```
 
 ### Notes
 
 - Draft PRs are shown with a `[DRAFT]` prefix in the title
+- The `--mine` flag filters to show only PRs where you are listed as a reviewer
 
 ---
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -11,6 +11,7 @@ import {
   VersionService,
   createApiClient,
 } from './services/index.js';
+import { PullrequestsApiWrapper } from './services/api-wrapper.js';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -99,6 +100,15 @@ export function bootstrap(): Container {
     const axiosInstance = createApiClient(configService);
     return new UsersApi(undefined, undefined, axiosInstance);
   });
+
+  // Inject UsersApi into ConfigService for user UUID resolution
+  const configServiceForInjection = container.resolve<ConfigService>(
+    ServiceTokens.ConfigService
+  );
+  const usersApiForInjection = container.resolve<UsersApi>(
+    ServiceTokens.UsersApi
+  );
+  configServiceForInjection.setUsersApi(usersApiForInjection);
 
   container.register(ServiceTokens.CommitStatusesApi, () => {
     const configService = container.resolve<ConfigService>(
@@ -250,10 +260,19 @@ export function bootstrap(): Container {
     const contextService = container.resolve<ContextService>(
       ServiceTokens.ContextService
     );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new ListPRsCommand(pullrequestsApi, contextService, output);
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
+    return new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
   });
 
   container.register(ServiceTokens.ViewPRCommand, () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -346,6 +346,7 @@ prCmd
     'OPEN'
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
+  .option('--mine', 'Show only PRs where you are a reviewer')
   .action(async (options) => {
     try {
       const cmd = container.resolve<ListPRsCommand>(

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -5,15 +5,18 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
+  IConfigService,
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
+import type { Pullrequest } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import type { PullrequestsApiWrapper } from '../../services/api-wrapper.js';
 
 export interface ListPRsOptions extends GlobalOptions {
   state?: string;
   limit?: string;
+  mine?: boolean;
 }
 
 export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
@@ -21,8 +24,9 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
   public readonly description = 'List pull requests';
 
   constructor(
-    private readonly pullrequestsApi: PullrequestsApi,
+    private readonly pullrequestsApi: PullrequestsApiWrapper,
     private readonly contextService: IContextService,
+    private readonly configService: IConfigService,
     output: IOutputService
   ) {
     super(output);
@@ -43,25 +47,35 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       | 'DECLINED'
       | 'SUPERSEDED';
 
-    try {
-      const response =
-        await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
-          {
-            workspace: repoContext.workspace,
-            repoSlug: repoContext.repoSlug,
-            state,
-          }
-        );
+    let query: string | undefined;
 
-      const data = response.data;
-      const values = data.values ? Array.from(data.values) : [];
+    if (options.mine) {
+      const userUuid = await this.configService.getUserUuid();
+      if (userUuid) {
+        query = `reviewers.uuid="${userUuid}"`;
+      } else {
+        this.output.warning(
+          'Could not determine your user UUID. Showing all PRs.'
+        );
+      }
+    }
+
+    try {
+      const response = await this.pullrequestsApi.list(
+        repoContext.workspace,
+        repoContext.repoSlug,
+        state,
+        query
+      );
+
+      const values = response.values;
 
       if (values.length === 0) {
         this.output.text(`No ${state.toLowerCase()} pull requests found`);
         return;
       }
 
-      const rows = values.map((pr: Pullrequest) => {
+      const rows = values.map((pr) => {
         const title = pr.draft ? `[DRAFT] ${pr.title}` : pr.title;
         const source = pr.source as { branch?: { name?: string } } | undefined;
         const destination = pr.destination as

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -21,6 +21,10 @@ export interface IConfigService {
   getValue<K extends keyof BBConfig>(key: K): Promise<BBConfig[K] | undefined>;
   setValue<K extends keyof BBConfig>(key: K, value: BBConfig[K]): Promise<void>;
   getConfigPath(): string;
+  /**
+   * Get the current user's UUID, fetching and caching it if necessary
+   */
+  getUserUuid(): Promise<string | undefined>;
 }
 
 /**

--- a/src/services/api-wrapper.ts
+++ b/src/services/api-wrapper.ts
@@ -114,14 +114,18 @@ export class PullrequestsApiWrapper {
   async list(
     workspace: string,
     repoSlug: string,
-    state?: 'OPEN' | 'MERGED' | 'DECLINED' | 'SUPERSEDED'
+    state?: 'OPEN' | 'MERGED' | 'DECLINED' | 'SUPERSEDED',
+    query?: string
   ): Promise<PaginatedResponse<Pullrequest>> {
     const response =
-      await this.api.repositoriesWorkspaceRepoSlugPullrequestsGet({
-        workspace,
-        repoSlug,
-        state,
-      });
+      await this.api.repositoriesWorkspaceRepoSlugPullrequestsGet(
+        {
+          workspace,
+          repoSlug,
+          state,
+        },
+        query ? { params: { q: query } } : undefined
+      );
     const data = response.data;
     return {
       values: toArray(

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -7,15 +7,25 @@ import { homedir } from 'node:os';
 import type { IConfigService } from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 import type { BBConfig, AuthCredentials } from '../types/config.js';
+import type { UsersApi } from '../generated/api.js';
 
 export class ConfigService implements IConfigService {
   private readonly configDir: string;
   private readonly configFile: string;
   private configCache: BBConfig | null = null;
+  private usersApi: UsersApi | null = null;
 
-  constructor(configDir?: string) {
+  constructor(configDir?: string, usersApi?: UsersApi) {
     this.configDir = configDir ?? join(homedir(), '.config', 'bb');
     this.configFile = join(this.configDir, 'config.json');
+    this.usersApi = usersApi ?? null;
+  }
+
+  /**
+   * Set the UsersApi instance for fetching user data
+   */
+  public setUsersApi(usersApi: UsersApi): void {
+    this.usersApi = usersApi;
   }
 
   private async ensureConfigDir(): Promise<void> {
@@ -130,5 +140,36 @@ export class ConfigService implements IConfigService {
    */
   public clearCache(): void {
     this.configCache = null;
+  }
+
+  /**
+   * Get the current user's UUID, fetching and caching it if necessary
+   */
+  public async getUserUuid(): Promise<string | undefined> {
+    const config = await this.getConfig();
+
+    // Return cached UUID if available
+    if (config.userUuid) {
+      return config.userUuid;
+    }
+
+    // Fetch UUID from API if we have a UsersApi instance
+    if (this.usersApi) {
+      try {
+        const response = await this.usersApi.userGet();
+        const userUuid = response.data.uuid;
+
+        if (userUuid) {
+          // Cache the UUID in config
+          await this.setValue('userUuid', userUuid);
+          return userUuid;
+        }
+      } catch {
+        // Silently fail - user UUID is not critical
+        return undefined;
+      }
+    }
+
+    return undefined;
   }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,8 @@ export { ContextService } from './context.service.js';
 export { OutputService } from './output.service.js';
 export { VersionService } from './version.service.js';
 export { createApiClient } from './api-client.service.js';
+export {
+  PullrequestsApiWrapper,
+  RepositoriesApiWrapper,
+  UsersApiWrapper,
+} from './api-wrapper.js';

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,7 @@ export interface BBConfig {
   lastVersionCheck?: string;
   skipVersionCheck?: boolean;
   versionCheckInterval?: number;
+  userUuid?: string;
 }
 
 export interface AuthCredentials {
@@ -34,6 +35,7 @@ export const CONFIG_KEYS = [
   'lastVersionCheck',
   'skipVersionCheck',
   'versionCheckInterval',
+  'userUuid',
 ] as const;
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
 

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -18,10 +18,15 @@ import { ChecksPRCommand } from '../../src/commands/pr/checks.command.js';
 import {
   createMockOutputService,
   createMockGitService,
+  createMockConfigService,
   mockPullRequest,
   mockUser,
 } from '../setup.js';
-import type { IContextService } from '../../src/core/interfaces/services.js';
+import type {
+  IContextService,
+  IConfigService,
+} from '../../src/core/interfaces/services.js';
+import { PullrequestsApiWrapper } from '../../src/services/api-wrapper.js';
 import type { BBError } from '../../src/types/errors.js';
 import type {
   Pullrequest,
@@ -351,13 +356,20 @@ function createMockContextService(context?: {
 describe('ListPRsCommand', () => {
   it('should list open pull requests by default', async () => {
     const pullrequestsApi = createMockPullrequestsApi();
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
     const contextService = createMockContextService({
       workspace: 'workspace',
       repoSlug: 'repo',
     });
+    const configService = createMockConfigService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -369,13 +381,20 @@ describe('ListPRsCommand', () => {
       { ...mockPullRequest, id: 2, state: 'MERGED' as const },
     ];
     const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
     const contextService = createMockContextService({
       workspace: 'workspace',
       repoSlug: 'repo',
     });
+    const configService = createMockConfigService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
     await command.execute({ state: 'MERGED' }, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -383,23 +402,37 @@ describe('ListPRsCommand', () => {
 
   it('should fail when no repo context', async () => {
     const pullrequestsApi = createMockPullrequestsApi();
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
     const contextService = createMockContextService();
+    const configService = createMockConfigService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
 
     await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow();
   });
 
   it('should show message when no PRs found', async () => {
     const pullrequestsApi = createMockPullrequestsApi({ pullRequests: [] });
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
     const contextService = createMockContextService({
       workspace: 'workspace',
       repoSlug: 'repo',
     });
+    const configService = createMockConfigService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(
@@ -410,17 +443,71 @@ describe('ListPRsCommand', () => {
   it('should label draft pull requests', async () => {
     const prs = [{ ...mockPullRequest, id: 1, draft: true }];
     const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
     const contextService = createMockContextService({
       workspace: 'workspace',
       repoSlug: 'repo',
     });
+    const configService = createMockConfigService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table-rows:'))).toBe(true);
     expect(output.logs.some((log) => log.includes('[DRAFT]'))).toBe(true);
+  });
+
+  it('should filter by reviewer when --mine flag is used', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const configService = createMockConfigService({ userUuid: '{test-uuid}' });
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
+    await command.execute({ mine: true }, { globalOptions: {} });
+
+    expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
+  });
+
+  it('should show warning when --mine is used but no user UUID is available', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const pullrequestsApiWrapper = new PullrequestsApiWrapper(pullrequestsApi);
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(
+      pullrequestsApiWrapper,
+      contextService,
+      configService,
+      output
+    );
+    await command.execute({ mine: true }, { globalOptions: {} });
+
+    expect(output.logs.some((log) => log.includes('warning:'))).toBe(true);
+    expect(
+      output.logs.some((log) =>
+        log.includes('Could not determine your user UUID')
+      )
+    ).toBe(true);
   });
 });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -71,6 +71,9 @@ export function createMockConfigService(config: BBConfig = {}): IConfigService {
     getConfigPath() {
       return '/tmp/test-config/config.json';
     },
+    async getUserUuid() {
+      return currentConfig.userUuid;
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

This PR adds a `--mine` flag to the `bb pr list` command that filters pull requests to show only those where the authenticated user is listed as a reviewer.

## Changes

- **New Feature**: Added `--mine` flag to `bb pr list` command
- **API Enhancement**: Extended `PullrequestsApiWrapper` to support query parameter for server-side filtering
- **User Caching**: Added `getUserUuid()` method to `ConfigService` that fetches and caches the user's UUID
- **Documentation**: Updated PR command documentation with new flag and examples
- **Tests**: Added comprehensive tests for the new functionality

## Usage

```bash
# Show only PRs where you are a reviewer
bb pr list --mine

# Combine with other filters
bb pr list --mine --state OPEN
bb pr list --mine --limit 50
```

## Technical Details

- Uses Bitbucket's API filtering via the `q` query parameter: `q=reviewers.uuid="{UUID}"`
- User UUID is fetched once and cached in the config file for optimal performance
- The generated OpenAPI client doesn't expose the `q` parameter, so we pass it via Axios options

## Testing

- All existing tests pass
- Added new tests for `--mine` flag functionality
- Added test for warning when user UUID is not available

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes are documented
- [x] Tests added and passing
- [x] Changeset created for version bump

Closes #79
