### PR TITLE
fix: return web diff URL for pr diff --web --json

### DIFF
--- a/.changeset/famous-shrimps-learn.md
+++ b/.changeset/famous-shrimps-learn.md
@@ -1,0 +1,6 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix `bb pr diff --web --json` to return a Bitbucket web diff URL instead of
+an API endpoint URL.

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -491,6 +491,9 @@ bb pr diff 42 --stat
 # Open diff in browser
 bb pr diff 42 --web
 
+# Return browser URL as JSON
+bb pr diff 42 --web --json
+
 # Disable colors for piping to file or other commands
 bb pr diff 42 --color never > pr-42.patch
 

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -39,6 +39,9 @@ bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.di
 
 # Get PR URLs
 bb pr list --json | jq -r '.pullRequests[].links.html.href'
+
+# Get web diff URL for a PR
+bb pr diff 42 --web --json | jq -r '.url'
 ```
 
 ### Common jq Patterns

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -88,6 +88,18 @@ Typical top-level metadata fields include:
 }
 ```
 
+### `bb pr diff 42 --web --json`
+
+```json
+{
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "pullRequestId": 42,
+  "mode": "web",
+  "url": "https://bitbucket.org/myworkspace/myrepo/pull-requests/42/diff"
+}
+```
+
 ### `bb auth token --json`
 
 ```json

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -189,16 +189,16 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
         }
       );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const diffUrl = (prResponse.data.links as any)?.diff?.href;
-    if (!diffUrl) {
-      throw new Error('Could not get diff URL');
+    const links = prResponse.data.links as
+      | { html?: { href?: string } }
+      | undefined;
+    const htmlUrl = links?.html?.href;
+    if (htmlUrl) {
+      const normalizedHtmlUrl = htmlUrl.replace(/\/$/, '');
+      return `${normalizedHtmlUrl}/diff`;
     }
 
-    return diffUrl.replace(
-      /api\.bitbucket\.org\/2\.0\/repositories\/(.*?)\/pullrequests\/(\d+)\/diff/,
-      'bitbucket.org/$1/pull-requests/$2/diff'
-    );
+    return `https://bitbucket.org/${workspace}/${repoSlug}/pull-requests/${prId}/diff`;
   }
 
   private async showStat(

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1083,6 +1083,35 @@ describe('DiffPRCommand', () => {
     );
   });
 
+  it('should return web diff URL in JSON when --web is set', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const gitService = createMockGitService();
+    const output = createMockOutputService();
+
+    const command = new DiffPRCommand(
+      pullrequestsApi,
+      contextService,
+      gitService,
+      output
+    );
+    await command.execute(
+      { id: '1', web: true },
+      { globalOptions: { json: true } }
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const parsed = JSON.parse(jsonLog!.substring(5));
+    expect(parsed.mode).toBe('web');
+    expect(parsed.url).toBe(
+      'https://bitbucket.org/workspace/repo/pull-requests/1/diff'
+    );
+  });
+
   it('should fail for non-existent PR', async () => {
     const pullrequestsApi = createMockPullrequestsApi({ pullRequests: [] });
     const contextService = createMockContextService({


### PR DESCRIPTION
## Summary
- fix `bb pr diff --web --json` to return a Bitbucket web diff URL instead of an API endpoint URL
- update `DiffPRCommand` to derive web diff links from the PR HTML URL with a deterministic fallback
- add regression coverage and docs updates for `--web --json` output

## Testing
- bun test tests/commands/pr.test.ts
- bun run lint
- bun run format:check
- bun run docs:build

Closes #99