### PR TITLE
refactor: centralize typed response parsers for PR/repo commands

### DIFF
--- a/.changeset/issue-81-typed-response-parsers.md
+++ b/.changeset/issue-81-typed-response-parsers.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Refine API response parsing by adding shared typed helpers for links,
+diffstats, and pull request activity payloads. This removes command-level
+`any` casts in PR/repo commands and adds focused tests for the new parsers.

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -10,6 +10,12 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  getRawContent,
+  getUserDisplayName,
+  parsePullrequestActivitiesPage,
+  type PullrequestActivity,
+} from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ActivityPROptions extends GlobalOptions {
@@ -45,7 +51,7 @@ export class ActivityPRCommand extends BaseCommand<
     const filterTypes = this.parseTypeFilter(options.type);
     const limit = parseLimit(options.limit);
 
-    const activities = await collectPages<unknown>({
+    const activities = await collectPages<PullrequestActivity>({
       limit,
       fetchPage: async (page, pagelen) => {
         const response =
@@ -60,9 +66,8 @@ export class ActivityPRCommand extends BaseCommand<
             }
           );
 
-        // The generated API types say this returns void, but it actually returns paginated activity
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return response.data as any;
+        // The generated API types say this returns void, but it actually returns paginated activity.
+        return parsePullrequestActivitiesPage(response.data);
       },
       shouldInclude: (activity) => {
         if (filterTypes.length === 0) {
@@ -73,9 +78,6 @@ export class ActivityPRCommand extends BaseCommand<
       },
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const typedActivities = activities as any[];
-
     if (context.globalOptions.json) {
       this.output.json({
         workspace: repoContext.workspace,
@@ -84,13 +86,13 @@ export class ActivityPRCommand extends BaseCommand<
         filters: {
           types: filterTypes,
         },
-        count: typedActivities.length,
-        activities: typedActivities,
+        count: activities.length,
+        activities,
       });
       return;
     }
 
-    if (typedActivities.length === 0) {
+    if (activities.length === 0) {
       if (filterTypes.length > 0) {
         this.output.info('No activity entries matched the requested filter');
       } else {
@@ -99,7 +101,7 @@ export class ActivityPRCommand extends BaseCommand<
       return;
     }
 
-    const rows = typedActivities.map((activity) => {
+    const rows = activities.map((activity) => {
       const activityType = this.getActivityType(activity);
       return [
         activityType.toUpperCase(),
@@ -123,8 +125,7 @@ export class ActivityPRCommand extends BaseCommand<
       .filter((type) => type.length > 0);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getActivityType(activity: any): string {
+  private getActivityType(activity: PullrequestActivity): string {
     if (activity.comment) {
       return 'comment';
     }
@@ -156,8 +157,7 @@ export class ActivityPRCommand extends BaseCommand<
     return activity.type ? activity.type.toLowerCase() : 'activity';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getActorName(activity: any): string {
+  private getActorName(activity: PullrequestActivity): string {
     const user =
       activity.comment?.user ??
       activity.comment?.author ??
@@ -169,15 +169,10 @@ export class ActivityPRCommand extends BaseCommand<
       activity.commit?.author?.user ??
       activity.user;
 
-    if (!user) {
-      return 'Unknown';
-    }
-
-    return user.display_name || user.username || 'Unknown';
+    return getUserDisplayName(user) ?? 'Unknown';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private formatActivityDate(activity: any): string {
+  private formatActivityDate(activity: PullrequestActivity): string {
     const date =
       activity.comment?.created_on ??
       activity.approval?.date ??
@@ -194,11 +189,13 @@ export class ActivityPRCommand extends BaseCommand<
     return this.output.formatDate(date);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private buildActivityDetails(activity: any, type: string): string {
+  private buildActivityDetails(
+    activity: PullrequestActivity,
+    type: string
+  ): string {
     switch (type) {
       case 'comment': {
-        const content = activity.comment?.content?.raw ?? '';
+        const content = getRawContent(activity.comment?.content) ?? '';
         const id = activity.comment?.id ? `#${activity.comment.id}` : '';
         const snippet = this.truncate(content, 80);
         return [id, snippet].filter(Boolean).join(' ');

--- a/src/commands/pr/checkout.command.ts
+++ b/src/commands/pr/checkout.command.ts
@@ -10,6 +10,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
+import { getBranchName } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
@@ -52,8 +53,7 @@ export class CheckoutPRCommand extends BaseCommand<
       );
 
     const pr = prResponse.data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const branchName = (pr.source as any)?.branch?.name;
+    const branchName = getBranchName(pr.source);
     const localBranchName = `pr-${prId}`;
 
     if (!branchName) {

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -13,6 +13,10 @@ import type {
   PullrequestsApi,
 } from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  getRawContent,
+  getUserDisplayName,
+} from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListCommentsPROptions extends GlobalOptions {
@@ -81,14 +85,10 @@ export class ListCommentsPRCommand extends BaseCommand<
     }
 
     const rows = values.map((comment) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const content = (comment.content as any)?.raw ?? '';
+      const content = getRawContent(comment.content) ?? '';
       return [
         comment.id?.toString() ?? '',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (comment.user as any)?.nickname ??
-          (comment.user as any)?.display_name ??
-          'Unknown',
+        getUserDisplayName(comment.user) ?? 'Unknown',
         comment.deleted
           ? '[deleted]'
           : options.truncate === false

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -13,6 +13,11 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { Pullrequest, PullrequestsApi } from '../../generated/api.js';
 import { collectPages, MAX_PAGE_LENGTH } from '../../services/pagination.js';
+import {
+  getBranchName,
+  getLinkHref,
+  parseDiffstatFiles,
+} from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
@@ -80,10 +85,7 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
           return response.data;
         },
         shouldInclude: (pullRequest) => {
-          const source = pullRequest.source as
-            | { branch?: { name?: string } }
-            | undefined;
-          return source?.branch?.name === currentBranch;
+          return getBranchName(pullRequest.source) === currentBranch;
         },
       });
       const pr = matches[0];
@@ -210,10 +212,7 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
         }
       );
 
-    const links = prResponse.data.links as
-      | { html?: { href?: string } }
-      | undefined;
-    const htmlUrl = links?.html?.href;
+    const htmlUrl = getLinkHref(prResponse.data.links, 'html');
     if (htmlUrl) {
       const normalizedHtmlUrl = htmlUrl.replace(/\/$/, '');
       return `${normalizedHtmlUrl}/diff`;
@@ -242,17 +241,7 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
         }
       );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const diffstat = diffstatResponse.data as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const files = Array.from(diffstat.values ?? []).map((file: any) => {
-      const path = file.new?.path || file.old?.path || 'unknown';
-      return {
-        path,
-        additions: file.lines_added ?? 0,
-        deletions: file.lines_removed ?? 0,
-      };
-    });
+    const files = parseDiffstatFiles(diffstatResponse.data);
 
     const totalAdditions = files.reduce(
       (sum: number, f: (typeof files)[0]) => sum + f.additions,
@@ -324,11 +313,8 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
         }
       );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const diffstat = diffstatResponse.data as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fileNames = Array.from(diffstat.values ?? []).map(
-      (file: any) => file.new?.path || file.old?.path || 'unknown'
+    const fileNames = parseDiffstatFiles(diffstatResponse.data).map(
+      (file) => file.path
     );
 
     if (useJson) {

--- a/src/commands/repo/create.command.ts
+++ b/src/commands/repo/create.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
+import { getCloneLinks, getLinkHref } from '../../services/response-parsers.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CreateRepoOptions {
@@ -80,15 +81,12 @@ export class CreateRepoCommand extends BaseCommand<
     }
 
     this.output.success(`Created repository ${repo.full_name}`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.output.text(
-      `  ${this.output.dim('URL:')} ${(repo.links as any)?.html?.href}`
-    );
+    const repoUrl = getLinkHref(repo.links, 'html') ?? '';
+    this.output.text(`  ${this.output.dim('URL:')} ${repoUrl}`);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sshClone = Array.from((repo.links as any)?.clone ?? []).find(
-      (c: any) => c.name === 'ssh'
-    ) as { href?: string } | undefined;
+    const sshClone = getCloneLinks(repo.links).find(
+      (cloneLink) => cloneLink.name === 'ssh'
+    );
     if (sshClone?.href) {
       this.output.text(
         `  ${this.output.dim('Clone:')} git clone ${sshClone.href}`

--- a/src/commands/repo/view.command.ts
+++ b/src/commands/repo/view.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
+import { getCloneLinks, getLinkHref } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ViewRepoOptions extends GlobalOptions {
@@ -90,15 +91,12 @@ export class ViewRepoCommand extends BaseCommand<ViewRepoOptions, void> {
       `  ${this.output.dim('Updated:')} ${this.output.formatDate(repo.updated_on ?? '')}`
     );
     this.output.text('');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.output.text(
-      `  ${this.output.dim('URL:')} ${(repo.links as any)?.html?.href}`
-    );
+    const repoUrl = getLinkHref(repo.links, 'html') ?? '';
+    this.output.text(`  ${this.output.dim('URL:')} ${repoUrl}`);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sshClone = Array.from((repo.links as any)?.clone ?? []).find(
-      (c: any) => c.name === 'ssh'
-    ) as { href?: string } | undefined;
+    const sshClone = getCloneLinks(repo.links).find(
+      (cloneLink) => cloneLink.name === 'ssh'
+    );
     if (sshClone?.href) {
       this.output.text(`  ${this.output.dim('SSH:')} ${sshClone.href}`);
     }

--- a/src/services/response-parsers.ts
+++ b/src/services/response-parsers.ts
@@ -1,0 +1,424 @@
+/**
+ * Helpers for parsing loosely typed API responses.
+ */
+
+import type { PaginatedCollection } from './pagination.js';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface CloneLink {
+  name: string;
+  href: string;
+}
+
+export interface DiffstatFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface ActivityUser {
+  display_name?: string;
+  username?: string;
+  nickname?: string;
+}
+
+export interface PullrequestActivity {
+  type?: string;
+  comment?: {
+    id?: number;
+    content?: { raw?: string };
+    user?: ActivityUser;
+    author?: ActivityUser;
+    created_on?: string;
+  };
+  approval?: { user?: ActivityUser; date?: string };
+  changes_requested?: { user?: ActivityUser; reason?: string; date?: string };
+  merge?: { user?: ActivityUser; date?: string; commit?: { hash?: string } };
+  decline?: { user?: ActivityUser; date?: string };
+  commit?: { author?: { user?: ActivityUser }; date?: string; hash?: string };
+  update?: {
+    author?: ActivityUser;
+    date?: string;
+    title?: string;
+    description?: string;
+    state?: string;
+  };
+  user?: ActivityUser;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function getIterable(value: unknown): Iterable<unknown> | undefined {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const iterableCandidate = value as { [Symbol.iterator]?: unknown };
+  const iterator = iterableCandidate[Symbol.iterator];
+  return typeof iterator === 'function'
+    ? (value as unknown as Iterable<unknown>)
+    : undefined;
+}
+
+function getValuesIterable(data: unknown): Iterable<unknown> | undefined {
+  if (isRecord(data) && 'values' in data) {
+    return getIterable(data.values);
+  }
+
+  return getIterable(data);
+}
+
+function mapPaginatedValues<T>(
+  data: unknown,
+  mapValue: (value: unknown) => T | undefined
+): PaginatedCollection<T> {
+  const iterableValues = getValuesIterable(data);
+  const values: T[] = [];
+
+  if (iterableValues) {
+    for (const value of iterableValues) {
+      const mappedValue = mapValue(value);
+      if (mappedValue !== undefined) {
+        values.push(mappedValue);
+      }
+    }
+  }
+
+  const next = isRecord(data) ? getString(data.next) : undefined;
+
+  return {
+    values,
+    next,
+  };
+}
+
+function getCommitFilePath(file: unknown): string | undefined {
+  if (!isRecord(file)) {
+    return undefined;
+  }
+
+  const path = file.path;
+  return typeof path === 'string' && path.length > 0 ? path : undefined;
+}
+
+function parseDiffstatFile(value: unknown): DiffstatFile | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    path:
+      getCommitFilePath(value.new) ?? getCommitFilePath(value.old) ?? 'unknown',
+    additions: getNumber(value.lines_added) ?? 0,
+    deletions: getNumber(value.lines_removed) ?? 0,
+  };
+}
+
+function parseActivityUser(value: unknown): ActivityUser | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const displayName = getString(value.display_name);
+  const username = getString(value.username);
+  const nickname = getString(value.nickname);
+
+  if (!displayName && !username && !nickname) {
+    return undefined;
+  }
+
+  return {
+    display_name: displayName,
+    username,
+    nickname,
+  };
+}
+
+function parseActivityHash(value: unknown): { hash?: string } | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const hash = getString(value.hash);
+  return hash ? { hash } : undefined;
+}
+
+function parseActivityComment(
+  value: unknown
+): PullrequestActivity['comment'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = getNumber(value.id);
+  const raw = getRawContent(value.content);
+  const user = parseActivityUser(value.user);
+  const author = parseActivityUser(value.author);
+  const createdOn = getString(value.created_on);
+
+  if (id === undefined && raw === undefined && !user && !author && !createdOn) {
+    return undefined;
+  }
+
+  return {
+    id,
+    content: raw === undefined ? undefined : { raw },
+    user,
+    author,
+    created_on: createdOn,
+  };
+}
+
+function parseApproval(
+  value: unknown
+): PullrequestActivity['approval'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const user = parseActivityUser(value.user);
+  const date = getString(value.date);
+
+  if (!user && !date) {
+    return undefined;
+  }
+
+  return { user, date };
+}
+
+function parseChangesRequested(
+  value: unknown
+): PullrequestActivity['changes_requested'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const user = parseActivityUser(value.user);
+  const reason = getString(value.reason);
+  const date = getString(value.date);
+
+  if (!user && !reason && !date) {
+    return undefined;
+  }
+
+  return {
+    user,
+    reason,
+    date,
+  };
+}
+
+function parseMerge(value: unknown): PullrequestActivity['merge'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const user = parseActivityUser(value.user);
+  const date = getString(value.date);
+  const commit = parseActivityHash(value.commit);
+
+  if (!user && !date && !commit) {
+    return undefined;
+  }
+
+  return {
+    user,
+    date,
+    commit,
+  };
+}
+
+function parseDecline(
+  value: unknown
+): PullrequestActivity['decline'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const user = parseActivityUser(value.user);
+  const date = getString(value.date);
+
+  if (!user && !date) {
+    return undefined;
+  }
+
+  return { user, date };
+}
+
+function parseCommit(
+  value: unknown
+): PullrequestActivity['commit'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const date = getString(value.date);
+  const hash = getString(value.hash);
+  const author = isRecord(value.author)
+    ? {
+        user: parseActivityUser(value.author.user),
+      }
+    : undefined;
+
+  if (!date && !hash && !author?.user) {
+    return undefined;
+  }
+
+  return {
+    date,
+    hash,
+    author,
+  };
+}
+
+function parseUpdate(
+  value: unknown
+): PullrequestActivity['update'] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const author = parseActivityUser(value.author);
+  const date = getString(value.date);
+  const title = getString(value.title);
+  const description = getString(value.description);
+  const state = getString(value.state);
+
+  if (!author && !date && !title && !description && !state) {
+    return undefined;
+  }
+
+  return {
+    author,
+    date,
+    title,
+    description,
+    state,
+  };
+}
+
+function parseActivity(value: unknown): PullrequestActivity | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    type: getString(value.type),
+    comment: parseActivityComment(value.comment),
+    approval: parseApproval(value.approval),
+    changes_requested: parseChangesRequested(value.changes_requested),
+    merge: parseMerge(value.merge),
+    decline: parseDecline(value.decline),
+    commit: parseCommit(value.commit),
+    update: parseUpdate(value.update),
+    user: parseActivityUser(value.user),
+  };
+}
+
+export function getLinkHref(links: unknown, key: string): string | undefined {
+  if (!isRecord(links)) {
+    return undefined;
+  }
+
+  const link = links[key];
+  if (!isRecord(link)) {
+    return undefined;
+  }
+
+  return getString(link.href);
+}
+
+export function getCloneLinks(links: unknown): CloneLink[] {
+  if (!isRecord(links)) {
+    return [];
+  }
+
+  const cloneLinks = getIterable(links.clone);
+  if (!cloneLinks) {
+    return [];
+  }
+
+  const parsedLinks: CloneLink[] = [];
+
+  for (const cloneLink of cloneLinks) {
+    if (!isRecord(cloneLink)) {
+      continue;
+    }
+
+    const name = getString(cloneLink.name);
+    const href = getString(cloneLink.href);
+    if (name && href) {
+      parsedLinks.push({ name, href });
+    }
+  }
+
+  return parsedLinks;
+}
+
+export function getBranchName(endpoint: unknown): string | undefined {
+  if (!isRecord(endpoint)) {
+    return undefined;
+  }
+
+  const branch = endpoint.branch;
+  if (!isRecord(branch)) {
+    return undefined;
+  }
+
+  const name = branch.name;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}
+
+export function getUserDisplayName(user: unknown): string | undefined {
+  if (!isRecord(user)) {
+    return undefined;
+  }
+
+  const nickname = getString(user.nickname);
+  if (nickname && nickname.length > 0) {
+    return nickname;
+  }
+
+  const displayName = getString(user.display_name);
+  if (displayName && displayName.length > 0) {
+    return displayName;
+  }
+
+  const username = getString(user.username);
+  return username && username.length > 0 ? username : undefined;
+}
+
+export function getRawContent(content: unknown): string | undefined {
+  if (!isRecord(content)) {
+    return undefined;
+  }
+
+  return getString(content.raw);
+}
+
+export function parseDiffstatFiles(data: unknown): DiffstatFile[] {
+  return Array.from(mapPaginatedValues(data, parseDiffstatFile).values ?? []);
+}
+
+export function parsePullrequestActivitiesPage(
+  data: unknown
+): PaginatedCollection<PullrequestActivity> {
+  return mapPaginatedValues(data, parseActivity);
+}

--- a/tests/services/response-parsers.test.ts
+++ b/tests/services/response-parsers.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Response parser helper tests
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  getBranchName,
+  getCloneLinks,
+  getLinkHref,
+  getRawContent,
+  getUserDisplayName,
+  parseDiffstatFiles,
+  parsePullrequestActivitiesPage,
+} from '../../src/services/response-parsers.js';
+
+describe('response-parsers', () => {
+  describe('parseDiffstatFiles', () => {
+    it('parses diffstat entries from paginated payloads', () => {
+      const parsed = parseDiffstatFiles({
+        values: new Set([
+          {
+            new: { path: 'src/file.ts' },
+            old: { path: 'src/file.ts' },
+            lines_added: 6,
+            lines_removed: 2,
+          },
+          {
+            old: { path: 'README.md' },
+            lines_added: 0,
+            lines_removed: 1,
+          },
+          {
+            lines_added: 'not-a-number',
+            lines_removed: undefined,
+          },
+        ]),
+      });
+
+      expect(parsed).toEqual([
+        { path: 'src/file.ts', additions: 6, deletions: 2 },
+        { path: 'README.md', additions: 0, deletions: 1 },
+        { path: 'unknown', additions: 0, deletions: 0 },
+      ]);
+    });
+
+    it('returns empty list for non-iterable payloads', () => {
+      expect(parseDiffstatFiles({ values: 123 })).toEqual([]);
+      expect(parseDiffstatFiles(null)).toEqual([]);
+    });
+  });
+
+  describe('parsePullrequestActivitiesPage', () => {
+    it('parses activity entries and preserves next link', () => {
+      const parsedPage = parsePullrequestActivitiesPage({
+        next: 'https://api.bitbucket.org?page=2',
+        values: new Set([
+          {
+            comment: {
+              id: 42,
+              content: { raw: 'Looks good' },
+              user: { nickname: 'pilot' },
+              created_on: '2024-01-01T00:00:00.000Z',
+            },
+          },
+          {
+            approval: {
+              user: { display_name: 'Reviewer' },
+              date: '2024-01-01T01:00:00.000Z',
+            },
+          },
+          'invalid-entry',
+        ]),
+      });
+
+      const values = Array.from(parsedPage.values ?? []);
+      expect(values).toHaveLength(2);
+      expect(values[0].comment?.id).toBe(42);
+      expect(values[0].comment?.content?.raw).toBe('Looks good');
+      expect(values[0].comment?.user?.nickname).toBe('pilot');
+      expect(values[1].approval?.user?.display_name).toBe('Reviewer');
+      expect(parsedPage.next).toBe('https://api.bitbucket.org?page=2');
+    });
+  });
+
+  describe('link and field helpers', () => {
+    it('extracts href links and clone URLs safely', () => {
+      const links = {
+        html: { href: 'https://bitbucket.org/workspace/repo' },
+        clone: [
+          { name: 'ssh', href: 'git@bitbucket.org:workspace/repo.git' },
+          { name: 'https', href: 'https://bitbucket.org/workspace/repo.git' },
+          { name: 'invalid' },
+        ],
+      };
+
+      expect(getLinkHref(links, 'html')).toBe(
+        'https://bitbucket.org/workspace/repo'
+      );
+      expect(getCloneLinks(links)).toEqual([
+        {
+          name: 'ssh',
+          href: 'git@bitbucket.org:workspace/repo.git',
+        },
+        {
+          name: 'https',
+          href: 'https://bitbucket.org/workspace/repo.git',
+        },
+      ]);
+      expect(getLinkHref(undefined, 'html')).toBeUndefined();
+      expect(getCloneLinks({ clone: 'invalid' })).toEqual([]);
+    });
+
+    it('extracts branch names, user names, and raw content safely', () => {
+      expect(getBranchName({ branch: { name: 'feature/typed-parsers' } })).toBe(
+        'feature/typed-parsers'
+      );
+      expect(getBranchName({ branch: {} })).toBeUndefined();
+
+      expect(
+        getUserDisplayName({
+          nickname: 'nick',
+          display_name: 'Display Name',
+          username: 'username',
+        })
+      ).toBe('nick');
+      expect(
+        getUserDisplayName({
+          display_name: 'Display Name',
+          username: 'username',
+        })
+      ).toBe('Display Name');
+      expect(getUserDisplayName({ username: 'username' })).toBe('username');
+      expect(getUserDisplayName({})).toBeUndefined();
+
+      expect(getRawContent({ raw: 'comment body' })).toBe('comment body');
+      expect(getRawContent({})).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/services/response-parsers.ts` with shared typed helpers for paginated values, diffstats, activity payloads, and link/branch/user extraction
- refactor PR/repo commands to consume shared parsers and remove command-level `any` casts (`pr diff`, `pr activity`, `pr comments`, `pr checkout`, `repo create`, `repo view`)
- add parser-focused tests and include a patch changeset for release automation

## Testing
- bun test tests/services/response-parsers.test.ts tests/commands/pr.test.ts tests/commands/repo.test.ts
- bun run lint
- bun run format:check
- bun test

## Issue
- Closes #81