### PR TITLE
fix: honor --limit across paginated commands

### DIFF
--- a/.changeset/tidy-geckos-chew.md
+++ b/.changeset/tidy-geckos-chew.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Honor `--limit` across paginated PR and repository list commands, including PR activity and PR comments. Also improve `bb pr diff` and `bb pr edit` auto-detection so they can find matching pull requests across multiple pages.

--- a/docs/src/content/docs/commands/pr.mdx
+++ b/docs/src/content/docs/commands/pr.mdx
@@ -145,6 +145,7 @@ bb pr list --limit 50
 ### Notes
 
 - Draft PRs are shown with a `[DRAFT]` prefix in the title
+- `--limit` is enforced across paginated API responses
 
 ---
 
@@ -224,6 +225,10 @@ bb pr activity 42 --limit 10
 # Get activity as JSON
 bb pr activity 42 --json
 ```
+
+### Notes
+
+- `--limit` is enforced across paginated activity responses
 
 ---
 
@@ -574,6 +579,7 @@ bb pr comments list 42 --json
 
 - By default, comment content is truncated to 60 characters in the table view
 - Use `--no-truncate` to display the full comment text
+- `--limit` is enforced across paginated comment responses
 
 ---
 

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -112,6 +112,10 @@ bb repo list -w myworkspace --limit 50
 bb repo list -w myworkspace --json
 ```
 
+### Notes
+
+- `--limit` is enforced across paginated repository responses
+
 ---
 
 ## `bb repo view`

--- a/docs/src/content/docs/guides/cicd.mdx
+++ b/docs/src/content/docs/guides/cicd.mdx
@@ -33,6 +33,9 @@ The Bitbucket CLI can automate pull request workflows, add comments, and manage 
    bb pr list -w myworkspace -r myrepo --json
    ```
 
+   If your pipeline needs more than the default page size, include
+   `--limit <number>` on list commands.
+
 </Steps>
 
 ---

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -17,6 +17,9 @@ bb repo list --json
 bb pr view 42 --json
 ```
 
+For list-style commands, results are limited by default. Pass `--limit` when
+your automation needs more rows.
+
 ### Parsing with jq
 
 [jq](https://jqlang.github.io/jq/) is the standard tool for processing JSON:

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -216,6 +216,9 @@ bb pr list --json | jq '.count'
 bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
 ```
 
+For list commands, add `--limit` when you need more than the default result
+count.
+
 ---
 
 ### Can I use bb with git hooks?

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ActivityPROptions extends GlobalOptions {
@@ -41,29 +42,39 @@ export class ActivityPRCommand extends BaseCommand<
     });
 
     const prId = Number.parseInt(options.id, 10);
-
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-        }
-      );
-
-    // The generated API types say this returns void, but it actually returns paginated activity
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = response.data as any;
-    const values = data?.values ? Array.from(data.values) : [];
-
     const filterTypes = this.parseTypeFilter(options.type);
+    const limit = parseLimit(options.limit);
+
+    const activities = await collectPages<unknown>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
+            {
+              workspace: repoContext.workspace,
+              repoSlug: repoContext.repoSlug,
+              pullRequestId: prId,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
+
+        // The generated API types say this returns void, but it actually returns paginated activity
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return response.data as any;
+      },
+      shouldInclude: (activity) => {
+        if (filterTypes.length === 0) {
+          return true;
+        }
+
+        return filterTypes.includes(this.getActivityType(activity));
+      },
+    });
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const activities =
-      filterTypes.length > 0
-        ? values.filter((activity: any) =>
-            filterTypes.includes(this.getActivityType(activity))
-          )
-        : values;
+    const typedActivities = activities as any[];
 
     if (context.globalOptions.json) {
       this.output.json({
@@ -73,13 +84,13 @@ export class ActivityPRCommand extends BaseCommand<
         filters: {
           types: filterTypes,
         },
-        count: activities.length,
-        activities,
+        count: typedActivities.length,
+        activities: typedActivities,
       });
       return;
     }
 
-    if (activities.length === 0) {
+    if (typedActivities.length === 0) {
       if (filterTypes.length > 0) {
         this.output.info('No activity entries matched the requested filter');
       } else {
@@ -88,7 +99,7 @@ export class ActivityPRCommand extends BaseCommand<
       return;
     }
 
-    const rows = activities.map((activity) => {
+    const rows = typedActivities.map((activity) => {
       const activityType = this.getActivityType(activity);
       return [
         activityType.toUpperCase(),

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -8,7 +8,11 @@ import type {
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type { PullrequestsApi } from '../../generated/api.js';
+import type {
+  PullrequestComment,
+  PullrequestsApi,
+} from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListCommentsPROptions extends GlobalOptions {
@@ -41,18 +45,26 @@ export class ListCommentsPRCommand extends BaseCommand<
     });
 
     const prId = Number.parseInt(options.id, 10);
+    const limit = parseLimit(options.limit);
 
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-        }
-      );
+    const values = await collectPages<PullrequestComment>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
+            {
+              workspace: repoContext.workspace,
+              repoSlug: repoContext.repoSlug,
+              pullRequestId: prId,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
 
-    const data = response.data;
-    const values = data.values ? Array.from(data.values) : [];
+        return response.data;
+      },
+    });
 
     if (context.globalOptions.json) {
       this.output.json({

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -11,7 +11,8 @@ import type {
   IOutputService,
   IGitService,
 } from '../../core/interfaces/services.js';
-import type { PullrequestsApi } from '../../generated/api.js';
+import type { Pullrequest, PullrequestsApi } from '../../generated/api.js';
+import { collectPages, MAX_PAGE_LENGTH } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
@@ -60,19 +61,32 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
     } else {
       const currentBranch = await this.gitService.getCurrentBranch();
 
-      const prsResponse =
-        await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
-          {
-            workspace: repoContext.workspace,
-            repoSlug: repoContext.repoSlug,
-            state: 'OPEN',
-          }
-        );
+      const matches = await collectPages<Pullrequest>({
+        limit: 1,
+        pageSize: MAX_PAGE_LENGTH,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+                state: 'OPEN',
+              },
+              {
+                params: { page, pagelen },
+              }
+            );
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const pr = Array.from(prsResponse.data.values ?? []).find(
-        (p: any) => p.source?.branch?.name === currentBranch
-      );
+          return response.data;
+        },
+        shouldInclude: (pullRequest) => {
+          const source = pullRequest.source as
+            | { branch?: { name?: string } }
+            | undefined;
+          return source?.branch?.name === currentBranch;
+        },
+      });
+      const pr = matches[0];
 
       if (!pr) {
         throw new BBError({

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -11,6 +11,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
+import { collectPages, MAX_PAGE_LENGTH } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
@@ -49,22 +50,32 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
     } else {
       const currentBranch = await this.gitService.getCurrentBranch();
 
-      const prsResponse =
-        await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
-          {
-            workspace: repoContext.workspace,
-            repoSlug: repoContext.repoSlug,
-            state: 'OPEN',
-          }
-        );
+      const matches = await collectPages<Pullrequest>({
+        limit: 1,
+        pageSize: MAX_PAGE_LENGTH,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+                state: 'OPEN',
+              },
+              {
+                params: { page, pagelen },
+              }
+            );
 
-      const values = prsResponse.data.values
-        ? Array.from(prsResponse.data.values)
-        : [];
-      const matchingPR = values.find((pr: Pullrequest) => {
-        const source = pr.source as { branch?: { name?: string } } | undefined;
-        return source?.branch?.name === currentBranch;
+          return response.data;
+        },
+        shouldInclude: (pullRequest) => {
+          const source = pullRequest.source as
+            | { branch?: { name?: string } }
+            | undefined;
+          return source?.branch?.name === currentBranch;
+        },
       });
+      const matchingPR = matches[0];
 
       if (!matchingPR) {
         throw new BBError({

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListPRsOptions extends GlobalOptions {
@@ -42,16 +43,26 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       | 'MERGED'
       | 'DECLINED'
       | 'SUPERSEDED';
+    const limit = parseLimit(options.limit);
 
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        state,
-      });
+    const values = await collectPages<Pullrequest>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
+            {
+              workspace: repoContext.workspace,
+              repoSlug: repoContext.repoSlug,
+              state,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
 
-    const data = response.data;
-    const values = data.values ? Array.from(data.values) : [];
+        return response.data;
+      },
+    });
 
     if (context.globalOptions.json) {
       this.output.json({

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -8,7 +8,8 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type { RepositoriesApi } from '../../generated/api.js';
+import type { RepositoriesApi, Repository } from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface ListReposOptions {
@@ -35,13 +36,23 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     const workspace = await this.resolveWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = Number.parseInt(options.limit || '25', 10);
+    const limit = parseLimit(options.limit);
 
-    const response = await this.repositoriesApi.repositoriesWorkspaceGet({
-      workspace,
+    const repos = await collectPages<Repository>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response = await this.repositoriesApi.repositoriesWorkspaceGet(
+          {
+            workspace,
+          },
+          {
+            params: { page, pagelen },
+          }
+        );
+
+        return response.data;
+      },
     });
-
-    const repos = Array.from(response.data.values ?? []).slice(0, limit);
 
     if (context.globalOptions.json) {
       this.output.json({

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -1,0 +1,79 @@
+/**
+ * Pagination helpers for Bitbucket paginated endpoints.
+ */
+
+export interface PaginatedCollection<T> {
+  values?: Iterable<T>;
+  next?: string;
+}
+
+export interface CollectPagesOptions<T> {
+  limit: number;
+  pageSize?: number;
+  fetchPage: (page: number, pagelen: number) => Promise<PaginatedCollection<T>>;
+  shouldInclude?: (item: T) => boolean;
+}
+
+export const DEFAULT_LIMIT = 25;
+export const MAX_PAGE_LENGTH = 50;
+
+export function parseLimit(
+  limit?: string,
+  fallback: number = DEFAULT_LIMIT
+): number {
+  if (!limit) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(limit, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export async function collectPages<T>(
+  options: CollectPagesOptions<T>
+): Promise<T[]> {
+  const { fetchPage, shouldInclude } = options;
+  const limit = Math.max(0, options.limit);
+
+  if (limit === 0) {
+    return [];
+  }
+
+  const requestedPageSize = options.pageSize ?? limit;
+  const pagelen = Math.max(1, Math.min(requestedPageSize, MAX_PAGE_LENGTH));
+
+  const items: T[] = [];
+  let page = 1;
+
+  while (items.length < limit) {
+    const data = await fetchPage(page, pagelen);
+    const pageValues = data.values ? Array.from(data.values) : [];
+
+    if (pageValues.length === 0) {
+      break;
+    }
+
+    for (const value of pageValues) {
+      if (shouldInclude && !shouldInclude(value)) {
+        continue;
+      }
+
+      items.push(value);
+      if (items.length >= limit) {
+        return items;
+      }
+    }
+
+    if (!data.next) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return items;
+}

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -14,6 +14,7 @@ import { ReadyPRCommand } from '../../src/commands/pr/ready.command.js';
 import { CheckoutPRCommand } from '../../src/commands/pr/checkout.command.js';
 import { DiffPRCommand } from '../../src/commands/pr/diff.command.js';
 import { ActivityPRCommand } from '../../src/commands/pr/activity.command.js';
+import { ListCommentsPRCommand } from '../../src/commands/pr/comments.list.command.js';
 import { ChecksPRCommand } from '../../src/commands/pr/checks.command.js';
 import { CommentPRCommand } from '../../src/commands/pr/comment.command.js';
 import {
@@ -26,6 +27,7 @@ import type { IContextService } from '../../src/core/interfaces/services.js';
 import { BBError, ErrorCode } from '../../src/types/errors.js';
 import type {
   Pullrequest,
+  PullrequestComment,
   PullrequestsApi,
   PaginatedPullrequests,
   Participant,
@@ -68,10 +70,53 @@ function createSet<T>(items: T[]): Set<T> {
   return new Set(items);
 }
 
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  if (!axiosOptions || typeof axiosOptions !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const params = (axiosOptions as { params?: unknown }).params;
+  if (!params || typeof params !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const pageValue = (params as { page?: unknown }).page;
+  const pagelenValue = (params as { pagelen?: unknown }).pagelen;
+
+  const page =
+    typeof pageValue === 'number' && Number.isFinite(pageValue) && pageValue > 0
+      ? pageValue
+      : 1;
+  const pagelen =
+    typeof pagelenValue === 'number' &&
+    Number.isFinite(pagelenValue) &&
+    pagelenValue > 0
+      ? pagelenValue
+      : 25;
+
+  return { page, pagelen };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
 // Mock PullrequestsApi factory - returns a partial mock that we cast to the full type
 function createMockPullrequestsApi(
   options: {
     pullRequests?: Pullrequest[];
+    pullRequestPages?: Pullrequest[][];
+    activityPages?: Array<Array<Record<string, unknown>>>;
+    comments?: PullrequestComment[];
+    commentsPages?: PullrequestComment[][];
     throwOnGet?: boolean;
     throwOnList?: boolean;
     throwOnCreate?: boolean;
@@ -83,20 +128,74 @@ function createMockPullrequestsApi(
     throwOnDiffstat?: boolean;
     throwOnActivity?: boolean;
     throwOnComment?: boolean;
+    onListCall?: (request: unknown, axiosOptions?: unknown) => void;
+    onActivityCall?: (request: unknown, axiosOptions?: unknown) => void;
+    onCommentsListCall?: (request: unknown, axiosOptions?: unknown) => void;
   } = {}
 ): PullrequestsApi & { lastCommentBody?: Record<string, unknown> } {
   const prs = options.pullRequests ?? [mockPullRequest];
+  const allPullRequests = options.pullRequestPages
+    ? options.pullRequestPages.flat()
+    : prs;
+  const defaultActivities: Array<Record<string, unknown>> = [
+    {
+      comment: {
+        id: 101,
+        content: { raw: 'Looks good to me' },
+        user: mockUser,
+        created_on: '2024-01-02T00:00:00.000Z',
+      },
+    },
+  ];
+  const defaultComments: PullrequestComment[] = [
+    {
+      id: 1,
+      type: 'pullrequest_comment',
+      content: { raw: 'Looks good to me' },
+      user: mockUser,
+      created_on: '2024-01-02T00:00:00.000Z',
+      deleted: false,
+    } as PullrequestComment,
+  ];
 
   const mockApi = {
-    async repositoriesWorkspaceRepoSlugPullrequestsGet() {
+    async repositoriesWorkspaceRepoSlugPullrequestsGet(
+      request: unknown,
+      axiosOptions?: unknown
+    ) {
       if (options.throwOnList) {
         throw new Error('API Error');
       }
+
+      options.onListCall?.(request, axiosOptions);
+
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      let pageValues: Pullrequest[];
+      let totalSize: number;
+      let hasNext: boolean;
+
+      if (options.pullRequestPages) {
+        pageValues = options.pullRequestPages[page - 1] ?? [];
+        totalSize = options.pullRequestPages.flat().length;
+        hasNext = page < options.pullRequestPages.length;
+      } else {
+        const start = (page - 1) * pagelen;
+        const end = start + pagelen;
+        pageValues = prs.slice(start, end);
+        totalSize = prs.length;
+        hasNext = end < prs.length;
+      }
+
       const paginated: PaginatedPullrequests = {
-        values: createSet(prs),
-        pagelen: 25,
-        size: prs.length,
+        values: createSet(pageValues),
+        page,
+        pagelen,
+        size: totalSize,
+        next: hasNext
+          ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests?page=${page + 1}`
+          : undefined,
       };
+
       return createAxiosResponse(paginated);
     },
 
@@ -106,7 +205,7 @@ function createMockPullrequestsApi(
       if (options.throwOnGet) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -138,7 +237,7 @@ function createMockPullrequestsApi(
       if (options.throwOnMerge) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -169,7 +268,7 @@ function createMockPullrequestsApi(
       if (options.throwOnDecline) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -186,7 +285,7 @@ function createMockPullrequestsApi(
       if (options.throwOnUpdate) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -204,7 +303,7 @@ function createMockPullrequestsApi(
       if (options.throwOnDiff) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -218,7 +317,7 @@ function createMockPullrequestsApi(
       if (options.throwOnDiffstat) {
         throw new Error('API Error');
       }
-      const pr = prs.find((p) => p.id === params.pullRequestId);
+      const pr = allPullRequests.find((p) => p.id === params.pullRequestId);
       if (!pr) {
         throw new Error('Not found');
       }
@@ -239,27 +338,83 @@ function createMockPullrequestsApi(
       } as unknown as void);
     },
 
-    async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(params: {
-      pullRequestId: number;
-    }) {
+    async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
+      params: {
+        pullRequestId: number;
+      },
+      axiosOptions?: unknown
+    ) {
       if (options.throwOnActivity) {
         throw new Error('API Error');
       }
+
+      options.onActivityCall?.(params, axiosOptions);
+
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      let pageValues: Array<Record<string, unknown>>;
+      let totalSize: number;
+      let hasNext: boolean;
+
+      if (options.activityPages) {
+        pageValues = options.activityPages[page - 1] ?? [];
+        totalSize = options.activityPages.flat().length;
+        hasNext = page < options.activityPages.length;
+      } else {
+        const allActivities = defaultActivities;
+        const start = (page - 1) * pagelen;
+        const end = start + pagelen;
+        pageValues = allActivities.slice(start, end);
+        totalSize = allActivities.length;
+        hasNext = end < allActivities.length;
+      }
+
       // The API returns void but we return data for testing
       return createAxiosResponse({
-        values: createSet([
-          {
-            comment: {
-              id: 101,
-              content: { raw: 'Looks good to me' },
-              user: mockUser,
-              created_on: '2024-01-02T00:00:00.000Z',
-            },
-          },
-        ]),
-        pagelen: 25,
-        size: 1,
+        values: createSet(pageValues),
+        page,
+        pagelen,
+        size: totalSize,
+        next: hasNext
+          ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/${params.pullRequestId}/activity?page=${page + 1}`
+          : undefined,
       } as unknown as void);
+    },
+
+    async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
+      params: {
+        pullRequestId: number;
+      },
+      axiosOptions?: unknown
+    ) {
+      options.onCommentsListCall?.(params, axiosOptions);
+
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const allComments = options.comments ?? defaultComments;
+      let pageValues: PullrequestComment[];
+      let totalSize: number;
+      let hasNext: boolean;
+
+      if (options.commentsPages) {
+        pageValues = options.commentsPages[page - 1] ?? [];
+        totalSize = options.commentsPages.flat().length;
+        hasNext = page < options.commentsPages.length;
+      } else {
+        const start = (page - 1) * pagelen;
+        const end = start + pagelen;
+        pageValues = allComments.slice(start, end);
+        totalSize = allComments.length;
+        hasNext = end < allComments.length;
+      }
+
+      return createAxiosResponse({
+        values: createSet(pageValues),
+        page,
+        pagelen,
+        size: totalSize,
+        next: hasNext
+          ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/${params.pullRequestId}/comments?page=${page + 1}`
+          : undefined,
+      });
     },
 
     async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsPost(params: {
@@ -445,6 +600,26 @@ describe('ListPRsCommand', () => {
     expect(output.logs.some((log) => log.includes('[DRAFT]'))).toBe(true);
   });
 
+  it('should respect limit option', async () => {
+    const prs = [
+      { ...mockPullRequest, id: 1, title: 'PR 1' },
+      { ...mockPullRequest, id: 2, title: 'PR 2' },
+      { ...mockPullRequest, id: 3, title: 'PR 3' },
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListPRsCommand(pullrequestsApi, contextService, output);
+    await command.execute({ limit: '2' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+  });
+
   it('should output json when requested', async () => {
     const pullrequestsApi = createMockPullrequestsApi();
     const contextService = createMockContextService({
@@ -558,6 +733,200 @@ describe('ActivityPRCommand', () => {
     expect(
       output.logs.some((log) => log.includes('No activity entries matched'))
     ).toBe(true);
+  });
+
+  it('should respect limit option', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      activityPages: [
+        [
+          {
+            comment: {
+              id: 1,
+              content: { raw: 'Comment 1' },
+              user: mockUser,
+              created_on: '2024-01-01T00:00:00.000Z',
+            },
+          },
+          {
+            comment: {
+              id: 2,
+              content: { raw: 'Comment 2' },
+              user: mockUser,
+              created_on: '2024-01-01T01:00:00.000Z',
+            },
+          },
+          {
+            comment: {
+              id: 3,
+              content: { raw: 'Comment 3' },
+              user: mockUser,
+              created_on: '2024-01-01T02:00:00.000Z',
+            },
+          },
+        ],
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1', limit: '2' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('should continue paginating when type filter is used', async () => {
+    const requestedPages: number[] = [];
+    const pullrequestsApi = createMockPullrequestsApi({
+      activityPages: [
+        [
+          {
+            approval: {
+              user: mockUser,
+              date: '2024-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+        [
+          {
+            comment: {
+              id: 10,
+              content: { raw: 'Filtered comment' },
+              user: mockUser,
+              created_on: '2024-01-01T01:00:00.000Z',
+            },
+          },
+        ],
+      ],
+      onActivityCall: (_request, axiosOptions) => {
+        requestedPages.push(extractPaginationParams(axiosOptions).page);
+      },
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { id: '1', type: 'comment', limit: '1' },
+      { globalOptions: {} }
+    );
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(requestedPages).toEqual([1, 2]);
+  });
+});
+
+describe('ListCommentsPRCommand', () => {
+  it('should list comments with limit', async () => {
+    const comments: PullrequestComment[] = [
+      {
+        id: 1,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 1' },
+        user: mockUser,
+        created_on: '2024-01-01T00:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+      {
+        id: 2,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 2' },
+        user: mockUser,
+        created_on: '2024-01-01T01:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+      {
+        id: 3,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 3' },
+        user: mockUser,
+        created_on: '2024-01-01T02:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ comments });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1', limit: '2' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('should include limited count in json output', async () => {
+    const comments: PullrequestComment[] = [
+      {
+        id: 1,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 1' },
+        user: mockUser,
+        created_on: '2024-01-01T00:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+      {
+        id: 2,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 2' },
+        user: mockUser,
+        created_on: '2024-01-01T01:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+      {
+        id: 3,
+        type: 'pullrequest_comment',
+        content: { raw: 'Comment 3' },
+        user: mockUser,
+        created_on: '2024-01-01T02:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ comments });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { id: '1', limit: '2' },
+      { globalOptions: { json: true } }
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const parsed = JSON.parse(jsonLog!.substring(5));
+    expect(parsed.count).toBe(2);
+    expect(parsed.comments).toHaveLength(2);
   });
 });
 
@@ -1021,6 +1390,49 @@ describe('DiffPRCommand', () => {
     expect(output.logs.some((log) => log.includes('diff --git'))).toBe(true);
   });
 
+  it('should auto-detect PR across paginated results', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      pullRequestPages: [
+        [
+          {
+            ...mockPullRequest,
+            id: 100,
+            source: {
+              branch: { name: 'other-branch' },
+            },
+          } as Pullrequest,
+        ],
+        [
+          {
+            ...mockPullRequest,
+            id: 101,
+            source: {
+              branch: { name: 'feature-branch' },
+            },
+          } as Pullrequest,
+        ],
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const gitService = createMockGitService({
+      currentBranch: 'feature-branch',
+    });
+    const output = createMockOutputService();
+
+    const command = new DiffPRCommand(
+      pullrequestsApi,
+      contextService,
+      gitService,
+      output
+    );
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs.some((log) => log.includes('diff --git'))).toBe(true);
+  });
+
   it('should fail when no ID provided and branch not found', async () => {
     const pullrequestsApi = createMockPullrequestsApi();
     const contextService = createMockContextService({
@@ -1201,6 +1613,52 @@ describe('EditPRCommand', () => {
     );
     await command.execute(
       { title: 'Updated via auto-detect' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
+  });
+
+  it('should auto-detect PR across paginated results', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      pullRequestPages: [
+        [
+          {
+            ...mockPullRequest,
+            id: 50,
+            source: {
+              branch: { name: 'other-branch' },
+            },
+          } as Pullrequest,
+        ],
+        [
+          {
+            ...mockPullRequest,
+            id: 51,
+            source: {
+              branch: { name: 'feature-branch' },
+            },
+          } as Pullrequest,
+        ],
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const gitService = createMockGitService({
+      currentBranch: 'feature-branch',
+    });
+    const output = createMockOutputService();
+
+    const command = new EditPRCommand(
+      pullrequestsApi,
+      contextService,
+      gitService,
+      output
+    );
+    await command.execute(
+      { title: 'Updated via paginated auto-detect' },
       { globalOptions: {} }
     );
 

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -18,18 +18,77 @@ import type { IContextService } from '../../src/core/interfaces/services.js';
 import type { BBError } from '../../src/types/errors.js';
 import type { RepositoriesApi } from '../../src/generated/api.js';
 
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  if (!axiosOptions || typeof axiosOptions !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const params = (axiosOptions as { params?: unknown }).params;
+  if (!params || typeof params !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const pageValue = (params as { page?: unknown }).page;
+  const pagelenValue = (params as { pagelen?: unknown }).pagelen;
+
+  const page =
+    typeof pageValue === 'number' && Number.isFinite(pageValue) && pageValue > 0
+      ? pageValue
+      : 1;
+  const pagelen =
+    typeof pagelenValue === 'number' &&
+    Number.isFinite(pagelenValue) &&
+    pagelenValue > 0
+      ? pagelenValue
+      : 25;
+
+  return { page, pagelen };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
 // Helper to create mock RepositoriesApi
 function createMockRepositoriesApi(
-  repos: (typeof mockRepository)[] = [mockRepository]
+  repos: (typeof mockRepository)[] = [mockRepository],
+  options: {
+    onListCall?: (request: unknown, axiosOptions?: unknown) => void;
+  } = {}
 ): RepositoriesApi {
   return {
-    repositoriesWorkspaceGet: async () => ({
-      data: {
-        values: repos,
-        pagelen: repos.length,
-        size: repos.length,
-      },
-    }),
+    repositoriesWorkspaceGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      options.onListCall?.(request, axiosOptions);
+
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      const values = repos.slice(start, end);
+
+      return {
+        data: {
+          values,
+          page,
+          pagelen,
+          size: repos.length,
+          next:
+            end < repos.length
+              ? `https://api.bitbucket.org/2.0/repositories/workspace?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
     repositoriesWorkspaceRepoSlugGet: async ({
       repoSlug,
     }: {
@@ -185,7 +244,39 @@ describe('ListReposCommand', () => {
       { globalOptions: {} }
     );
 
-    expect(output.logs.some((log) => log.includes('table:'))).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('should paginate when limit exceeds first page size', async () => {
+    const repos = Array.from({ length: 55 }, (_, index) => ({
+      ...mockRepository,
+      slug: `repo-${index + 1}`,
+      full_name: `workspace/repo-${index + 1}`,
+      name: `repo-${index + 1}`,
+    }));
+    const requestedPages: number[] = [];
+    const repositoriesApi = createMockRepositoriesApi(repos, {
+      onListCall: (_request, axiosOptions) => {
+        requestedPages.push(extractPaginationParams(axiosOptions).page);
+      },
+    });
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      configService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace', limit: '55' },
+      { globalOptions: {} }
+    );
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(55);
+    expect(requestedPages).toEqual([1, 2]);
   });
 
   it('should show message when no repositories found', async () => {


### PR DESCRIPTION
## Summary
- add a shared pagination helper (`collectPages`) with consistent limit parsing and a safe `pagelen` cap
- honor `--limit` across paginated responses for `bb repo list`, `bb pr list`, `bb pr activity`, and `bb pr comments list`
- update `bb pr diff` and `bb pr edit` auto-detection to find matching PRs across multiple pages
- expand command tests for limit/pagination behavior and update docs for scripting and CI usage
- add a patch changeset for release notes

## Testing
- bun test tests/commands/pr.test.ts
- bun test tests/commands/repo.test.ts
- bun run lint
- bun run format:check
- bun test

Closes #82