### PR TITLE
feat: normalize JSON output and color handling across commands

### DIFF
--- a/.changeset/normalize-output-json-behavior.md
+++ b/.changeset/normalize-output-json-behavior.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Normalize CLI output behavior by adding global JSON support to all commands,
+introducing global `--no-color` handling, and routing command formatting through
+`IOutputService` helpers instead of direct `chalk` usage.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ bb pr list
 bb repo list
 bb pr create --title "Add feature"
 bb pr approve 42
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 ```
 
-**Global options:** `--json`, `-w, --workspace`, `-r, --repo`
+**Global options:** `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`
 
 ---
 

--- a/docs/src/content/docs/commands/auth.mdx
+++ b/docs/src/content/docs/commands/auth.mdx
@@ -5,6 +5,8 @@ description: Authentication commands reference
 
 Manage authentication with Bitbucket.
 
+Global options available on all auth commands: `--json`, `--no-color`.
+
 ## `bb auth login`
 
 Authenticate with Bitbucket using an API token.

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -5,6 +5,8 @@ description: Shell completion utilities reference
 
 Enable tab completion for bash, zsh, or fish shells.
 
+Global options available on completion commands: `--json`, `--no-color`.
+
 ## Supported Shells
 
 | Shell | Config File |
@@ -18,8 +20,14 @@ Enable tab completion for bash, zsh, or fish shells.
 Install shell completions for your current shell.
 
 ```bash
-bb completion install
+bb completion install [options]
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
 
 The installer auto-detects your shell and adds the necessary configuration.
 
@@ -44,6 +52,9 @@ source ~/.config/fish/config.fish
 # Install completions
 bb completion install
 
+# Install with JSON output
+bb completion install --json
+
 # Test it works
 bb <Tab>        # Shows: auth, repo, pr, config, completion
 bb repo <Tab>   # Shows: clone, create, list, view, delete
@@ -56,14 +67,23 @@ bb repo <Tab>   # Shows: clone, create, list, view, delete
 Remove shell completions.
 
 ```bash
-bb completion uninstall
+bb completion uninstall [options]
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
 # Remove completions
 bb completion uninstall
+
+# Remove completions with JSON output
+bb completion uninstall --json
 ```
 
 ---
@@ -74,7 +94,7 @@ Tab completion works for:
 
 - **Commands**: `auth`, `repo`, `pr`, `config`, `completion`
 - **Subcommands**: `login`, `clone`, `create`, `list`, etc.
-- **Options**: `--json`, `--workspace`, `--repo`, `--help`
+- **Options**: `--json`, `--no-color`, `--workspace`, `--repo`, `--help`
 
 ### Example Session
 

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -5,6 +5,8 @@ description: Configuration commands reference
 
 Manage CLI configuration settings.
 
+Global options available on all config commands: `--json`, `--no-color`.
+
 ## Configuration File
 
 Configuration is stored in a JSON file at:
@@ -20,8 +22,7 @@ The configuration file stores your CLI settings and authentication credentials.
 |-----|-------------|
 | `username` | Bitbucket username (set during `auth login`) |
 | `apiToken` | Bitbucket API token (set during `auth login`, masked in output) |
-| `workspace` | Default workspace for commands |
-| `repo` | Default repository for commands |
+| `defaultWorkspace` | Default workspace for commands |
 | `skipVersionCheck` | Disable update notifications (default: false) |
 | `versionCheckInterval` | Days between update checks (default: 1) |
 
@@ -33,8 +34,7 @@ The config file is stored as JSON:
 {
   "username": "myuser",
   "apiToken": "***",
-  "workspace": "myworkspace",
-  "repo": "myrepo",
+  "defaultWorkspace": "myworkspace",
   "skipVersionCheck": false,
   "versionCheckInterval": 1
 }
@@ -62,11 +62,20 @@ bb config get <key>
 
 ```bash
 # Get default workspace
-bb config get workspace
+bb config get defaultWorkspace
 
 # Get username
 bb config get username
+
+# Get output as JSON
+bb config get defaultWorkspace --json
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
 
 ---
 
@@ -89,17 +98,23 @@ bb config set <key> <value>
 
 ```bash
 # Set default workspace
-bb config set workspace myworkspace
-
-# Set default repository
-bb config set repo myrepo
+bb config set defaultWorkspace myworkspace
 
 # Disable update notifications
 bb config set skipVersionCheck true
 
 # Check for updates weekly instead of daily
 bb config set versionCheckInterval 7
+
+# Get output as JSON
+bb config set defaultWorkspace myworkspace --json
 ```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
 
 :::caution
 Use `bb auth login` to set credentials instead of manually setting `username` and `apiToken`.
@@ -139,10 +154,10 @@ Config file: /Users/you/.config/bb/config.json
 KEY               VALUE
 -----------------  ---------
 username          myuser
-workspace         myworkspace
-appPassword       ********
+defaultWorkspace  myworkspace
+apiToken          ********
 ```
 
 :::note
-The `appPassword` value is always masked for security.
+The `apiToken` value is always masked for security.
 :::

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -5,6 +5,8 @@ description: Complete reference for Bitbucket CLI pull request commands. Learn t
 
 Manage pull requests in Bitbucket repositories.
 
+Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
 ## `bb pr create`
 
 Create a new pull request.
@@ -116,6 +118,7 @@ bb pr list [options]
 | `-r, --repo <repo>` | Repository |
 | `-s, --state <state>` | Filter by state: OPEN, MERGED, DECLINED, SUPERSEDED (default: OPEN) |
 | `--limit <number>` | Maximum number of PRs (default: 25) |
+| `--json` | Output as JSON |
 
 ### Examples
 
@@ -500,6 +503,7 @@ bb pr diff 42 --stat --json
 - When no ID is provided, the command searches for an open PR where the source branch matches your current git branch
 - The `--stat` output shows files changed with insertions (+) and deletions (-)
 - Use `--color never` when piping output to files or other commands
+- Use the global `--no-color` flag to disable color output for all command formatting
 - The diff is colorized by default when output is a terminal (green for additions, red for deletions, cyan for hunk headers)
 
 ---
@@ -676,6 +680,9 @@ bb pr comments delete 42 123
 
 # Delete comment in specific repository
 bb pr comments delete 42 456 -w myworkspace -r myrepo
+
+# Delete comment with JSON output
+bb pr comments delete 42 456 --json
 ```
 
 ### Notes

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -5,6 +5,8 @@ description: Complete reference for Bitbucket CLI repository commands. Learn to 
 
 Manage Bitbucket repositories.
 
+Global options available on all repo commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
 ## `bb repo clone`
 
 Clone a Bitbucket repository.

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -120,7 +120,7 @@ Here are the commands you'll use most often:
 If you work primarily in one workspace, set it as default:
 
 ```bash
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 ```
 
 Now commands will use this workspace automatically:

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -140,9 +140,8 @@ Choose your AI agent:
          - `bb repo list -w workspace` - List repos
          - `bb repo clone workspace/repo` - Clone
 
-         **Configuration:**
-         - `bb config set workspace myworkspace`
-         - `bb config set repo myrepo`
+          **Configuration:**
+          - `bb config set defaultWorkspace myworkspace`
 
           ### Tips
 

--- a/docs/src/content/docs/guides/cicd.mdx
+++ b/docs/src/content/docs/guides/cicd.mdx
@@ -116,7 +116,7 @@ jobs:
 
           # Check if PR already exists
           EXISTING=$(bb pr list -w workspace -r repo --json | \
-            jq --arg branch "$BRANCH" '[.[] | select(.source.branch.name == $branch)] | length')
+            jq --arg branch "$BRANCH" '[.pullRequests[] | select(.source.branch.name == $branch)] | length')
 
           if [ "$EXISTING" -eq 0 ]; then
             bb pr create -w workspace -r repo \
@@ -222,7 +222,7 @@ pipeline {
                 sh '''
                     export PATH="$HOME/.bun/bin:$PATH"
                     bb pr list -w myworkspace -r myrepo --json > prs.json
-                    PR_COUNT=$(jq length prs.json)
+                    PR_COUNT=$(jq '.count' prs.json)
                     echo "Found $PR_COUNT open PRs"
                 '''
             }
@@ -236,7 +236,7 @@ pipeline {
                 sh '''
                     export PATH="$HOME/.bun/bin:$PATH"
                     APPROVED_PRS=$(bb pr list -w myworkspace -r myrepo --json | \
-                        jq -r '.[] | select(.participants | any(.approved == true)) | .id')
+                        jq -r '.pullRequests[] | select(.participants | any(.approved == true)) | .id')
 
                     for PR_ID in $APPROVED_PRS; do
                         echo "Merging PR #$PR_ID"
@@ -345,7 +345,7 @@ REPO="myrepo"
 
 # Find PRs that are approved and have passing builds
 approved_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '
-  .[] |
+  .pullRequests[] |
   select(.participants | any(.approved == true)) |
   select(.state == "OPEN") |
   .id
@@ -378,7 +378,7 @@ echo "# Changelog - Week of $(date +%Y-%m-%d)"
 echo ""
 
 bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --json | jq -r --arg since "$SINCE_DATE" '
-  .[] |
+  .pullRequests[] |
   select(.updated_on >= $since) |
   "- \(.title) (#\(.id)) by @\(.author.username)"
 '

--- a/docs/src/content/docs/guides/repository-context.mdx
+++ b/docs/src/content/docs/guides/repository-context.mdx
@@ -11,7 +11,7 @@ The CLI checks multiple sources in this order:
 
 1. **Command-line flags** (`--workspace` and `--repo`)
 2. **Current Git repository** (automatically detected from your git remote URL)
-3. **Config file defaults** (`workspace` and `repo` settings)
+3. **Config file defaults** (`defaultWorkspace` setting)
 4. **Combinations** of the above sources
 
 ### Examples
@@ -39,8 +39,7 @@ This works from anywhere, even outside a git repository.
 
 ```bash
 # Set defaults once
-bb config set workspace myworkspace
-bb config set repo myrepo
+bb config set defaultWorkspace myworkspace
 
 # Then use commands without flags
 bb pr list  # ✅ Uses config defaults
@@ -80,7 +79,7 @@ bb repo view myrepo
 ```
 
 The CLI will:
-1. Check if you set a default workspace via `bb config set workspace`
+1. Check if you set a default workspace via `bb config set defaultWorkspace`
 2. Check if you're in a git repository and use its workspace
 3. Error if neither is available
 
@@ -110,7 +109,7 @@ This error appears when the CLI can't figure out which workspace/repo to use.
 **Solutions:**
 1. Use explicit flags: `-w myworkspace -r myrepo`
 2. Run from within a Bitbucket repository
-3. Set defaults: `bb config set workspace myworkspace`
+3. Set defaults: `bb config set defaultWorkspace myworkspace`
 
 ### "Repository not found"
 
@@ -127,7 +126,7 @@ The workspace/repo combination was determined but doesn't exist.
 
 Set your default workspace if you primarily work with one:
 ```bash
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 ```
 
 Then work from within your git repositories - context will be automatic.
@@ -156,4 +155,4 @@ cd ../project-b && bb pr list  # Uses project-b's workspace
 
 - Use `bb repo view` with no arguments to see what context the CLI detected
 - The `--json` flag works with most commands for scripting
-- Global flags (`-w`, `-r`, `--json`) work with all commands
+- Global flags (`-w`, `-r`, `--json`, `--no-color`) work with all commands

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -23,22 +23,22 @@ bb pr view 42 --json
 
 ```bash
 # List all PR titles
-bb pr list --json | jq '.[].title'
+bb pr list --json | jq '.pullRequests[].title'
 
 # Get PR count
-bb pr list --json | jq 'length'
+bb pr list --json | jq '.count'
 
 # Filter by state
-bb pr list -s MERGED --json | jq 'length'
+bb pr list -s MERGED --json | jq '.count'
 
 # Get specific fields
-bb pr list --json | jq '.[] | {id, title, author: .author.display_name}'
+bb pr list --json | jq '.pullRequests[] | {id, title, author: .author.display_name}'
 
 # Filter by author
-bb pr list --json | jq '.[] | select(.author.username == "alice")'
+bb pr list --json | jq '.pullRequests[] | select(.author.username == "alice")'
 
 # Get PR URLs
-bb pr list --json | jq -r '.[].links.html.href'
+bb pr list --json | jq -r '.pullRequests[].links.html.href'
 ```
 
 ### Common jq Patterns
@@ -46,13 +46,13 @@ bb pr list --json | jq -r '.[].links.html.href'
 ```bash
 # PRs updated in the last 7 days
 bb pr list --json | jq --arg date "$(date -d '7 days ago' -Iseconds)" \
-  '.[] | select(.updated_on > $date)'
+  '.pullRequests[] | select(.updated_on > $date)'
 
 # PRs targeting main branch
-bb pr list --json | jq '.[] | select(.destination.branch.name == "main")'
+bb pr list --json | jq '.pullRequests[] | select(.destination.branch.name == "main")'
 
 # Group PRs by author
-bb pr list --json | jq 'group_by(.author.username) | map({author: .[0].author.username, count: length})'
+bb pr list --json | jq '.pullRequests | group_by(.author.username) | map({author: .[0].author.username, count: length})'
 ```
 
 ---
@@ -159,7 +159,7 @@ Add delays between requests:
 ```bash
 #!/bin/bash
 
-for pr_id in $(bb pr list --json | jq -r '.[].id'); do
+for pr_id in $(bb pr list --json | jq -r '.pullRequests[].id'); do
   bb pr view "$pr_id" --json
   sleep 1  # Rate limit protection
 done
@@ -184,7 +184,7 @@ AUTHOR="trusted-bot"
 echo "Finding PRs from $AUTHOR..."
 
 pr_ids=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | \
-  jq -r --arg author "$AUTHOR" '.[] | select(.author.username == $author) | .id')
+  jq -r --arg author "$AUTHOR" '.pullRequests[] | select(.author.username == $author) | .id')
 
 for pr_id in $pr_ids; do
   echo "Approving PR #$pr_id..."
@@ -210,7 +210,7 @@ echo ""
 echo "Generated: $(date)"
 echo ""
 
-bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.[] |
+bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[] |
   "## PR #\(.id): \(.title)\n" +
   "- **Author:** \(.author.display_name)\n" +
   "- **Branch:** \(.source.branch.name) → \(.destination.branch.name)\n" +
@@ -236,7 +236,7 @@ cutoff=$(date -d "$DAYS_OLD days ago" -Iseconds 2>/dev/null || \
 echo "Finding PRs older than $DAYS_OLD days..."
 
 stale_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | \
-  jq -r --arg cutoff "$cutoff" '.[] | select(.updated_on < $cutoff) | .id')
+  jq -r --arg cutoff "$cutoff" '.pullRequests[] | select(.updated_on < $cutoff) | .id')
 
 if [ -z "$stale_prs" ]; then
   echo "No stale PRs found"
@@ -265,7 +265,7 @@ mkdir -p "$BACKUP_DIR"
 cd "$BACKUP_DIR"
 
 echo "Fetching repository list..."
-repos=$(bb repo list -w "$WORKSPACE" --json | jq -r '.[].name')
+repos=$(bb repo list -w "$WORKSPACE" --json | jq -r '.repositories[].name')
 
 for repo in $repos; do
   echo "Cloning $repo..."
@@ -293,13 +293,13 @@ total_files=0
 total_additions=0
 total_deletions=0
 
-for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.[].id'); do
+for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[].id'); do
   stats=$(bb pr diff "$pr_id" -w "$WORKSPACE" -r "$REPO" --stat --json 2>/dev/null)
 
   if [ -n "$stats" ]; then
-    files=$(echo "$stats" | jq '.stat.filesChanged // 0')
-    additions=$(echo "$stats" | jq '.stat.insertions // 0')
-    deletions=$(echo "$stats" | jq '.stat.deletions // 0')
+    files=$(echo "$stats" | jq '.filesChanged // 0')
+    additions=$(echo "$stats" | jq '.totalAdditions // 0')
+    deletions=$(echo "$stats" | jq '.totalDeletions // 0')
 
     echo "PR #$pr_id: $files files, +$additions -$deletions"
 
@@ -336,7 +336,7 @@ def run_bb(args):
 
 # List PRs
 prs = run_bb(['pr', 'list', '-w', 'workspace', '-r', 'repo'])
-for pr in prs:
+for pr in prs['pullRequests']:
     print(f"#{pr['id']}: {pr['title']}")
 
 # Get PR details
@@ -362,7 +362,7 @@ function runBB(args) {
 
 // List PRs
 const prs = runBB(['pr', 'list', '-w', 'workspace', '-r', 'repo']);
-prs.forEach(pr => {
+prs.pullRequests.forEach(pr => {
   console.log(`#${pr.id}: ${pr.title}`);
 });
 ```

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -137,8 +137,7 @@ For full functionality, grant all repository and pull request scopes.
 
 **Option 1:** Set defaults
 ```bash
-bb config set workspace myworkspace
-bb config set repo myrepo
+bb config set defaultWorkspace myworkspace
 ```
 
 **Option 2:** Work from cloned repositories
@@ -210,13 +209,13 @@ Use the `--json` flag for machine-readable output:
 
 ```bash
 # List PR titles
-bb pr list --json | jq '.[].title'
+bb pr list --json | jq '.pullRequests[].title'
 
 # Get PR count
-bb pr list --json | jq 'length'
+bb pr list --json | jq '.count'
 
 # Filter by author
-bb pr list --json | jq '.[] | select(.author.username == "alice")'
+bb pr list --json | jq '.pullRequests[] | select(.author.username == "alice")'
 ```
 
 ---
@@ -230,7 +229,7 @@ Yes! Example pre-push hook to check for open PRs:
 # .git/hooks/pre-push
 
 branch=$(git branch --show-current)
-prs=$(bb pr list --json 2>/dev/null | jq --arg b "$branch" '[.[] | select(.source.branch.name == $b)] | length')
+prs=$(bb pr list --json 2>/dev/null | jq --arg b "$branch" '[.pullRequests[] | select(.source.branch.name == $b)] | length')
 
 if [ "$prs" -gt 0 ]; then
   echo "Note: PR already exists for branch $branch"

--- a/docs/src/content/docs/help/troubleshooting.mdx
+++ b/docs/src/content/docs/help/troubleshooting.mdx
@@ -105,7 +105,7 @@ Error: Could not determine repository. Use -w and -r flags or run from within a 
 **Causes:**
 - Not in a git repository
 - Git remote doesn't point to Bitbucket
-- No default workspace/repo configured
+- No default workspace configured
 
 **Solutions:**
 
@@ -116,8 +116,7 @@ bb pr list -w myworkspace -r myrepo
 
 **Option 2:** Set defaults
 ```bash
-bb config set workspace myworkspace
-bb config set repo myrepo
+bb config set defaultWorkspace myworkspace
 ```
 
 **Option 3:** Work from a cloned repository
@@ -216,7 +215,7 @@ Error: Rate limit exceeded
 3. Use `--json` and process locally to reduce API calls:
    ```bash
    # One API call, process locally
-   bb pr list --json | jq '.[] | select(.author.username == "me")'
+   bb pr list --json | jq '.pullRequests[] | select(.author.username == "me")'
    ```
 
 ---

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -116,7 +116,7 @@ bb pr list
     JSON output for all commands. Perfect for CI/CD pipelines and automation scripts.
 
     ```bash
-    bb pr list --json | jq '.[].title'
+    bb pr list --json | jq '.pullRequests[].title'
     ```
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -32,8 +32,7 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 |-----|------|-------------|--------|
 | `username` | string | Your Bitbucket username | `bb auth login` |
 | `apiToken` | string | Your API token (stored securely) | `bb auth login` |
-| `workspace` | string | Default workspace | `bb config set` |
-| `repo` | string | Default repository | `bb config set` |
+| `defaultWorkspace` | string | Default workspace | `bb config set defaultWorkspace` |
 | `skipVersionCheck` | boolean | Disable update notifications | `bb config set` |
 | `versionCheckInterval` | number | Days between update checks (default: 1) | `bb config set` |
 
@@ -43,8 +42,7 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 {
   "username": "myuser",
   "apiToken": "ATBB_xxxxxxxxxxxxxxxxxxxx",
-  "workspace": "myworkspace",
-  "repo": "myrepo",
+  "defaultWorkspace": "myworkspace",
   "skipVersionCheck": false,
   "versionCheckInterval": 7
 }
@@ -67,8 +65,7 @@ Configuration file: /Users/you/.config/bb/config.json
 Key              Value
 username         myuser
 apiToken         ********
-workspace        myworkspace
-repo             myrepo
+defaultWorkspace myworkspace
 ```
 
 <Aside type="note">
@@ -78,15 +75,14 @@ The API token is masked for security. Use `bb auth token` to see the actual toke
 ### Get a Specific Value
 
 ```bash
-bb config get workspace
+bb config get defaultWorkspace
 # Output: myworkspace
 ```
 
 ### Set a Value
 
 ```bash
-bb config set workspace myworkspace
-bb config set repo myrepo
+bb config set defaultWorkspace myworkspace
 bb config set skipVersionCheck true
 bb config set versionCheckInterval 7
 ```
@@ -161,7 +157,7 @@ When determining workspace and repository, the CLI checks sources in this order:
 
 3. **Configuration file** (lowest priority)
    ```bash
-   bb config set workspace myworkspace
+   bb config set defaultWorkspace myworkspace
    bb pr list  # Uses config default
    ```
 
@@ -192,7 +188,7 @@ Never share your config file or commit it to version control. The API token gran
 bb auth logout
 ```
 
-This removes `username` and `apiToken` but keeps `workspace` and `repo` settings.
+This removes `username` and `apiToken` but keeps `defaultWorkspace` and other settings.
 
 ### Full Reset
 

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -13,6 +13,8 @@ Environment variables allow you to configure the CLI without storing credentials
 |----------|-------------|---------|
 | `BB_USERNAME` | Your Bitbucket username | `myuser` |
 | `BB_API_TOKEN` | Your Bitbucket API token | `ATBB...` |
+| `NO_COLOR` | Disable color output globally | `1` |
+| `FORCE_COLOR` | Force-enable color output globally | `1` |
 
 ## Configuration Priority
 
@@ -22,6 +24,13 @@ The CLI resolves configuration in this order (highest priority first):
 2. **Environment variables** (`BB_USERNAME`, `BB_API_TOKEN`)
 3. **Git repository context** (detected from remote URL)
 4. **Configuration file** (`~/.config/bb/config.json`)
+
+For color output, precedence is:
+
+1. `--color` (force color on)
+2. `FORCE_COLOR`
+3. `--no-color`
+4. `NO_COLOR`
 
 ---
 

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -198,11 +198,12 @@ bb auth login
 
 **Solution:**
 Valid configuration keys are:
-- `workspace` - Default workspace
-- `repo` - Default repository
+- `defaultWorkspace` - Default workspace
+- `skipVersionCheck` - Disable update notifications
+- `versionCheckInterval` - Days between update checks
 
 ```bash
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 bb config list
 ```
 
@@ -255,7 +256,7 @@ bb pr list -w myworkspace -r myrepo
 ```
 2. Set a default:
 ```bash
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 ```
 3. Run from within a cloned Bitbucket repository
 
@@ -274,7 +275,7 @@ bb repo list -w myworkspace
 ```
 2. Set a default workspace:
 ```bash
-bb config set workspace myworkspace
+bb config set defaultWorkspace myworkspace
 ```
 
 ---

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -1,367 +1,125 @@
 ---
 title: JSON Output
-description: Reference for JSON output format of all commands
+description: Reference for JSON output behavior across all commands
 ---
 
-import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+All commands support the global `--json` flag.
 
-All commands support the `--json` flag for machine-readable output. This page documents the JSON schema for each command.
+Use JSON mode for automation, scripts, and CI/CD pipelines.
 
-## Using JSON Output
+## Quick Usage
 
 ```bash
-# Basic usage
+# List pull requests as JSON
 bb pr list --json
 
-# Pipe to jq for processing
-bb pr list --json | jq '.[].title'
-
-# Save to file
-bb pr list --json > prs.json
+# Disable color formatting and return JSON
+bb repo view --json --no-color
 ```
 
----
+## Output Model
 
-## Authentication Commands
+JSON output is normalized, but not every command returns the same shape.
 
-### `bb auth status --json`
+- List commands return an object envelope with metadata and an array.
+- Read/create/update commands usually return a resource object (or resource plus metadata).
+- Action commands usually return `success: true` plus identifiers.
 
-```json
-{
-  "authenticated": true,
-  "username": "myuser",
-  "displayName": "My Name",
-  "accountId": "123456:abcd-efgh-ijkl",
-  "defaultWorkspace": "myworkspace"
-}
-```
+Typical top-level metadata fields include:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `authenticated` | boolean | Whether user is logged in |
-| `username` | string | Bitbucket username |
-| `displayName` | string | User's display name |
-| `accountId` | string | Bitbucket account ID |
-| `defaultWorkspace` | string \| null | Configured default workspace |
+- `workspace`
+- `repoSlug`
+- `pullRequestId`
+- `count`
 
----
-
-## Repository Commands
-
-### `bb repo list --json`
-
-```json
-[
-  {
-    "name": "my-repo",
-    "full_name": "myworkspace/my-repo",
-    "description": "Repository description",
-    "is_private": true,
-    "created_on": "2024-01-15T10:30:00.000000+00:00",
-    "updated_on": "2024-12-28T15:45:00.000000+00:00",
-    "language": "TypeScript",
-    "links": {
-      "html": {
-        "href": "https://bitbucket.org/myworkspace/my-repo"
-      },
-      "clone": [
-        {
-          "name": "https",
-          "href": "https://bitbucket.org/myworkspace/my-repo.git"
-        },
-        {
-          "name": "ssh",
-          "href": "git@bitbucket.org:myworkspace/my-repo.git"
-        }
-      ]
-    },
-    "mainbranch": {
-      "name": "main",
-      "type": "branch"
-    },
-    "owner": {
-      "username": "myworkspace",
-      "display_name": "My Workspace",
-      "type": "team"
-    }
-  }
-]
-```
-
-### `bb repo view --json`
-
-Same schema as a single item from `bb repo list --json`.
-
-### `bb repo create --json`
-
-Returns the created repository object (same schema as `bb repo view`).
-
----
-
-## Pull Request Commands
+## Common Examples
 
 ### `bb pr list --json`
 
 ```json
-[
-  {
-    "id": 42,
-    "title": "Add new feature",
-    "description": "This PR adds...",
-    "state": "OPEN",
-    "draft": false,
-    "created_on": "2024-12-20T09:00:00.000000+00:00",
-    "updated_on": "2024-12-28T14:30:00.000000+00:00",
-    "author": {
-      "username": "alice",
-      "display_name": "Alice Smith",
-      "account_id": "123:abc"
-    },
-    "source": {
-      "branch": {
-        "name": "feature/new-feature"
-      },
-      "repository": {
-        "full_name": "myworkspace/my-repo"
-      }
-    },
-    "destination": {
-      "branch": {
-        "name": "main"
-      }
-    },
-    "close_source_branch": true,
-    "comment_count": 5,
-    "task_count": 2,
-    "participants": [
-      {
-        "user": {
-          "username": "bob",
-          "display_name": "Bob Jones"
-        },
-        "role": "REVIEWER",
-        "approved": true
-      }
-    ],
-    "links": {
-      "html": {
-        "href": "https://bitbucket.org/myworkspace/my-repo/pull-requests/42"
-      },
-      "diff": {
-        "href": "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pullrequests/42/diff"
-      }
-    }
-  }
-]
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | number | Pull request ID |
-| `title` | string | PR title |
-| `description` | string | PR description/body |
-| `state` | string | `OPEN`, `MERGED`, `DECLINED`, `SUPERSEDED` |
-| `created_on` | string | ISO 8601 timestamp |
-| `updated_on` | string | ISO 8601 timestamp |
-| `draft` | boolean | Draft status (true = draft) |
-| `author` | object | PR author details |
-| `source.branch.name` | string | Source branch name |
-| `destination.branch.name` | string | Target branch name |
-| `close_source_branch` | boolean | Delete source after merge |
-| `comment_count` | number | Number of comments |
-| `task_count` | number | Number of tasks |
-| `participants` | array | Reviewers and their status |
-
-### `bb pr view --json`
-
-Same schema as a single item from `bb pr list --json`, with additional details.
-
-### `bb pr create --json`
-
-Returns the created PR object (same schema as `bb pr view`).
-
-### `bb pr merge --json`
-
-Returns the merged PR object with `state: "MERGED"`.
-
-### `bb pr diff --stat --json`
-
-```json
 {
-  "stat": {
-    "filesChanged": 5,
-    "insertions": 120,
-    "deletions": 45,
-    "files": [
-      {
-        "path": "src/index.ts",
-        "additions": 50,
-        "deletions": 10
-      },
-      {
-        "path": "src/utils.ts",
-        "additions": 70,
-        "deletions": 35
-      }
-    ]
-  }
-}
-```
-
-### `bb pr diff --name-only --json`
-
-```json
-{
-  "diff": "src/index.ts\nsrc/utils.ts\npackage.json"
-}
-```
-
-### `bb pr diff --json` (full diff)
-
-```json
-{
-  "diff": "diff --git a/src/index.ts b/src/index.ts\n..."
-}
-```
-
----
-
-## Config Commands
-
-### `bb config list --json`
-
-```json
-{
-  "username": "myuser",
-  "apiToken": "********",
   "workspace": "myworkspace",
-  "repo": "myrepo"
+  "repoSlug": "myrepo",
+  "state": "OPEN",
+  "count": 2,
+  "pullRequests": [
+    {
+      "id": 42,
+      "title": "Add feature",
+      "state": "OPEN"
+    }
+  ]
 }
 ```
 
-<Aside type="note">
-The API token is always masked in config list output.
-</Aside>
-
-### `bb config get --json`
+### `bb repo list --json`
 
 ```json
 {
-  "key": "workspace",
-  "value": "myworkspace"
+  "workspace": "myworkspace",
+  "count": 1,
+  "repositories": [
+    {
+      "full_name": "myworkspace/myrepo",
+      "is_private": true
+    }
+  ]
 }
 ```
 
----
-
-## Error Response Format
-
-When a command fails, JSON output includes error details:
+### `bb pr diff 42 --stat --json`
 
 ```json
 {
-  "name": "BBError",
-  "code": 2002,
-  "message": "Repository not found",
-  "context": {
-    "workspace": "myworkspace",
-    "repo": "nonexistent"
-  }
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "pullRequestId": 42,
+  "mode": "stat",
+  "filesChanged": 3,
+  "totalAdditions": 27,
+  "totalDeletions": 11,
+  "files": [
+    {
+      "path": "src/index.ts",
+      "additions": 10,
+      "deletions": 3
+    }
+  ]
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Error type |
-| `code` | number | Error code (see [Error Codes](/reference/error-codes/)) |
-| `message` | string | Human-readable message |
-| `context` | object | Additional context (optional) |
+### `bb auth token --json`
 
----
+```json
+{
+  "token": "base64-encoded-credentials"
+}
+```
 
-## Parsing Examples
-
-### jq (Command Line)
+## jq Examples
 
 ```bash
-# Get all PR titles
-bb pr list --json | jq -r '.[].title'
+# Print PR titles
+bb pr list --json | jq -r '.pullRequests[].title'
 
-# Count open PRs
-bb pr list --json | jq 'length'
+# Count PRs
+bb pr list --json | jq '.count'
 
-# Get PRs by specific author
-bb pr list --json | jq '.[] | select(.author.username == "alice")'
+# Get repository names
+bb repo list --json | jq -r '.repositories[].full_name'
 
-# Extract specific fields
-bb pr list --json | jq '.[] | {id, title, author: .author.display_name}'
-
-# Get PR URLs
-bb pr list --json | jq -r '.[].links.html.href'
-
-# Filter PRs updated this week
-bb pr list --json | jq --arg date "$(date -d '7 days ago' -Iseconds)" \
-  '.[] | select(.updated_on > $date)'
+# Extract diff file paths
+bb pr diff 42 --stat --json | jq -r '.files[].path'
 ```
 
-### Node.js
+## Scripting Notes
 
-```javascript
-import { execSync } from 'child_process';
+- Prefer `--json` in scripts rather than parsing text output.
+- Do not rely on text formatting symbols (`✓`, table separators, colors).
+- If you need stable fields, prefer command-specific documented keys (`pullRequests`, `repositories`, `files`, `success`).
 
-const output = execSync('bb pr list --json', { encoding: 'utf8' });
-const prs = JSON.parse(output);
+## Errors
 
-// Filter approved PRs
-const approved = prs.filter(pr =>
-  pr.participants.some(p => p.approved)
-);
+When a command fails, the CLI exits non-zero and prints an error message to stderr.
 
-// Get PR IDs
-const ids = prs.map(pr => pr.id);
-```
-
-### Python
-
-```python
-import subprocess
-import json
-
-result = subprocess.run(
-    ['bb', 'pr', 'list', '--json'],
-    capture_output=True,
-    text=True
-)
-prs = json.loads(result.stdout)
-
-# Group by author
-from collections import defaultdict
-by_author = defaultdict(list)
-for pr in prs:
-    by_author[pr['author']['username']].append(pr)
-```
-
-### Bash
-
-```bash
-#!/bin/bash
-
-# Parse with jq and iterate
-bb pr list --json | jq -c '.[]' | while read -r pr; do
-  id=$(echo "$pr" | jq -r '.id')
-  title=$(echo "$pr" | jq -r '.title')
-  echo "PR #$id: $title"
-done
-```
-
----
-
-## Tips
-
-1. **Always use `--json` in scripts** for reliable parsing
-2. **Use jq's `-r` flag** for raw string output without quotes
-3. **Handle empty arrays** - `bb pr list --json` returns `[]` if no PRs
-4. **Errors go to stderr** - redirect stderr to capture error JSON:
-   ```bash
-   bb pr view 999 --json 2>&1 | jq '.code'
-   ```
+In automation, always check the process exit code before parsing stdout JSON.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -67,13 +67,20 @@ import { ListConfigCommand } from './commands/config/list.command.js';
 import { InstallCompletionCommand } from './commands/completion/install.command.js';
 import { UninstallCompletionCommand } from './commands/completion/uninstall.command.js';
 
-export function bootstrap(): Container {
+export interface BootstrapOptions {
+  noColor?: boolean;
+}
+
+export function bootstrap(options: BootstrapOptions = {}): Container {
   const container = Container.getInstance();
 
   // Register core services
   container.register(ServiceTokens.ConfigService, () => new ConfigService());
   container.register(ServiceTokens.GitService, () => new GitService());
-  container.register(ServiceTokens.OutputService, () => new OutputService());
+  container.register(
+    ServiceTokens.OutputService,
+    () => new OutputService({ noColor: options.noColor })
+  );
 
   // Register API clients with axios instance
   container.register(ServiceTokens.PullrequestsApi, () => {

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -30,7 +30,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
 
   public async execute(
     options: LoginOptions,
-    _context: CommandContext
+    context: CommandContext
   ): Promise<void> {
     const username = options.username || process.env.BB_USERNAME;
     const apiToken = options.password || process.env.BB_API_TOKEN;
@@ -52,6 +52,18 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
     try {
       const response = await this.usersApi.userGet();
       const user = response.data;
+
+      if (context.globalOptions.json) {
+        this.output.json({
+          authenticated: true,
+          user: {
+            username: user.username,
+            displayName: user.display_name,
+            accountId: user.account_id,
+          },
+        });
+        return;
+      }
 
       this.output.success(
         `Logged in as ${user.display_name} (${user.username})`

--- a/src/commands/auth/logout.command.ts
+++ b/src/commands/auth/logout.command.ts
@@ -20,11 +20,14 @@ export class LogoutCommand extends BaseCommand<void, void> {
     super(output);
   }
 
-  public async execute(
-    _options: void,
-    _context: CommandContext
-  ): Promise<void> {
+  public async execute(_options: void, context: CommandContext): Promise<void> {
     await this.configService.clearConfig();
+
+    if (context.globalOptions.json) {
+      this.output.json({ authenticated: false, success: true });
+      return;
+    }
+
     this.output.success('Logged out of Bitbucket');
   }
 }

--- a/src/commands/auth/token.command.ts
+++ b/src/commands/auth/token.command.ts
@@ -20,10 +20,7 @@ export class TokenCommand extends BaseCommand<void, void> {
     super(output);
   }
 
-  public async execute(
-    _options: void,
-    _context: CommandContext
-  ): Promise<void> {
+  public async execute(_options: void, context: CommandContext): Promise<void> {
     const credentials = await this.configService.getCredentials();
 
     if (!credentials.username || !credentials.apiToken) {
@@ -34,7 +31,11 @@ export class TokenCommand extends BaseCommand<void, void> {
       `${credentials.username}:${credentials.apiToken}`
     ).toString('base64');
 
-    // Always output the raw token (not JSON formatted)
+    if (context.globalOptions.json) {
+      this.output.json({ token });
+      return;
+    }
+
     this.output.text(token);
   }
 }

--- a/src/commands/completion/install.command.ts
+++ b/src/commands/completion/install.command.ts
@@ -15,15 +15,24 @@ export class InstallCompletionCommand extends BaseCommand<void, void> {
     super(output);
   }
 
-  public async execute(
-    _options: void,
-    _context: CommandContext
-  ): Promise<void> {
+  public async execute(_options: void, context: CommandContext): Promise<void> {
     try {
       await tabtab.install({
         name: 'bb',
         completer: 'bb',
       });
+
+      if (context.globalOptions.json) {
+        this.output.json({
+          success: true,
+          shellCompletion: {
+            command: 'bb',
+            installed: true,
+          },
+        });
+        return;
+      }
+
       this.output.success('Shell completions installed successfully!');
       this.output.text(
         'Restart your shell or source your profile to enable completions.'

--- a/src/commands/completion/uninstall.command.ts
+++ b/src/commands/completion/uninstall.command.ts
@@ -15,14 +15,23 @@ export class UninstallCompletionCommand extends BaseCommand<void, void> {
     super(output);
   }
 
-  public async execute(
-    _options: void,
-    _context: CommandContext
-  ): Promise<void> {
+  public async execute(_options: void, context: CommandContext): Promise<void> {
     try {
       await tabtab.uninstall({
         name: 'bb',
       });
+
+      if (context.globalOptions.json) {
+        this.output.json({
+          success: true,
+          shellCompletion: {
+            command: 'bb',
+            installed: false,
+          },
+        });
+        return;
+      }
+
       this.output.success('Shell completions uninstalled successfully!');
     } catch (error) {
       throw new Error(`Failed to uninstall completions: ${error}`);

--- a/src/commands/config/get.command.ts
+++ b/src/commands/config/get.command.ts
@@ -8,10 +8,7 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import {
-  isReadableConfigKey,
-  type ReadableConfigKey,
-} from '../../types/config.js';
+import { isReadableConfigKey } from '../../types/config.js';
 
 export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
   public readonly name = 'get';
@@ -28,7 +25,7 @@ export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
 
   public async execute(
     options: { key: string },
-    _context: CommandContext
+    context: CommandContext
   ): Promise<void> {
     const { key } = options;
 
@@ -47,6 +44,14 @@ export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
     }
 
     const value = await this.configService.getValue(key);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        key,
+        value: value ?? null,
+      });
+      return;
+    }
 
     // Output the value (or empty string if undefined)
     this.output.text(String(value || ''));

--- a/src/commands/config/list.command.ts
+++ b/src/commands/config/list.command.ts
@@ -2,7 +2,6 @@
  * List config command implementation
  */
 
-import chalk from 'chalk';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -27,10 +26,7 @@ export class ListConfigCommand extends BaseCommand<void, void> {
     super(output);
   }
 
-  public async execute(
-    _options: void,
-    _context: CommandContext
-  ): Promise<void> {
+  public async execute(_options: void, context: CommandContext): Promise<void> {
     const config = await this.configService.getConfig();
 
     // Build display config with masked password
@@ -40,8 +36,18 @@ export class ListConfigCommand extends BaseCommand<void, void> {
       apiToken: config.apiToken ? '********' : '',
     };
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        configPath: this.configService.getConfigPath(),
+        config: Object.fromEntries(
+          Object.entries(displayConfig).filter(([, value]) => value !== '')
+        ),
+      });
+      return;
+    }
+
     this.output.text(
-      chalk.dim(`Config file: ${this.configService.getConfigPath()}`)
+      this.output.dim(`Config file: ${this.configService.getConfigPath()}`)
     );
     this.output.text('');
 

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -8,10 +8,7 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import {
-  isSettableConfigKey,
-  type SettableConfigKey,
-} from '../../types/config.js';
+import { isSettableConfigKey } from '../../types/config.js';
 
 export class SetConfigCommand extends BaseCommand<
   { key: string; value: string },
@@ -31,7 +28,7 @@ export class SetConfigCommand extends BaseCommand<
 
   public async execute(
     options: { key: string; value: string },
-    _context: CommandContext
+    context: CommandContext
   ): Promise<void> {
     const { key, value } = options;
 
@@ -50,6 +47,15 @@ export class SetConfigCommand extends BaseCommand<
     }
 
     await this.configService.setValue(key, value);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        key,
+        value,
+      });
+      return;
+    }
 
     this.output.success(`Set ${key} = ${value}`);
   }

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -65,6 +65,20 @@ export class ActivityPRCommand extends BaseCommand<
           )
         : values;
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pullRequestId: prId,
+        filters: {
+          types: filterTypes,
+        },
+        count: activities.length,
+        activities,
+      });
+      return;
+    }
+
     if (activities.length === 0) {
       if (filterTypes.length > 0) {
         this.output.info('No activity entries matched the requested filter');

--- a/src/commands/pr/approve.command.ts
+++ b/src/commands/pr/approve.command.ts
@@ -47,6 +47,14 @@ export class ApprovePRCommand extends BaseCommand<
       }
     );
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+      });
+      return;
+    }
+
     this.output.success(`Approved pull request #${prId}`);
   }
 }

--- a/src/commands/pr/checkout.command.ts
+++ b/src/commands/pr/checkout.command.ts
@@ -61,14 +61,36 @@ export class CheckoutPRCommand extends BaseCommand<
 
     await this.gitService.fetch();
 
+    let checkedOutBranch: string;
+
     try {
       await this.gitService.checkout(branchName);
+      checkedOutBranch = branchName;
+      if (context.globalOptions.json) {
+        this.output.json({
+          success: true,
+          pullRequestId: prId,
+          branch: checkedOutBranch,
+          pullRequest: pr,
+        });
+        return;
+      }
       this.output.success(`Checked out PR #${prId} as '${branchName}'`);
     } catch {
       await this.gitService.checkoutNewBranch(
         localBranchName,
         `origin/${branchName}`
       );
+      checkedOutBranch = localBranchName;
+      if (context.globalOptions.json) {
+        this.output.json({
+          success: true,
+          pullRequestId: prId,
+          branch: checkedOutBranch,
+          pullRequest: pr,
+        });
+        return;
+      }
       this.output.success(`Checked out PR #${prId} as '${localBranchName}'`);
     }
 

--- a/src/commands/pr/comment.command.ts
+++ b/src/commands/pr/comment.command.ts
@@ -39,19 +39,29 @@ export class CommentPRCommand extends BaseCommand<
 
     const prId = Number.parseInt(options.id, 10);
 
-    await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsPost(
-      {
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pullRequestId: prId,
-        body: {
-          type: 'pullrequest_comment',
-          content: {
-            raw: options.message,
+    const response =
+      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsPost(
+        {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pullRequestId: prId,
+          body: {
+            type: 'pullrequest_comment',
+            content: {
+              raw: options.message,
+            },
           },
-        },
-      }
-    );
+        }
+      );
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        comment: response.data,
+      });
+      return;
+    }
 
     this.output.success(`Added comment to pull request #${prId}`);
   }

--- a/src/commands/pr/comments.delete.command.ts
+++ b/src/commands/pr/comments.delete.command.ts
@@ -49,6 +49,15 @@ export class DeleteCommentPRCommand extends BaseCommand<
       }
     );
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        commentId,
+      });
+      return;
+    }
+
     this.output.success(`Deleted comment #${commentId} from PR #${prId}`);
   }
 }

--- a/src/commands/pr/comments.edit.command.ts
+++ b/src/commands/pr/comments.edit.command.ts
@@ -44,20 +44,31 @@ export class EditCommentPRCommand extends BaseCommand<
     const prId = Number.parseInt(options.prId, 10);
     const commentId = Number.parseInt(options.commentId, 10);
 
-    await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsCommentIdPut(
-      {
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pullRequestId: prId,
-        commentId: commentId,
-        body: {
-          type: 'pullrequest_comment',
-          content: {
-            raw: options.message,
+    const response =
+      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsCommentIdPut(
+        {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pullRequestId: prId,
+          commentId: commentId,
+          body: {
+            type: 'pullrequest_comment',
+            content: {
+              raw: options.message,
+            },
           },
-        },
-      }
-    );
+        }
+      );
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        commentId,
+        comment: response.data,
+      });
+      return;
+    }
 
     this.output.success(`Updated comment #${commentId} on PR #${prId}`);
   }

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -54,6 +54,15 @@ export class ListCommentsPRCommand extends BaseCommand<
     const data = response.data;
     const values = data.values ? Array.from(data.values) : [];
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        pullRequestId: prId,
+        count: values.length,
+        comments: values,
+      });
+      return;
+    }
+
     if (values.length === 0) {
       this.output.info('No comments found on this pull request');
       return;

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -2,7 +2,6 @@
  * Create PR command implementation
  */
 
-import chalk from 'chalk';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -88,8 +87,13 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
     const pr = response.data;
     const links = pr.links as { html?: { href?: string } } | undefined;
 
+    if (context.globalOptions.json) {
+      this.output.json(pr);
+      return;
+    }
+
     this.output.success(`Created pull request #${pr.id}`);
-    this.output.text(`  ${chalk.dim('Title:')} ${pr.title}`);
-    this.output.text(`  ${chalk.dim('URL:')} ${links?.html?.href}`);
+    this.output.text(`  ${this.output.dim('Title:')} ${pr.title}`);
+    this.output.text(`  ${this.output.dim('URL:')} ${links?.html?.href}`);
   }
 }

--- a/src/commands/pr/decline.command.ts
+++ b/src/commands/pr/decline.command.ts
@@ -50,6 +50,15 @@ export class DeclinePRCommand extends BaseCommand<
 
     const pr = response.data;
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        pullRequest: pr,
+      });
+      return;
+    }
+
     this.output.success(`Declined pull request #${prId}: ${pr.title}`);
   }
 }

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -3,7 +3,6 @@
  */
 
 import * as fs from 'node:fs';
-import chalk from 'chalk';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -115,15 +114,20 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
     const pr = response.data;
     const links = pr.links as { html?: { href?: string } } | undefined;
 
+    if (context.globalOptions.json) {
+      this.output.json(pr);
+      return;
+    }
+
     this.output.success(`Updated pull request #${pr.id}`);
-    this.output.text(`  ${chalk.dim('Title:')} ${pr.title}`);
+    this.output.text(`  ${this.output.dim('Title:')} ${pr.title}`);
     if (pr.description) {
       const truncatedDesc =
         pr.description.length > 100
           ? pr.description.substring(0, 100) + '...'
           : pr.description;
-      this.output.text(`  ${chalk.dim('Description:')} ${truncatedDesc}`);
+      this.output.text(`  ${this.output.dim('Description:')} ${truncatedDesc}`);
     }
-    this.output.text(`  ${chalk.dim('URL:')} ${links?.html?.href}`);
+    this.output.text(`  ${this.output.dim('URL:')} ${links?.html?.href}`);
   }
 }

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -53,6 +53,17 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     const data = response.data;
     const values = data.values ? Array.from(data.values) : [];
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        state,
+        count: values.length,
+        pullRequests: values,
+      });
+      return;
+    }
+
     if (values.length === 0) {
       this.output.text(`No ${state.toLowerCase()} pull requests found`);
       return;

--- a/src/commands/pr/merge.command.ts
+++ b/src/commands/pr/merge.command.ts
@@ -80,6 +80,15 @@ export class MergePRCommand extends BaseCommand<
 
     const pr = response.data;
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        pullRequest: pr,
+      });
+      return;
+    }
+
     this.output.success(`Merged pull request #${prId}: ${pr.title}`);
   }
 }

--- a/src/commands/pr/ready.command.ts
+++ b/src/commands/pr/ready.command.ts
@@ -54,6 +54,15 @@ export class ReadyPRCommand extends BaseCommand<
 
     const pr = response.data;
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        pullRequestId: prId,
+        pullRequest: pr,
+      });
+      return;
+    }
+
     this.output.success(`Marked pull request #${prId} as ready for review`);
     this.output.text(`  ${pr.title}`);
   }

--- a/src/commands/pr/reviewers.add.command.ts
+++ b/src/commands/pr/reviewers.add.command.ts
@@ -71,17 +71,31 @@ export class AddReviewerPRCommand extends BaseCommand<
     }
 
     // Update PR with new reviewers list
-    await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
-      {
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
+    const response =
+      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
+        {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pullRequestId: prId,
+          body: {
+            type: 'pullrequest',
+            reviewers: reviewerUuids.map((uuid) => ({ uuid })),
+          } as unknown as import('../../generated/api.js').Pullrequest,
+        }
+      );
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
         pullRequestId: prId,
-        body: {
-          type: 'pullrequest',
-          reviewers: reviewerUuids.map((uuid) => ({ uuid })),
-        } as unknown as import('../../generated/api.js').Pullrequest,
-      }
-    );
+        reviewer: {
+          username: options.username,
+          uuid: user.uuid,
+        },
+        pullRequest: response.data,
+      });
+      return;
+    }
 
     this.output.success(
       `Added ${options.username} as reviewer to pull request #${prId}`

--- a/src/commands/pr/reviewers.list.command.ts
+++ b/src/commands/pr/reviewers.list.command.ts
@@ -51,11 +51,18 @@ export class ListReviewersPRCommand extends BaseCommand<
       );
 
     const pr = response.data;
-    const reviewers = pr.reviewers ?? [];
+    const reviewers = Array.from(pr.reviewers ?? []);
 
     if (context.globalOptions.json) {
-      this.output.json(reviewers);
-    } else if (reviewers.length === 0) {
+      this.output.json({
+        pullRequestId: prId,
+        count: reviewers.length,
+        reviewers,
+      });
+      return;
+    }
+
+    if (reviewers.length === 0) {
       this.output.info('No reviewers assigned to this pull request');
     } else {
       this.output.table(

--- a/src/commands/repo/clone.command.ts
+++ b/src/commands/repo/clone.command.ts
@@ -39,6 +39,17 @@ export class CloneCommand extends BaseCommand<
     await this.gitService.clone(repoUrl, directory);
 
     const targetDir = directory || this.extractRepoName(repository);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        repository,
+        path: targetDir,
+        cloneUrl: repoUrl,
+      });
+      return;
+    }
+
     this.output.success(`Cloned ${repository} into ${targetDir}`);
   }
 

--- a/src/commands/repo/create.command.ts
+++ b/src/commands/repo/create.command.ts
@@ -2,7 +2,6 @@
  * Create repository command implementation
  */
 
-import chalk from 'chalk';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -36,7 +35,7 @@ export class CreateRepoCommand extends BaseCommand<
 
   public async execute(
     options: { name: string } & CreateRepoOptions,
-    _context: CommandContext
+    context: CommandContext
   ): Promise<void> {
     const { name, description, project } = options;
     const isPublic = options.public === true;
@@ -74,10 +73,15 @@ export class CreateRepoCommand extends BaseCommand<
 
     const repo = response.data;
 
+    if (context.globalOptions.json) {
+      this.output.json(repo);
+      return;
+    }
+
     this.output.success(`Created repository ${repo.full_name}`);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.output.text(
-      `  ${chalk.dim('URL:')} ${(repo.links as any)?.html?.href}`
+      `  ${this.output.dim('URL:')} ${(repo.links as any)?.html?.href}`
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,7 +89,9 @@ export class CreateRepoCommand extends BaseCommand<
       (c: any) => c.name === 'ssh'
     ) as { href?: string } | undefined;
     if (sshClone?.href) {
-      this.output.text(`  ${chalk.dim('Clone:')} git clone ${sshClone.href}`);
+      this.output.text(
+        `  ${this.output.dim('Clone:')} git clone ${sshClone.href}`
+      );
     }
   }
 

--- a/src/commands/repo/delete.command.ts
+++ b/src/commands/repo/delete.command.ts
@@ -61,6 +61,15 @@ export class DeleteRepoCommand extends BaseCommand<
       repoSlug: repoContext.repoSlug,
     });
 
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+      });
+      return;
+    }
+
     this.output.success(
       `Deleted repository ${repoContext.workspace}/${repoContext.repoSlug}`
     );

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -29,9 +29,11 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
 
   public async execute(
     options: ListReposOptions,
-    _context: CommandContext
+    context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(options.workspace);
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
     const limit = Number.parseInt(options.limit || '25', 10);
 
     const response = await this.repositoriesApi.repositoriesWorkspaceGet({
@@ -39,6 +41,15 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     });
 
     const repos = Array.from(response.data.values ?? []).slice(0, limit);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace,
+        count: repos.length,
+        repositories: repos,
+      });
+      return;
+    }
 
     if (repos.length === 0) {
       this.output.text('No repositories found');

--- a/src/commands/repo/view.command.ts
+++ b/src/commands/repo/view.command.ts
@@ -2,7 +2,6 @@
  * View repository command implementation
  */
 
-import chalk from 'chalk';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -55,40 +54,45 @@ export class ViewRepoCommand extends BaseCommand<ViewRepoOptions, void> {
 
     const repo = response.data;
 
-    this.output.text(chalk.bold(repo.full_name ?? ''));
+    if (context.globalOptions.json) {
+      this.output.json(repo);
+      return;
+    }
+
+    this.output.text(this.output.bold(repo.full_name ?? ''));
 
     if (repo.description) {
-      this.output.text(chalk.dim(repo.description));
+      this.output.text(this.output.dim(repo.description));
     }
 
     this.output.text('');
     this.output.text(
-      `  ${chalk.dim('Visibility:')} ${repo.is_private ? 'Private' : 'Public'}`
+      `  ${this.output.dim('Visibility:')} ${repo.is_private ? 'Private' : 'Public'}`
     );
     this.output.text(
-      `  ${chalk.dim('Owner:')} ${repo.owner?.display_name ?? 'Unknown'}`
+      `  ${this.output.dim('Owner:')} ${repo.owner?.display_name ?? 'Unknown'}`
     );
 
     if (repo.language) {
-      this.output.text(`  ${chalk.dim('Language:')} ${repo.language}`);
+      this.output.text(`  ${this.output.dim('Language:')} ${repo.language}`);
     }
 
     if (repo.mainbranch) {
       this.output.text(
-        `  ${chalk.dim('Default branch:')} ${repo.mainbranch.name}`
+        `  ${this.output.dim('Default branch:')} ${repo.mainbranch.name}`
       );
     }
 
     this.output.text(
-      `  ${chalk.dim('Created:')} ${this.output.formatDate(repo.created_on ?? '')}`
+      `  ${this.output.dim('Created:')} ${this.output.formatDate(repo.created_on ?? '')}`
     );
     this.output.text(
-      `  ${chalk.dim('Updated:')} ${this.output.formatDate(repo.updated_on ?? '')}`
+      `  ${this.output.dim('Updated:')} ${this.output.formatDate(repo.updated_on ?? '')}`
     );
     this.output.text('');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.output.text(
-      `  ${chalk.dim('URL:')} ${(repo.links as any)?.html?.href}`
+      `  ${this.output.dim('URL:')} ${(repo.links as any)?.html?.href}`
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -96,7 +100,7 @@ export class ViewRepoCommand extends BaseCommand<ViewRepoOptions, void> {
       (c: any) => c.name === 'ssh'
     ) as { href?: string } | undefined;
     if (sshClone?.href) {
-      this.output.text(`  ${chalk.dim('SSH:')} ${sshClone.href}`);
+      this.output.text(`  ${this.output.dim('SSH:')} ${sshClone.href}`);
     }
   }
 }

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -57,5 +57,17 @@ export interface IOutputService {
   warning(message: string): void;
   info(message: string): void;
   text(message: string): void;
+  format(text: string, formatter: (text: string) => string): string;
+  dim(text: string): string;
+  highlight(text: string): string;
+  bold(text: string): string;
+  red(text: string): string;
+  green(text: string): string;
+  yellow(text: string): string;
+  cyan(text: string): string;
+  magenta(text: string): string;
+  gray(text: string): string;
+  blue(text: string): string;
+  underline(text: string): string;
   formatDate(date: string | Date): string;
 }

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -113,4 +113,36 @@ export class OutputService implements IOutputService {
   public bold(text: string): string {
     return this.format(text, chalk.bold);
   }
+
+  public red(text: string): string {
+    return this.format(text, chalk.red);
+  }
+
+  public green(text: string): string {
+    return this.format(text, chalk.green);
+  }
+
+  public yellow(text: string): string {
+    return this.format(text, chalk.yellow);
+  }
+
+  public cyan(text: string): string {
+    return this.format(text, chalk.cyan);
+  }
+
+  public magenta(text: string): string {
+    return this.format(text, chalk.magenta);
+  }
+
+  public gray(text: string): string {
+    return this.format(text, chalk.gray);
+  }
+
+  public blue(text: string): string {
+    return this.format(text, chalk.blue);
+  }
+
+  public underline(text: string): string {
+    return this.format(text, chalk.underline);
+  }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -23,6 +23,7 @@ export interface RepoContext {
 
 export interface GlobalOptions {
   json?: boolean;
+  noColor?: boolean;
   workspace?: string;
   repo?: string;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { withGlobalOptions } from '../src/cli.js';
+import { resolveNoColorSetting, withGlobalOptions } from '../src/cli.js';
 import type { CommandContext } from '../src/core/interfaces/commands.js';
 
 describe('withGlobalOptions', () => {
@@ -124,5 +124,41 @@ describe('withGlobalOptions', () => {
     expect(result.workspace).toBe('ws');
     // json should not be in result as it's only in globalOptions
     expect((result as Record<string, unknown>).json).toBeUndefined();
+  });
+});
+
+describe('resolveNoColorSetting', () => {
+  it('should enable noColor when --no-color is passed', () => {
+    const noColor = resolveNoColorSetting(
+      ['node', 'bb', '--no-color'],
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(noColor).toBe(true);
+  });
+
+  it('should enable noColor when NO_COLOR is set', () => {
+    const noColor = resolveNoColorSetting(['node', 'bb'], {
+      NO_COLOR: '1',
+    } as NodeJS.ProcessEnv);
+
+    expect(noColor).toBe(true);
+  });
+
+  it('should prefer FORCE_COLOR over NO_COLOR and --no-color', () => {
+    const noColor = resolveNoColorSetting(['node', 'bb', '--no-color'], {
+      NO_COLOR: '1',
+      FORCE_COLOR: '1',
+    } as NodeJS.ProcessEnv);
+
+    expect(noColor).toBe(false);
+  });
+
+  it('should allow --color to override NO_COLOR', () => {
+    const noColor = resolveNoColorSetting(['node', 'bb', '--color'], {
+      NO_COLOR: '1',
+    } as NodeJS.ProcessEnv);
+
+    expect(noColor).toBe(false);
   });
 });

--- a/tests/commands/auth.test.ts
+++ b/tests/commands/auth.test.ts
@@ -182,8 +182,7 @@ describe('StatusCommand', () => {
     const command = new StatusCommand(configService, usersApi, output);
     await command.execute(undefined, { globalOptions: { json: true } });
 
-    // Command outputs text regardless of json flag
-    expect(output.logs).toContain('success:Logged in to Bitbucket');
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 });
 
@@ -200,6 +199,19 @@ describe('TokenCommand', () => {
 
     const expectedToken = Buffer.from('testuser:testpass').toString('base64');
     expect(output.logs).toContain(`text:${expectedToken}`);
+  });
+
+  it('should output json token when requested', async () => {
+    const configService = createMockConfigService({
+      username: 'testuser',
+      apiToken: 'testpass',
+    });
+    const output = createMockOutputService();
+
+    const command = new TokenCommand(configService, output);
+    await command.execute(undefined, { globalOptions: { json: true } });
+
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 
   it('should fail when not logged in', async () => {

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -422,6 +422,20 @@ describe('ListPRsCommand', () => {
     expect(output.logs.some((log) => log.includes('table-rows:'))).toBe(true);
     expect(output.logs.some((log) => log.includes('[DRAFT]'))).toBe(true);
   });
+
+  it('should output json when requested', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    await command.execute({}, { globalOptions: { json: true } });
+
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
+  });
 });
 
 describe('ViewPRCommand', () => {
@@ -468,6 +482,20 @@ describe('ViewPRCommand', () => {
     await command.execute({ id: '1' }, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('[DRAFT]'))).toBe(true);
+  });
+
+  it('should output json when requested', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ViewPRCommand(pullrequestsApi, contextService, output);
+    await command.execute({ id: '1' }, { globalOptions: { json: true } });
+
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 });
 
@@ -745,6 +773,31 @@ describe('CreatePRCommand', () => {
     );
 
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
+  });
+
+  it('should output json when requested', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const gitService = createMockGitService({
+      currentBranch: 'feature-branch',
+    });
+    const output = createMockOutputService();
+
+    const command = new CreatePRCommand(
+      pullrequestsApi,
+      contextService,
+      gitService,
+      output
+    );
+    await command.execute(
+      { title: 'My PR' },
+      { globalOptions: { json: true } }
+    );
+
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 });
 

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -220,8 +220,7 @@ describe('ListReposCommand', () => {
       { globalOptions: { json: true } }
     );
 
-    // Command outputs table regardless of json flag
-    expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 });
 
@@ -295,10 +294,7 @@ describe('ViewRepoCommand', () => {
     );
     await command.execute({}, { globalOptions: { json: true } });
 
-    // Command outputs text regardless of json flag
-    expect(output.logs.some((log) => log.includes('workspace/repo'))).toBe(
-      true
-    );
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 
   it('should display repository details', async () => {
@@ -433,8 +429,7 @@ describe('CreateRepoCommand', () => {
       { globalOptions: { json: true } }
     );
 
-    // Command outputs text regardless of json flag
-    expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
+    expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -145,6 +145,42 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     text(message: string) {
       logs.push(`text:${message}`);
     },
+    format(text: string, formatter: (text: string) => string) {
+      return formatter(text);
+    },
+    dim(text: string) {
+      return text;
+    },
+    highlight(text: string) {
+      return text;
+    },
+    bold(text: string) {
+      return text;
+    },
+    red(text: string) {
+      return text;
+    },
+    green(text: string) {
+      return text;
+    },
+    yellow(text: string) {
+      return text;
+    },
+    cyan(text: string) {
+      return text;
+    },
+    magenta(text: string) {
+      return text;
+    },
+    gray(text: string) {
+      return text;
+    },
+    blue(text: string) {
+      return text;
+    },
+    underline(text: string) {
+      return text;
+    },
     formatDate(date: string | Date) {
       return new Date(date).toISOString();
     },


### PR DESCRIPTION
## Summary
- implement full global `--json` support across all CLI commands and normalize machine-readable output envelopes for scripting
- add global `--no-color` behavior (with `NO_COLOR`/`FORCE_COLOR` handling) and route command formatting through `IOutputService` instead of direct `chalk`
- refresh docs (README + docs site) and tests to match new output contracts, jq examples, and configuration key usage (`defaultWorkspace`)

## Validation
- `bun run lint`
- `bun run test`
- `bun run docs:build`
- `bunx prettier --check \"README.md\" \"docs/src/content/docs/**/*.mdx\"`

Closes #85
Closes #92