### PR TITLE
fix: preserve non-auth config on auth logout

### DIFF
--- a/.changeset/fresh-brooms-matter.md
+++ b/.changeset/fresh-brooms-matter.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix `bb auth logout` and failed `bb auth login` cleanup to remove only
+authentication fields (`username` and `apiToken`) while preserving other
+configuration values.

--- a/docs/src/content/docs/commands/auth.mdx
+++ b/docs/src/content/docs/commands/auth.mdx
@@ -79,7 +79,7 @@ bb auth logout
 
 ### What Gets Removed
 
-This command removes your stored credentials (`username` and `apiToken`) from the config file. Other settings like `workspace` and `repo` are preserved.
+This command removes only your stored credentials (`username` and `apiToken`) from the config file. Other settings like `defaultWorkspace`, `skipVersionCheck`, and `versionCheckInterval` are preserved.
 
 ---
 

--- a/docs/src/content/docs/getting-started/authentication.mdx
+++ b/docs/src/content/docs/getting-started/authentication.mdx
@@ -57,7 +57,7 @@ This shows your current authentication status and account information.
 bb auth logout
 ```
 
-This removes stored credentials from your system.
+This removes only stored credentials (`username` and `apiToken`) from your system and preserves non-auth CLI settings.
 
 ## Configuration Storage
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -204,6 +204,8 @@ bb auth logout
 
 This removes `username` and `apiToken` but keeps `defaultWorkspace` and other settings.
 
+It does not perform a full config reset.
+
 ### Full Reset
 
 Delete the configuration file entirely:

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -69,7 +69,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
         `Logged in as ${user.display_name} (${user.username})`
       );
     } catch (error) {
-      await this.configService.clearConfig();
+      await this.configService.clearCredentials();
       throw new Error(
         `Authentication failed: ${error instanceof Error ? error.message : String(error)}`
       );

--- a/src/commands/auth/logout.command.ts
+++ b/src/commands/auth/logout.command.ts
@@ -21,7 +21,7 @@ export class LogoutCommand extends BaseCommand<void, void> {
   }
 
   public async execute(_options: void, context: CommandContext): Promise<void> {
-    await this.configService.clearConfig();
+    await this.configService.clearCredentials();
 
     if (context.globalOptions.json) {
       this.output.json({ authenticated: false, success: true });

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -17,6 +17,7 @@ export interface IConfigService {
   setConfig(config: BBConfig): Promise<void>;
   getCredentials(): Promise<AuthCredentials>;
   setCredentials(credentials: AuthCredentials): Promise<void>;
+  clearCredentials(): Promise<void>;
   clearConfig(): Promise<void>;
   getValue<K extends keyof BBConfig>(key: K): Promise<BBConfig[K] | undefined>;
   setValue<K extends keyof BBConfig>(key: K, value: BBConfig[K]): Promise<void>;

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -98,6 +98,12 @@ export class ConfigService implements IConfigService {
     });
   }
 
+  public async clearCredentials(): Promise<void> {
+    const config = await this.getConfig();
+    const { username: _username, apiToken: _apiToken, ...rest } = config;
+    await this.setConfig(rest);
+  }
+
   public async clearConfig(): Promise<void> {
     this.configCache = null;
     await this.setConfig({});

--- a/tests/commands/auth.test.ts
+++ b/tests/commands/auth.test.ts
@@ -99,7 +99,9 @@ describe('LoginCommand', () => {
   });
 
   it('should output error message when authentication fails', async () => {
-    const configService = createMockConfigService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'team-workspace',
+    });
     const output = createMockOutputService();
     const usersApi = createMockUsersApiError('Invalid credentials');
 
@@ -121,24 +123,27 @@ describe('LoginCommand', () => {
     const config = await configService.getConfig();
     expect(config.username).toBeUndefined();
     expect(config.apiToken).toBeUndefined();
+    expect(config.defaultWorkspace).toBe('team-workspace');
   });
 });
 
 describe('LogoutCommand', () => {
-  it('should clear config on logout', async () => {
+  it('should clear only credentials on logout', async () => {
     const configService = createMockConfigService({
       username: 'testuser',
       apiToken: 'testpass',
+      defaultWorkspace: 'team-workspace',
     });
     const output = createMockOutputService();
 
     const command = new LogoutCommand(configService, output);
     await command.execute(undefined, { globalOptions: {} });
 
-    // Verify config was cleared
+    // Verify only credentials were cleared
     const config = await configService.getConfig();
     expect(config.username).toBeUndefined();
     expect(config.apiToken).toBeUndefined();
+    expect(config.defaultWorkspace).toBe('team-workspace');
 
     expect(output.logs).toContain('success:Logged out of Bitbucket');
   });

--- a/tests/services/config.service.test.ts
+++ b/tests/services/config.service.test.ts
@@ -208,6 +208,28 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('clearCredentials', () => {
+    it('should clear only authentication values', async () => {
+      await configService.setConfig({
+        username: 'user',
+        apiToken: 'pass',
+        defaultWorkspace: 'workspace',
+        skipVersionCheck: true,
+        versionCheckInterval: 3,
+      });
+
+      await configService.clearCredentials();
+
+      const config = await configService.getConfig();
+
+      expect(config.username).toBeUndefined();
+      expect(config.apiToken).toBeUndefined();
+      expect(config.defaultWorkspace).toBe('workspace');
+      expect(config.skipVersionCheck).toBe(true);
+      expect(config.versionCheckInterval).toBe(3);
+    });
+  });
+
   describe('getValue', () => {
     it('should return specific config value', async () => {
       await configService.setConfig({

--- a/tests/services/context.service.expanded.test.ts
+++ b/tests/services/context.service.expanded.test.ts
@@ -80,6 +80,14 @@ function createMockConfigService(config: BBConfig = {}): IConfigService {
       currentConfig.username = creds.username;
       currentConfig.apiToken = creds.apiToken;
     },
+    async clearCredentials() {
+      const {
+        username: _username,
+        apiToken: _apiToken,
+        ...rest
+      } = currentConfig;
+      currentConfig = rest;
+    },
     async clearConfig() {
       currentConfig = {};
     },

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -66,6 +66,14 @@ export function createMockConfigService(config: BBConfig = {}): IConfigService {
       currentConfig.username = creds.username;
       currentConfig.apiToken = creds.apiToken;
     },
+    async clearCredentials() {
+      const {
+        username: _username,
+        apiToken: _apiToken,
+        ...rest
+      } = currentConfig;
+      currentConfig = rest;
+    },
     async clearConfig() {
       currentConfig = {};
     },


### PR DESCRIPTION
## Summary
- change auth cleanup to remove only `username` and `apiToken` while preserving other config keys
- update `bb auth logout` and failed `bb auth login` rollback to use credential-only clearing
- add/adjust tests, docs, and a patch changeset to reflect the behavior

## Validation
- bun test
- bun run lint
- bun run format:check

Closes #101