### PR TITLE
feat: add retry with exponential backoff for transient API errors

### DIFF
--- a/.changeset/api-retry-backoff.md
+++ b/.changeset/api-retry-backoff.md
@@ -1,0 +1,5 @@
+---
+"@pilatos/bitbucket-cli": minor
+---
+
+Add automatic retry with exponential backoff for rate-limited (429) and transient server errors (502/503/504)

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -2,11 +2,40 @@
  * API Client Service - Axios instance with auth and error handling
  */
 
-import axios, { AxiosInstance, AxiosError } from 'axios';
+import axios, {
+  AxiosInstance,
+  AxiosError,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 import type { IConfigService } from '../core/interfaces/services.js';
 import { BBError, ErrorCode, APIError } from '../types/errors.js';
 
 const BASE_URL = 'https://api.bitbucket.org/2.0';
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+
+interface RetryableConfig extends InternalAxiosRequestConfig {
+  __retryCount?: number;
+}
+
+function getRetryDelay(error: AxiosError, attempt: number): number {
+  if (error.response?.status === 429) {
+    const retryAfter = error.response.headers['retry-after'];
+    if (retryAfter) {
+      const seconds = Number.parseInt(retryAfter, 10);
+      if (!Number.isNaN(seconds)) {
+        return seconds * 1000;
+      }
+    }
+  }
+  return BASE_DELAY_MS * Math.pow(2, attempt - 1);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export function createApiClient(configService: IConfigService): AxiosInstance {
   const instance = axios.create({
@@ -33,7 +62,7 @@ export function createApiClient(configService: IConfigService): AxiosInstance {
     (error) => Promise.reject(error)
   );
 
-  // Response interceptor to transform axios errors into BBError
+  // Response interceptor with retry logic and error transformation
   instance.interceptors.response.use(
     (response) => {
       if (process.env.DEBUG === 'true') {
@@ -45,7 +74,7 @@ export function createApiClient(configService: IConfigService): AxiosInstance {
       }
       return response;
     },
-    (error: AxiosError) => {
+    async (error: AxiosError) => {
       if (process.env.DEBUG === 'true') {
         console.debug(`[HTTP] Error:`, error.message);
         if (error.response) {
@@ -55,6 +84,28 @@ export function createApiClient(configService: IConfigService): AxiosInstance {
           );
         }
       }
+
+      // Retry on transient/rate-limit errors
+      if (error.response && RETRYABLE_STATUS_CODES.has(error.response.status)) {
+        const config = error.config as RetryableConfig | undefined;
+        if (config) {
+          const retryCount = config.__retryCount ?? 0;
+          if (retryCount < MAX_RETRIES) {
+            config.__retryCount = retryCount + 1;
+            const delay = getRetryDelay(error, config.__retryCount);
+            const status = error.response.status;
+            const label =
+              status === 429 ? 'Rate limited' : `Server error (${status})`;
+            console.error(
+              `${label}, retrying in ${(delay / 1000).toFixed(1)}s (attempt ${config.__retryCount}/${MAX_RETRIES})...`
+            );
+            await sleep(delay);
+            return instance(config);
+          }
+        }
+      }
+
+      // Transform non-retryable errors (or exhausted retries) into BBError
       if (error.response) {
         const { status, data } = error.response;
         const message = extractErrorMessage(data) || error.message;

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -1,0 +1,291 @@
+/**
+ * API Client Service tests - retry/backoff logic
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  spyOn,
+  mock,
+} from 'bun:test';
+import { createApiClient } from '../../src/services/api-client.service.js';
+import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
+import type { IConfigService } from '../../src/core/interfaces/services.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Creates a mock config service with valid credentials.
+ */
+function mockConfigService(): IConfigService {
+  return {
+    async getConfig() {
+      return { username: 'testuser', apiToken: 'testtoken' };
+    },
+    async setConfig() {},
+    async getCredentials() {
+      return { username: 'testuser', apiToken: 'testtoken' };
+    },
+    async setCredentials() {},
+    async clearCredentials() {},
+    async clearConfig() {},
+    async getValue() {
+      return undefined;
+    },
+    async setValue() {},
+    getConfigPath() {
+      return '/tmp/test-config.json';
+    },
+  };
+}
+
+/**
+ * Helper: creates an axios adapter that returns responses from a queue.
+ * Each entry is either a successful response or an error response.
+ * Tracks the number of calls made.
+ */
+function createMockAdapter(
+  responses: Array<{
+    status: number;
+    data?: unknown;
+    headers?: Record<string, string>;
+  }>
+) {
+  let callCount = 0;
+  const adapter = (config: unknown) => {
+    const idx = callCount;
+    callCount++;
+    const resp = responses[idx] ?? responses[responses.length - 1];
+    if (resp.status >= 200 && resp.status < 300) {
+      return Promise.resolve({
+        data: resp.data ?? {},
+        status: resp.status,
+        statusText: 'OK',
+        headers: resp.headers ?? {},
+        config,
+      });
+    }
+    // Simulate an axios error for non-2xx
+    const error = new Error(`Request failed with status code ${resp.status}`);
+    (error as any).response = {
+      data: resp.data ?? {},
+      status: resp.status,
+      statusText: resp.status.toString(),
+      headers: resp.headers ?? {},
+      config,
+    };
+    (error as any).config = config;
+    (error as any).isAxiosError = true;
+    // For network errors we handle separately; here we always have a response
+    return Promise.reject(error);
+  };
+
+  return {
+    adapter,
+    getCallCount: () => callCount,
+  };
+}
+
+/**
+ * Helper: creates an adapter that simulates a network error (no response).
+ */
+function createNetworkErrorAdapter() {
+  let callCount = 0;
+  const adapter = (_config: unknown) => {
+    callCount++;
+    const error = new Error('Network Error');
+    (error as any).request = {}; // has request but no response
+    (error as any).config = _config;
+    (error as any).isAxiosError = true;
+    return Promise.reject(error);
+  };
+  return {
+    adapter,
+    getCallCount: () => callCount,
+  };
+}
+
+// Speed up the sleep() calls by overriding global setTimeout
+const originalSetTimeout = globalThis.setTimeout;
+
+describe('createApiClient - retry/backoff', () => {
+  let client: AxiosInstance;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Make setTimeout resolve instantly to avoid real delays
+    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+      fn();
+      return 0 as any;
+    }) as any;
+
+    // Suppress retry log noise in test output
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns response on successful request without retry', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 200, data: { ok: true } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ ok: true });
+    expect(mockAdapter.getCallCount()).toBe(1);
+  });
+
+  it('retries on 429 and succeeds on second attempt', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: { error: { message: 'Rate limited' } } },
+      { status: 200, data: { ok: true } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ ok: true });
+    expect(mockAdapter.getCallCount()).toBe(2);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('retries on 502 and succeeds on second attempt', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 502, data: {} },
+      { status: 200, data: { recovered: true } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ recovered: true });
+    expect(mockAdapter.getCallCount()).toBe(2);
+  });
+
+  it('throws APIError with API_RATE_LIMITED after exhausting retries on 429', async () => {
+    // 3 retries + 1 initial = 4 calls total, all returning 429
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: { error: { message: 'Rate limited' } } },
+      { status: 429, data: { error: { message: 'Rate limited' } } },
+      { status: 429, data: { error: { message: 'Rate limited' } } },
+      { status: 429, data: { error: { message: 'Rate limited' } } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      const apiErr = err as APIError;
+      expect(apiErr.code).toBe(ErrorCode.API_RATE_LIMITED);
+      expect(apiErr.statusCode).toBe(429);
+    }
+
+    // 1 initial + 3 retries = 4 calls
+    expect(mockAdapter.getCallCount()).toBe(4);
+  });
+
+  it('throws immediately on 404 without retrying', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 404, data: { error: { message: 'Not found' } } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      const apiErr = err as APIError;
+      expect(apiErr.code).toBe(ErrorCode.API_NOT_FOUND);
+      expect(apiErr.statusCode).toBe(404);
+    }
+
+    expect(mockAdapter.getCallCount()).toBe(1);
+  });
+
+  it('throws immediately on 401 without retrying', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 401, data: { error: { message: 'Unauthorized' } } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      const apiErr = err as APIError;
+      expect(apiErr.code).toBe(ErrorCode.AUTH_INVALID);
+      expect(apiErr.statusCode).toBe(401);
+    }
+
+    expect(mockAdapter.getCallCount()).toBe(1);
+  });
+
+  it('respects Retry-After header on 429', async () => {
+    const setTimeoutCalls: number[] = [];
+    // Override setTimeout to track the delay values
+    globalThis.setTimeout = ((fn: Function, ms?: number) => {
+      setTimeoutCalls.push(ms ?? 0);
+      fn();
+      return 0 as any;
+    }) as any;
+
+    const mockAdapter = createMockAdapter([
+      {
+        status: 429,
+        data: { error: { message: 'Rate limited' } },
+        headers: { 'retry-after': '5' },
+      },
+      { status: 200, data: { ok: true } },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(mockAdapter.getCallCount()).toBe(2);
+    // The retry delay should be 5000ms (5 seconds from Retry-After header)
+    expect(setTimeoutCalls).toContain(5000);
+  });
+
+  it('throws BBError with NETWORK_ERROR on network failure', async () => {
+    const networkMock = createNetworkErrorAdapter();
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = networkMock.adapter as any;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BBError);
+      const bbErr = err as BBError;
+      expect(bbErr.code).toBe(ErrorCode.NETWORK_ERROR);
+      expect(bbErr.message).toBe(
+        'Network error: Unable to reach Bitbucket API'
+      );
+    }
+
+    // Network errors are not retried (no response object)
+    expect(networkMock.getCallCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Added automatic retry for transient API failures in `src/services/api-client.service.ts`:
  - **429 Too Many Requests** — respects `Retry-After` header, falls back to exponential backoff
  - **502/503/504** — retries with exponential backoff
- Up to 3 retries with delays of 1s, 2s, 4s (doubling each attempt)
- Retry attempts are logged to stderr so users see what's happening (e.g., `Rate limited, retrying in 2.0s (attempt 1/3)...`)
- After max retries, the original error is thrown as `APIError` as before
- No new dependencies — implemented using Axios's built-in request re-issuing from interceptors

### How it works

The response error interceptor checks if the status is retryable. If so, it stores a retry counter on the request config, sleeps for the calculated delay, and re-issues the request via `instance(config)`. This goes back through the full interceptor chain (including auth) on each retry.

Closes #127

## Test plan

- [x] `bun test` — 417 tests pass
- [x] `bun run lint` — passes
- [x] `bun run format:check` — passes
- [ ] Manually verify: with `DEBUG=true`, trigger a 429 and confirm retry messages appear
- [ ] Verify non-retryable errors (401, 403, 404) are thrown immediately without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)