### PR TITLE
feat: add --mine reviewer filter to pr list

### DIFF
--- a/.changeset/slow-beers-lay.md
+++ b/.changeset/slow-beers-lay.md
@@ -1,0 +1,6 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add a `--mine` flag to `bb pr list` so you can filter pull requests where the
+authenticated user is assigned as a reviewer.

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -120,6 +120,7 @@ bb pr list [options]
 | `-r, --repo <repo>` | Repository |
 | `-s, --state <state>` | Filter by state: OPEN, MERGED, DECLINED, SUPERSEDED (default: OPEN) |
 | `--limit <number>` | Maximum number of PRs (default: 25) |
+| `--mine` | Show only pull requests where you are a reviewer |
 | `--json` | Output as JSON |
 
 ### Examples
@@ -142,12 +143,16 @@ bb pr list --json
 
 # List more results
 bb pr list --limit 50
+
+# Show only pull requests assigned to you for review
+bb pr list --mine
 ```
 
 ### Notes
 
 - Draft PRs are shown with a `[DRAFT]` prefix in the title
 - `--limit` is enforced across paginated API responses
+- `--mine` filters by PRs where the authenticated user is assigned as a reviewer
 
 ---
 

--- a/docs/src/content/docs/commands/pr/index.mdx
+++ b/docs/src/content/docs/commands/pr/index.mdx
@@ -59,6 +59,7 @@ Global options available on all PR commands: `--json`, `--no-color`, `-w, --work
 |------|---------|
 | Create a PR | `bb pr create -t "Add feature"` |
 | List open PRs | `bb pr list` |
+| List PRs assigned to you | `bb pr list --mine` |
 | View PR details | `bb pr view 42` |
 | View checks | `bb pr checks 42` |
 | Review diff | `bb pr diff 42 --stat` |

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -254,13 +254,19 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const pullrequestsApi = container.resolve<PullrequestsApi>(
       ServiceTokens.PullrequestsApi
     );
+    const usersApi = container.resolve<UsersApi>(ServiceTokens.UsersApi);
     const contextService = container.resolve<ContextService>(
       ServiceTokens.ContextService
     );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new ListPRsCommand(pullrequestsApi, contextService, output);
+    return new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
   });
 
   container.register(ServiceTokens.ViewPRCommand, () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -429,12 +429,14 @@ prCmd
     'OPEN'
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
+  .option('--mine', 'Show only PRs where you are a reviewer')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb pr list',
         'bb pr list -s MERGED --limit 10',
+        'bb pr list --mine',
         'bb pr list --json',
       ],
       validValues: {

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -8,13 +8,18 @@ import type {
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
+import type {
+  PullrequestsApi,
+  Pullrequest,
+  UsersApi,
+} from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListPRsOptions extends GlobalOptions {
   state?: string;
   limit?: string;
+  mine?: boolean;
 }
 
 export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
@@ -23,6 +28,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
 
   constructor(
     private readonly pullrequestsApi: PullrequestsApi,
+    private readonly usersApi: UsersApi,
     private readonly contextService: IContextService,
     output: IOutputService
   ) {
@@ -44,6 +50,9 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       | 'DECLINED'
       | 'SUPERSEDED';
     const limit = parseLimit(options.limit);
+    const reviewerQuery = options.mine
+      ? await this.buildMineFilter()
+      : undefined;
 
     const values = await collectPages<Pullrequest>({
       limit,
@@ -56,7 +65,11 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
               state,
             },
             {
-              params: { page, pagelen },
+              params: {
+                page,
+                pagelen,
+                ...(reviewerQuery ? { q: reviewerQuery } : {}),
+              },
             }
           );
 
@@ -69,6 +82,9 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
         workspace: repoContext.workspace,
         repoSlug: repoContext.repoSlug,
         state,
+        filters: {
+          mine: options.mine === true,
+        },
         count: values.length,
         pullRequests: values,
       });
@@ -102,5 +118,19 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       return text;
     }
     return text.substring(0, maxLength - 3) + '...';
+  }
+
+  private async buildMineFilter(): Promise<string | undefined> {
+    const response = await this.usersApi.userGet();
+    const userUuid = response.data.uuid;
+
+    if (!userUuid) {
+      this.output.warning(
+        'Could not determine your user UUID. Showing all pull requests.'
+      );
+      return undefined;
+    }
+
+    return `reviewers.uuid="${userUuid}"`;
   }
 }

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -34,6 +34,7 @@ import type {
   CommitStatusesApi,
   Commitstatus,
   PaginatedCommitstatuses,
+  UsersApi,
 } from '../../src/generated/api.js';
 import type { AxiosResponse } from 'axios';
 
@@ -479,6 +480,19 @@ function createMockCommitStatusesApi(
   return mockApi as unknown as CommitStatusesApi;
 }
 
+function createMockUsersApi(options: { uuid?: string } = {}): UsersApi {
+  const mockApi = {
+    async userGet() {
+      return createAxiosResponse({
+        ...mockUser,
+        uuid: options.uuid,
+      });
+    },
+  };
+
+  return mockApi as unknown as UsersApi;
+}
+
 function createMockContextService(context?: {
   workspace?: string;
   repoSlug?: string;
@@ -534,7 +548,8 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -552,7 +567,8 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({ state: 'MERGED' }, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -563,7 +579,8 @@ describe('ListPRsCommand', () => {
     const contextService = createMockContextService();
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
 
     await expect(command.run({}, { globalOptions: {} })).rejects.toThrow();
   });
@@ -576,7 +593,8 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({}, { globalOptions: {} });
 
     expect(
@@ -593,7 +611,8 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table-rows:'))).toBe(true);
@@ -613,7 +632,8 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({ limit: '2' }, { globalOptions: {} });
 
     const rows = getTableRows(output.logs);
@@ -628,10 +648,70 @@ describe('ListPRsCommand', () => {
     });
     const output = createMockOutputService();
 
-    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
     await command.execute({}, { globalOptions: { json: true } });
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
+  });
+
+  it('should include reviewer filter when --mine is set', async () => {
+    let capturedAxiosOptions: unknown;
+    const pullrequestsApi = createMockPullrequestsApi({
+      onListCall: (_request, axiosOptions) => {
+        capturedAxiosOptions = axiosOptions;
+      },
+    });
+    const usersApi = createMockUsersApi({ uuid: '{my-uuid}' });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({ mine: true }, { globalOptions: {} });
+
+    const opts = capturedAxiosOptions as { params: Record<string, unknown> };
+    expect(opts.params.q).toBe('reviewers.uuid="{my-uuid}"');
+  });
+
+  it('should warn and show all PRs when --mine is set but uuid is missing', async () => {
+    let capturedAxiosOptions: unknown;
+    const pullrequestsApi = createMockPullrequestsApi({
+      onListCall: (_request, axiosOptions) => {
+        capturedAxiosOptions = axiosOptions;
+      },
+    });
+    const usersApi = createMockUsersApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({ mine: true }, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.includes(
+          'Could not determine your user UUID. Showing all pull requests.'
+        )
+      )
+    ).toBe(true);
+    const opts = capturedAxiosOptions as { params: Record<string, unknown> };
+    expect(opts.params.q).toBeUndefined();
   });
 });
 

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -549,7 +549,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -568,7 +573,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({ state: 'MERGED' }, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
@@ -580,7 +590,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
 
     await expect(command.run({}, { globalOptions: {} })).rejects.toThrow();
   });
@@ -594,7 +609,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(
@@ -612,7 +632,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({}, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('table-rows:'))).toBe(true);
@@ -633,7 +658,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({ limit: '2' }, { globalOptions: {} });
 
     const rows = getTableRows(output.logs);
@@ -649,7 +679,12 @@ describe('ListPRsCommand', () => {
     const output = createMockOutputService();
 
     const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
-    const command = new ListPRsCommand(pullrequestsApi, usersApi, contextService, output);
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
     await command.execute({}, { globalOptions: { json: true } });
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);


### PR DESCRIPTION
## Summary
- Add a `--mine` flag to `bb pr list` to filter pull requests where the authenticated user is a reviewer.
- Implement filtering via Bitbucket's `q` query (`reviewers.uuid=\"{uuid}\"`) by resolving the current user through `UsersApi.userGet()`.
- Refresh this work on top of current `main`, update docs, and add focused tests for `--mine` behavior and fallback when UUID is unavailable.

## Notes
- This PR supersedes #80, which became outdated.
- Also wires the existing `--limit` option to API `pagelen` for server-side pagination consistency.

Closes #79