### PR TITLE
fix: emit structured JSON errors when --json is enabled

### DIFF
--- a/.changeset/chilly-cameras-serve.md
+++ b/.changeset/chilly-cameras-serve.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Emit structured JSON errors to stderr when `--json` is enabled, including typed error codes for command validation and config failures. This makes scripting more reliable while preserving non-zero exits and existing human-readable error output in non-JSON mode.

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -92,8 +92,16 @@ bb pr list --json > prs.json || {
 ```
 
 <Aside type="tip">
-For detailed error information, capture stderr and parse JSON error output.
+In `--json` mode, success JSON is written to stdout and error JSON is written to stderr.
+Parse them separately in scripts.
 </Aside>
+
+```bash
+if ! bb config get invalidKey --json > out.json 2> err.json; then
+  jq '.' err.json
+  exit 1
+fi
+```
 
 ---
 
@@ -331,7 +339,8 @@ def run_bb(args):
         text=True
     )
     if result.returncode != 0:
-        raise Exception(f"bb command failed: {result.stderr}")
+        error = json.loads(result.stderr)
+        raise Exception(f"bb command failed [{error['code']}]: {error['message']}")
     return json.loads(result.stdout)
 
 # List PRs

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -312,9 +312,16 @@ fi
 # Process prs.json...
 ```
 
-For JSON output, errors include the error code:
+For JSON output, errors are emitted to stderr and include the error code:
 
 ```bash
 bb pr view 999 --json 2>&1
 # {"name":"BBError","code":2002,"message":"Pull request not found"}
 ```
+
+Typical JSON error payload fields:
+
+- `name` - Error class name
+- `code` - Numeric CLI error code
+- `message` - Human-readable message
+- `context` - Optional structured metadata

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -120,6 +120,17 @@ bb pr diff 42 --stat --json | jq -r '.files[].path'
 
 ## Errors
 
-When a command fails, the CLI exits non-zero and prints an error message to stderr.
+When a command fails, the CLI exits non-zero.
+
+- In normal mode, errors are plain text on stderr.
+- In `--json` mode, errors are compact JSON objects on stderr.
+
+Example:
+
+```bash
+bb config get invalidKey --json 2>error.json
+cat error.json
+# {"name":"BBError","code":4003,"message":"Unknown config key 'invalidKey'. Valid keys: username, defaultWorkspace, skipVersionCheck, versionCheckInterval","context":{"key":"invalidKey"}}
+```
 
 In automation, always check the process exit code before parsing stdout JSON.

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { UsersApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface LoginOptions {
   username?: string;
@@ -36,15 +37,19 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
     const apiToken = options.password || process.env.BB_API_TOKEN;
 
     if (!username) {
-      throw new Error(
-        'Username is required. Use --username option or set BB_USERNAME environment variable.'
-      );
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          'Username is required. Use --username option or set BB_USERNAME environment variable.',
+      });
     }
 
     if (!apiToken) {
-      throw new Error(
-        'API token is required. Use --password option or set BB_API_TOKEN environment variable.'
-      );
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          'API token is required. Use --password option or set BB_API_TOKEN environment variable.',
+      });
     }
 
     await this.configService.setCredentials({ username, apiToken });
@@ -70,9 +75,10 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
       );
     } catch (error) {
       await this.configService.clearCredentials();
-      throw new Error(
-        `Authentication failed: ${error instanceof Error ? error.message : String(error)}`
-      );
+      throw new BBError({
+        code: ErrorCode.AUTH_INVALID,
+        message: `Authentication failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
     }
   }
 }

--- a/src/commands/auth/status.command.ts
+++ b/src/commands/auth/status.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { UsersApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface AuthStatus {
   authenticated: boolean;
@@ -80,9 +81,11 @@ export class StatusCommand extends BaseCommand<void, void> {
         );
       }
     } catch (error) {
-      throw new Error(
-        `Authentication is invalid or expired. Run ${this.output.highlight('bb auth login')} to re-authenticate.`
-      );
+      throw new BBError({
+        code: ErrorCode.AUTH_INVALID,
+        message: `Authentication is invalid or expired. Run ${this.output.highlight('bb auth login')} to re-authenticate.`,
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   }
 }

--- a/src/commands/auth/token.command.ts
+++ b/src/commands/auth/token.command.ts
@@ -8,6 +8,7 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export class TokenCommand extends BaseCommand<void, void> {
   public readonly name = 'token';
@@ -24,7 +25,10 @@ export class TokenCommand extends BaseCommand<void, void> {
     const credentials = await this.configService.getCredentials();
 
     if (!credentials.username || !credentials.apiToken) {
-      throw new Error("Not authenticated. Run 'bb auth login' first.");
+      throw new BBError({
+        code: ErrorCode.AUTH_REQUIRED,
+        message: "Not authenticated. Run 'bb auth login' first.",
+      });
     }
 
     const token = Buffer.from(

--- a/src/commands/completion/install.command.ts
+++ b/src/commands/completion/install.command.ts
@@ -5,6 +5,7 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type { IOutputService } from '../../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 import tabtab from 'tabtab';
 
 export class InstallCompletionCommand extends BaseCommand<void, void> {
@@ -38,7 +39,11 @@ export class InstallCompletionCommand extends BaseCommand<void, void> {
         'Restart your shell or source your profile to enable completions.'
       );
     } catch (error) {
-      throw new Error(`Failed to install completions: ${error}`);
+      throw new BBError({
+        code: ErrorCode.UNKNOWN,
+        message: `Failed to install completions: ${error}`,
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   }
 }

--- a/src/commands/completion/uninstall.command.ts
+++ b/src/commands/completion/uninstall.command.ts
@@ -5,6 +5,7 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type { IOutputService } from '../../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 import tabtab from 'tabtab';
 
 export class UninstallCompletionCommand extends BaseCommand<void, void> {
@@ -34,7 +35,11 @@ export class UninstallCompletionCommand extends BaseCommand<void, void> {
 
       this.output.success('Shell completions uninstalled successfully!');
     } catch (error) {
-      throw new Error(`Failed to uninstall completions: ${error}`);
+      throw new BBError({
+        code: ErrorCode.UNKNOWN,
+        message: `Failed to uninstall completions: ${error}`,
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   }
 }

--- a/src/commands/config/get.command.ts
+++ b/src/commands/config/get.command.ts
@@ -13,6 +13,7 @@ import {
   normalizeReadableConfigValue,
   READABLE_CONFIG_KEYS,
 } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
   public readonly name = 'get';
@@ -35,16 +36,20 @@ export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
 
     // Check if key is hidden
     if (GetConfigCommand.HIDDEN_KEYS.includes(key)) {
-      throw new Error(
-        `Cannot display '${key}' - use 'bb auth token' to get authentication credentials`
-      );
+      throw new BBError({
+        code: ErrorCode.CONFIG_INVALID_KEY,
+        message: `Cannot display '${key}' - use 'bb auth token' to get authentication credentials`,
+        context: { key },
+      });
     }
 
     // Check if key is valid
     if (!isReadableConfigKey(key)) {
-      throw new Error(
-        `Unknown config key '${key}'. Valid keys: ${READABLE_CONFIG_KEYS.join(', ')}`
-      );
+      throw new BBError({
+        code: ErrorCode.CONFIG_INVALID_KEY,
+        message: `Unknown config key '${key}'. Valid keys: ${READABLE_CONFIG_KEYS.join(', ')}`,
+        context: { key },
+      });
     }
 
     const rawValue = await this.configService.getValue(key);

--- a/src/commands/config/set.command.ts
+++ b/src/commands/config/set.command.ts
@@ -13,6 +13,7 @@ import {
   parseSettableConfigValue,
   SETTABLE_CONFIG_KEYS,
 } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export class SetConfigCommand extends BaseCommand<
   { key: string; value: string },
@@ -38,16 +39,20 @@ export class SetConfigCommand extends BaseCommand<
 
     // Check if key is protected
     if (SetConfigCommand.PROTECTED_KEYS.includes(key)) {
-      throw new Error(
-        `Cannot set '${key}' directly. Use 'bb auth login' to configure authentication.`
-      );
+      throw new BBError({
+        code: ErrorCode.CONFIG_INVALID_KEY,
+        message: `Cannot set '${key}' directly. Use 'bb auth login' to configure authentication.`,
+        context: { key },
+      });
     }
 
     // Check if key is valid
     if (!isSettableConfigKey(key)) {
-      throw new Error(
-        `Unknown config key '${key}'. Valid keys: ${SETTABLE_CONFIG_KEYS.join(', ')}`
-      );
+      throw new BBError({
+        code: ErrorCode.CONFIG_INVALID_KEY,
+        message: `Unknown config key '${key}'. Valid keys: ${SETTABLE_CONFIG_KEYS.join(', ')}`,
+        context: { key },
+      });
     }
 
     const parsedValue = parseSettableConfigValue(key, value);

--- a/src/commands/pr/checkout.command.ts
+++ b/src/commands/pr/checkout.command.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CheckoutPROptions extends GlobalOptions {}
 
@@ -56,7 +57,11 @@ export class CheckoutPRCommand extends BaseCommand<
     const localBranchName = `pr-${prId}`;
 
     if (!branchName) {
-      throw new Error('Pull request source branch not found');
+      throw new BBError({
+        code: ErrorCode.API_NOT_FOUND,
+        message: 'Pull request source branch not found',
+        context: { pullRequestId: prId },
+      });
     }
 
     await this.gitService.fetch();

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CreatePROptions extends GlobalOptions {
   title?: string;
@@ -39,7 +40,10 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
     context: CommandContext
   ): Promise<void> {
     if (!options.title) {
-      throw new Error('Pull request title is required. Use --title option.');
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: 'Pull request title is required. Use --title option.',
+      });
     }
 
     const repoContext = await this.contextService.requireRepoContext({

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 const execAsync = promisify(exec);
 
@@ -50,7 +51,11 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
     if (options.id) {
       prId = Number.parseInt(options.id, 10);
       if (Number.isNaN(prId)) {
-        throw new TypeError('Invalid PR ID');
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: 'Invalid PR ID',
+          context: { id: options.id },
+        });
       }
     } else {
       const currentBranch = await this.gitService.getCurrentBranch();
@@ -70,9 +75,11 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
       );
 
       if (!pr) {
-        throw new Error(
-          `No open pull request found for branch "${currentBranch}"`
-        );
+        throw new BBError({
+          code: ErrorCode.API_NOT_FOUND,
+          message: `No open pull request found for branch "${currentBranch}"`,
+          context: { branch: currentBranch },
+        });
       }
 
       prId = pr.id!;
@@ -192,7 +199,11 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const diffUrl = (prResponse.data.links as any)?.diff?.href;
     if (!diffUrl) {
-      throw new Error('Could not get diff URL');
+      throw new BBError({
+        code: ErrorCode.API_NOT_FOUND,
+        message: 'Could not get diff URL',
+        context: { pullRequestId: prId },
+      });
     }
 
     return diffUrl.replace(

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface EditPROptions extends GlobalOptions {
   id?: string;
@@ -66,9 +67,11 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
       });
 
       if (!matchingPR) {
-        throw new Error(
-          `No open pull request found for current branch '${currentBranch}'. Specify a PR ID explicitly.`
-        );
+        throw new BBError({
+          code: ErrorCode.API_NOT_FOUND,
+          message: `No open pull request found for current branch '${currentBranch}'. Specify a PR ID explicitly.`,
+          context: { branch: currentBranch },
+        });
       }
 
       prId = matchingPR.id!;
@@ -79,16 +82,21 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
       try {
         body = fs.readFileSync(options.bodyFile, 'utf-8');
       } catch (err) {
-        throw new Error(
-          `Failed to read file '${options.bodyFile}': ${err instanceof Error ? err.message : 'Unknown error'}`
-        );
+        throw new BBError({
+          code: ErrorCode.UNKNOWN,
+          message: `Failed to read file '${options.bodyFile}': ${err instanceof Error ? err.message : 'Unknown error'}`,
+          cause: err instanceof Error ? err : undefined,
+          context: { bodyFile: options.bodyFile },
+        });
       }
     }
 
     if (!options.title && !body) {
-      throw new Error(
-        'At least one of --title or --body (or --body-file) is required.'
-      );
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          'At least one of --title or --body (or --body-file) is required.',
+      });
     }
 
     const request: Pullrequest = {

--- a/src/commands/repo/clone.command.ts
+++ b/src/commands/repo/clone.command.ts
@@ -9,6 +9,7 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CloneOptions {
   directory?: string;
@@ -67,9 +68,11 @@ export class CloneCommand extends BaseCommand<
       const config = await this.configService.getConfig();
 
       if (!config.defaultWorkspace) {
-        throw new Error(
-          'No workspace specified. Use workspace/repo format or set a default workspace.'
-        );
+        throw new BBError({
+          code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+          message:
+            'No workspace specified. Use workspace/repo format or set a default workspace.',
+        });
       }
 
       workspace = config.defaultWorkspace;
@@ -78,9 +81,11 @@ export class CloneCommand extends BaseCommand<
       workspace = parts[0];
       repoSlug = parts[1];
     } else {
-      throw new Error(
-        'Invalid repository format. Use workspace/repo or a full URL.'
-      );
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: 'Invalid repository format. Use workspace/repo or a full URL.',
+        context: { repository },
+      });
     }
 
     return `git@bitbucket.org:${workspace}/${repoSlug}.git`;
@@ -90,7 +95,11 @@ export class CloneCommand extends BaseCommand<
     const parts = repository.split('/');
     const lastPart = parts.at(-1);
     if (!lastPart) {
-      throw new Error('Invalid repository format.');
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: 'Invalid repository format.',
+        context: { repository },
+      });
     }
     return lastPart.replace('.git', '');
   }

--- a/src/commands/repo/create.command.ts
+++ b/src/commands/repo/create.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CreateRepoOptions {
   workspace?: string;
@@ -103,9 +104,11 @@ export class CreateRepoCommand extends BaseCommand<
     const config = await this.configService.getConfig();
 
     if (!config.defaultWorkspace) {
-      throw new Error(
-        'No workspace specified. Use --workspace option or set a default workspace.'
-      );
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
     }
 
     return config.defaultWorkspace;

--- a/src/commands/repo/delete.command.ts
+++ b/src/commands/repo/delete.command.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteRepoOptions extends GlobalOptions {
   yes?: boolean;
@@ -50,10 +51,12 @@ export class DeleteRepoCommand extends BaseCommand<
       await this.contextService.requireRepoContext(contextOptions);
 
     if (!yes) {
-      throw new Error(
-        `This will permanently delete ${repoContext.workspace}/${repoContext.repoSlug}.\n` +
-          'Use --yes to confirm deletion.'
-      );
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          `This will permanently delete ${repoContext.workspace}/${repoContext.repoSlug}.\n` +
+          'Use --yes to confirm deletion.',
+      });
     }
 
     await this.repositoriesApi.repositoriesWorkspaceRepoSlugDelete({

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface ListReposOptions {
   workspace?: string;
@@ -73,9 +74,11 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     const config = await this.configService.getConfig();
 
     if (!config.defaultWorkspace) {
-      throw new Error(
-        'No workspace specified. Use --workspace option or set a default workspace.'
-      );
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
     }
 
     return config.defaultWorkspace;

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -39,16 +39,39 @@ export abstract class BaseCommand<
    * Handle command error - output error and set exit code
    */
   protected handleError(error: unknown, context: CommandContext): void {
-    if (error instanceof Error) {
+    if (context.globalOptions.json) {
+      this.output.jsonError(this.normalizeErrorForJson(error));
+    } else if (error instanceof Error) {
       this.output.error(error.message);
     } else {
       this.output.error(String(error));
     }
+
     // Only set exit code in production - during tests this causes false failures
     // because the exit code persists across test files
     if (process.env.NODE_ENV !== 'test') {
       process.exitCode = 1;
     }
+  }
+
+  private normalizeErrorForJson(error: unknown): Record<string, unknown> {
+    if (error instanceof BBError) {
+      return error.toJSON();
+    }
+
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        code: ErrorCode.UNKNOWN,
+        message: error.message,
+      };
+    }
+
+    return {
+      name: 'Error',
+      code: ErrorCode.UNKNOWN,
+      message: String(error),
+    };
   }
 
   /**

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -52,6 +52,7 @@ export interface IContextService {
  */
 export interface IOutputService {
   json(data: unknown): void;
+  jsonError(data: unknown): void;
   table(headers: string[], rows: string[][]): void;
   success(message: string): void;
   error(message: string): void;

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -16,6 +16,10 @@ export class OutputService implements IOutputService {
     console.log(JSON.stringify(data, null, 2));
   }
 
+  public jsonError(data: unknown): void {
+    console.error(JSON.stringify(data));
+  }
+
   public table(headers: string[], rows: string[][]): void {
     if (rows.length === 0) {
       return;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,6 +2,8 @@
  * Configuration types with validation
  */
 
+import { BBError, ErrorCode } from './errors.js';
+
 export interface BBConfig {
   username?: string;
   apiToken?: string;
@@ -104,18 +106,24 @@ export function parseSettableConfigValue<K extends SettableConfigKey>(
     case 'skipVersionCheck': {
       const parsed = parseBooleanLiteral(value);
       if (parsed === undefined) {
-        throw new Error(
-          "Invalid value for 'skipVersionCheck'. Expected 'true' or 'false'."
-        );
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message:
+            "Invalid value for 'skipVersionCheck'. Expected 'true' or 'false'.",
+          context: { key, value },
+        });
       }
       return parsed as BBConfig[K];
     }
     case 'versionCheckInterval': {
       const parsed = parsePositiveIntegerLiteral(value);
       if (parsed === undefined) {
-        throw new Error(
-          "Invalid value for 'versionCheckInterval'. Expected a positive integer (1 or greater)."
-        );
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message:
+            "Invalid value for 'versionCheckInterval'. Expected a positive integer (1 or greater).",
+          context: { key, value },
+        });
       }
       return parsed as BBConfig[K];
     }

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -98,6 +98,21 @@ describe('GetConfigCommand', () => {
       output.logs.some((log) => log.includes('versionCheckInterval'))
     ).toBe(true);
   });
+
+  it('should emit structured JSON error for invalid keys in json mode', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new GetConfigCommand(configService, output);
+
+    await expect(
+      command.run({ key: 'invalidKey' }, { globalOptions: { json: true } })
+    ).rejects.toBeDefined();
+
+    expect(output.logs).toContain(
+      'jsonError:{"name":"BBError","code":4003,"message":"Unknown config key \'invalidKey\'. Valid keys: username, defaultWorkspace, skipVersionCheck, versionCheckInterval","context":{"key":"invalidKey"}}'
+    );
+  });
 });
 
 describe('SetConfigCommand', () => {

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { BaseCommand } from '../../src/core/base-command.js';
 import { createMockOutputService } from '../setup.js';
 import type { CommandContext } from '../../src/core/interfaces/commands.js';
-import type { BBError } from '../../src/types/errors.js';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
 
 class TestCommand extends BaseCommand<{ option?: string }, { data: string }> {
   public readonly name = 'test';
@@ -37,6 +37,22 @@ class TestCommandWithError extends BaseCommand<{ option?: string }, void> {
     _context: CommandContext
   ): Promise<void> {
     throw new Error('Test error');
+  }
+}
+
+class TestCommandWithBBError extends BaseCommand<{ option?: string }, void> {
+  public readonly name = 'test-error-bb';
+  public readonly description = 'Test command with BBError';
+
+  async execute(
+    _options: { option?: string },
+    _context: CommandContext
+  ): Promise<void> {
+    throw new BBError({
+      code: ErrorCode.CONFIG_INVALID_KEY,
+      message: 'Unknown config key',
+      context: { key: 'invalidKey' },
+    });
   }
 }
 
@@ -184,6 +200,30 @@ describe('BaseCommand', () => {
       );
 
       expect(output.logs).toContain('error:Test error');
+    });
+
+    it('should output structured JSON error on failure in json mode', async () => {
+      const command = new TestCommandWithError(output);
+
+      await expect(
+        command.run({}, { globalOptions: { json: true } })
+      ).rejects.toThrow('Test error');
+
+      expect(output.logs).toContain(
+        'jsonError:{"name":"Error","code":9999,"message":"Test error"}'
+      );
+    });
+
+    it('should preserve BBError code and context in json mode', async () => {
+      const command = new TestCommandWithBBError(output);
+
+      await expect(
+        command.run({}, { globalOptions: { json: true } })
+      ).rejects.toThrow('Unknown config key');
+
+      expect(output.logs).toContain(
+        'jsonError:{"name":"BBError","code":4003,"message":"Unknown config key","context":{"key":"invalidKey"}}'
+      );
     });
   });
 });

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -59,6 +59,17 @@ describe('OutputService', () => {
     });
   });
 
+  describe('jsonError', () => {
+    it('should output compact JSON to stderr', () => {
+      output.jsonError({ name: 'BBError', code: 4003, message: 'Invalid key' });
+
+      expect(consoleErrors).toHaveLength(1);
+      expect(consoleErrors[0]).toBe(
+        '{"name":"BBError","code":4003,"message":"Invalid key"}'
+      );
+    });
+  });
+
   describe('table', () => {
     it('should output formatted table', () => {
       output.table(

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -134,6 +134,9 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     json(data: unknown) {
       logs.push(`json:${JSON.stringify(data)}`);
     },
+    jsonError(data: unknown) {
+      logs.push(`jsonError:${JSON.stringify(data)}`);
+    },
     table(headers: string[], rows: string[][]) {
       logs.push(`table:${headers.join(',')}`);
       logs.push(`table-rows:${JSON.stringify(rows)}`);


### PR DESCRIPTION
## Summary
- add structured error output to stderr in JSON mode via `BaseCommand` and `OutputService`, while preserving text errors in non-JSON mode
- convert command validation/error paths from plain `Error` to typed `BBError` + `ErrorCode` across config/auth/repo/pr/completion commands
- add tests for JSON error emission and docs updates for stdout/stderr behavior in scripting

## Validation
- bun run format:check
- bun run lint
- bun test
- bun test tests/commands/auth.test.ts
- bun test tests/commands/repo.test.ts
- bun test tests/commands/pr.test.ts
- bun test tests/commands/completion.test.ts
- bun run build (docs/)

Closes #98