### PR TITLE
fix: resolve -w collision in bb pr diff

### DIFF
--- a/.changeset/cold-bears-tie.md
+++ b/.changeset/cold-bears-tie.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Resolve the `-w` short-flag collision in `bb pr diff` by making `--web`
+long-form only, keeping `-w` consistently reserved for global
+`--workspace`.

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -96,6 +96,8 @@ Tab completion works for:
 - **Subcommands**: `login`, `clone`, `create`, `list`, etc.
 - **Options**: `--json`, `--no-color`, `--workspace`, `--repo`, `--help`
 
+`-w` is reserved as the global shorthand for `--workspace`.
+
 ### Example Session
 
 ```bash

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -502,6 +502,7 @@ bb pr diff 42 --stat --json
 
 - When no ID is provided, the command searches for an open PR where the source branch matches your current git branch
 - The `--stat` output shows files changed with insertions (+) and deletions (-)
+- `-w` remains the global short alias for `--workspace`; use `--web` (long form) to open the diff in a browser
 - Use `--color never` when piping output to files or other commands
 - Use the global `--no-color` flag to disable color output for all command formatting
 - The diff is colorized by default when output is a terminal (green for additions, red for deletions, cyan for hunk headers)

--- a/docs/src/content/docs/guides/repository-context.mdx
+++ b/docs/src/content/docs/guides/repository-context.mdx
@@ -158,3 +158,4 @@ cd ../project-b && bb pr list  # Uses project-b's workspace
 - Use `bb repo view` with no arguments to see what context the CLI detected
 - The `--json` flag works with most commands for scripting
 - Global flags (`--workspace`, `--repo`, `--json`, `--no-color`) are available across commands
+- The `-w` short flag always maps to `--workspace` globally

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -469,7 +469,7 @@ prCmd
   .option('--color <when>', 'Colorize output (auto, always, never)', 'auto')
   .option('--name-only', 'Show only names of changed files')
   .option('--stat', 'Show diffstat')
-  .option('-w, --web', 'Open diff in web browser')
+  .option('--web', 'Open diff in web browser')
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'bun:test';
 import { resolveNoColorSetting, withGlobalOptions } from '../src/cli.js';
+import { cli } from '../src/cli.js';
 import type { CommandContext } from '../src/core/interfaces/commands.js';
 
 describe('withGlobalOptions', () => {
@@ -160,5 +161,31 @@ describe('resolveNoColorSetting', () => {
     } as NodeJS.ProcessEnv);
 
     expect(noColor).toBe(false);
+  });
+});
+
+describe('CLI option wiring', () => {
+  it('should reserve -w for global --workspace and keep pr diff --web long-only', () => {
+    const workspaceOption = cli.options.find(
+      (option) => option.long === '--workspace'
+    );
+    expect(workspaceOption?.short).toBe('-w');
+
+    const prCommand = cli.commands.find((command) => command.name() === 'pr');
+    expect(prCommand).toBeDefined();
+
+    const diffCommand = prCommand?.commands.find(
+      (command) => command.name() === 'diff'
+    );
+    expect(diffCommand).toBeDefined();
+
+    const webOption = diffCommand?.options.find(
+      (option) => option.long === '--web'
+    );
+    expect(webOption).toBeDefined();
+    expect(webOption?.short).toBeUndefined();
+    expect(diffCommand?.options.some((option) => option.short === '-w')).toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary
- remove the `-w` short alias from `bb pr diff --web` so `-w` is consistently reserved for global `--workspace`
- add CLI wiring tests that verify `pr diff --web` is long-only and no command-level `-w` remains on `pr diff`
- align command/help docs and add a patch changeset for the user-facing CLI behavior update

## Validation
- bun test tests/cli.test.ts
- bun run lint
- bun run format:check
- bun run dev pr diff --help

Closes #100