### PR TITLE
fix: align Windows config path behavior with docs

### DIFF
--- a/.changeset/pretty-buses-jog.md
+++ b/.changeset/pretty-buses-jog.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix Windows config path resolution to store `config.json` in `%APPDATA%\bb` by default, with a home-directory fallback when `APPDATA` is unavailable. This aligns runtime behavior with the documentation.

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -26,7 +26,7 @@ Repository context is resolved in this order (highest priority first):
 
 Authentication credentials are resolved from:
 
-1. **Configuration file** (`~/.config/bb/config.json`)
+1. **Configuration file** (`~/.config/bb/config.json` on macOS/Linux, `%APPDATA%\bb\config.json` on Windows)
 2. **Environment variables** (`BB_USERNAME`, `BB_API_TOKEN`) when running `bb auth login`
 
 For color output, precedence is:

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -2,20 +2,47 @@
  * Configuration service implementation
  */
 
-import { join } from 'node:path';
+import { join, win32 } from 'node:path';
 import { homedir } from 'node:os';
 import type { IConfigService } from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 import type { BBConfig, AuthCredentials } from '../types/config.js';
+
+interface ConfigServicePathOptions {
+  platform?: NodeJS.Platform;
+  appData?: string;
+  homeDir?: string;
+}
 
 export class ConfigService implements IConfigService {
   private readonly configDir: string;
   private readonly configFile: string;
   private configCache: BBConfig | null = null;
 
-  constructor(configDir?: string) {
-    this.configDir = configDir ?? join(homedir(), '.config', 'bb');
-    this.configFile = join(this.configDir, 'config.json');
+  constructor(configDir?: string, options: ConfigServicePathOptions = {}) {
+    const platform = options.platform ?? process.platform;
+    const joinPath = platform === 'win32' ? win32.join : join;
+
+    this.configDir =
+      configDir ?? this.resolveDefaultConfigDir({ ...options, platform });
+    this.configFile = joinPath(this.configDir, 'config.json');
+  }
+
+  private resolveDefaultConfigDir(options: ConfigServicePathOptions): string {
+    const platform = options.platform ?? process.platform;
+
+    if (platform === 'win32') {
+      const appDataDir = options.appData ?? process.env.APPDATA;
+      if (appDataDir) {
+        return win32.join(appDataDir, 'bb');
+      }
+
+      const homeDir = options.homeDir ?? homedir();
+      return win32.join(homeDir, 'AppData', 'Roaming', 'bb');
+    }
+
+    const homeDir = options.homeDir ?? homedir();
+    return join(homeDir, '.config', 'bb');
   }
 
   private async ensureConfigDir(): Promise<void> {

--- a/tests/services/config.service.test.ts
+++ b/tests/services/config.service.test.ts
@@ -255,6 +255,40 @@ describe('ConfigService', () => {
 
       expect(path).toBe(join(testConfigDir, 'config.json'));
     });
+
+    it('should use APPDATA on Windows', () => {
+      const windowsService = new ConfigService(undefined, {
+        platform: 'win32',
+        appData: 'C:\\Users\\test\\AppData\\Roaming',
+        homeDir: 'C:\\Users\\test',
+      });
+
+      expect(windowsService.getConfigPath()).toBe(
+        'C:\\Users\\test\\AppData\\Roaming\\bb\\config.json'
+      );
+    });
+
+    it('should fall back to home directory on Windows when APPDATA is missing', () => {
+      const windowsService = new ConfigService(undefined, {
+        platform: 'win32',
+        homeDir: 'C:\\Users\\test',
+      });
+
+      expect(windowsService.getConfigPath()).toBe(
+        'C:\\Users\\test\\AppData\\Roaming\\bb\\config.json'
+      );
+    });
+
+    it('should use dot-config directory on non-Windows platforms', () => {
+      const linuxService = new ConfigService(undefined, {
+        platform: 'linux',
+        homeDir: '/home/test',
+      });
+
+      expect(linuxService.getConfigPath()).toBe(
+        '/home/test/.config/bb/config.json'
+      );
+    });
   });
 
   describe('clearCache', () => {


### PR DESCRIPTION
## Summary
- implement platform-aware default config path resolution in `ConfigService`
- use `%APPDATA%\\bb\\config.json` on Windows with a `%USERPROFILE%\\AppData\\Roaming\\bb` fallback
- add unit tests for Windows/non-Windows path resolution and update docs wording for configuration file location

## Validation
- bun test tests/services/config.service.test.ts
- bun test tests/commands/config.test.ts
- bun run lint
- bun run format:check
- bun run docs:build

Closes #102