### PR TITLE
fix: externalize tabtab to avoid completion install ENOENT

### DIFF
--- a/.changeset/angry-pencils-suffer.md
+++ b/.changeset/angry-pencils-suffer.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix `bb completion install` path errors in published builds by externalizing
+`tabtab` during bundling so shell script templates are resolved from runtime
+`node_modules` instead of CI-only absolute paths.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target bun",
+    "build": "bun build src/index.ts --outdir dist --target bun --external tabtab",
     "test": "bun test",
     "lint": "tsc --noEmit",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- externalize `tabtab` in the Bun build so runtime resolves completion templates from installed `node_modules` instead of bundled CI paths
- prevent `bb completion install` from logging ENOENT errors for `/home/runner/work/.../tabtab/lib/scripts/*.sh` in published builds
- add a patch changeset documenting the completion install fix

## Testing
- bun run build
- bun test tests/commands/completion.test.ts
- bun run lint

## Issue
Closes #114