### PR TITLE
fix: remove unsafe type casts in reviewer commands

### DIFF
--- a/.changeset/fix-reviewer-type-casts.md
+++ b/.changeset/fix-reviewer-type-casts.md
@@ -1,0 +1,5 @@
+---
+"@pilatos/bitbucket-cli": patch
+---
+
+Remove unsafe `as unknown as` type casts in reviewer add/remove commands and extract shared reviewer update logic into a reusable service

--- a/src/commands/pr/reviewers.add.command.ts
+++ b/src/commands/pr/reviewers.add.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, UsersApi } from '../../generated/api.js';
+import { updatePullRequestReviewers } from '../../services/reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface AddReviewerPROptions extends GlobalOptions {
@@ -43,46 +44,23 @@ export class AddReviewerPRCommand extends BaseCommand<
 
     const prId = this.parseIntOption(options.id, 'id');
 
-    // First look up the user to get their UUID
+    // Look up the user to get their UUID
     const userResponse = await this.usersApi.usersSelectedUserGet({
       selectedUser: options.username,
     });
     const user = userResponse.data;
 
-    // Get current PR to see existing reviewers
-    const prResponse =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
+    const updatedPr = await updatePullRequestReviewers(
+      this.pullrequestsApi,
+      repoContext,
+      prId,
+      (uuids) => {
+        if (!uuids.includes(user.uuid!)) {
+          return [...uuids, user.uuid!];
         }
-      );
-    const pr = prResponse.data;
-
-    // Build list of reviewers (existing + new)
-    const existingReviewers = pr.reviewers ? Array.from(pr.reviewers) : [];
-    const reviewerUuids = existingReviewers
-      .map((r) => (r as { uuid?: string }).uuid)
-      .filter(Boolean);
-
-    if (!reviewerUuids.includes(user.uuid)) {
-      reviewerUuids.push(user.uuid);
-    }
-
-    // Update PR with new reviewers list
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-          body: {
-            type: 'pullrequest',
-            reviewers: reviewerUuids.map((uuid) => ({ uuid })),
-          } as unknown as import('../../generated/api.js').Pullrequest,
-        }
-      );
+        return uuids;
+      }
+    );
 
     if (context.globalOptions.json) {
       this.output.json({
@@ -92,7 +70,7 @@ export class AddReviewerPRCommand extends BaseCommand<
           username: options.username,
           uuid: user.uuid,
         },
-        pullRequest: response.data,
+        pullRequest: updatedPr,
       });
       return;
     }

--- a/src/commands/pr/reviewers.remove.command.ts
+++ b/src/commands/pr/reviewers.remove.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, UsersApi } from '../../generated/api.js';
+import { updatePullRequestReviewers } from '../../services/reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface RemoveReviewerPROptions extends GlobalOptions {
@@ -43,42 +44,18 @@ export class RemoveReviewerPRCommand extends BaseCommand<
 
     const prId = this.parseIntOption(options.id, 'id');
 
-    // First look up the user to get their UUID
+    // Look up the user to get their UUID
     const userResponse = await this.usersApi.usersSelectedUserGet({
       selectedUser: options.username,
     });
     const user = userResponse.data;
 
-    // Get current PR to see existing reviewers
-    const prResponse =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-        }
-      );
-    const pr = prResponse.data;
-
-    // Build list of reviewers (excluding the one to remove)
-    const existingReviewers = pr.reviewers ? Array.from(pr.reviewers) : [];
-    const reviewerUuids = existingReviewers
-      .map((r) => (r as { uuid?: string }).uuid)
-      .filter((uuid) => uuid && uuid !== user.uuid);
-
-    // Update PR with new reviewers list
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-          body: {
-            type: 'pullrequest',
-            reviewers: reviewerUuids.map((uuid) => ({ uuid })),
-          } as unknown as import('../../generated/api.js').Pullrequest,
-        }
-      );
+    const updatedPr = await updatePullRequestReviewers(
+      this.pullrequestsApi,
+      repoContext,
+      prId,
+      (uuids) => uuids.filter((uuid) => uuid !== user.uuid)
+    );
 
     if (context.globalOptions.json) {
       this.output.json({
@@ -88,7 +65,7 @@ export class RemoveReviewerPRCommand extends BaseCommand<
           username: options.username,
           uuid: user.uuid,
         },
-        pullRequest: response.data,
+        pullRequest: updatedPr,
       });
       return;
     }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,8 @@ export { ContextService } from './context.service.js';
 export { OutputService } from './output.service.js';
 export { VersionService } from './version.service.js';
 export { createApiClient } from './api-client.service.js';
+export {
+  extractReviewerUuids,
+  buildReviewersUpdateBody,
+  updatePullRequestReviewers,
+} from './reviewer.service.js';

--- a/src/services/reviewer.service.ts
+++ b/src/services/reviewer.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared logic for updating pull request reviewers.
+ */
+
+import type {
+  Account,
+  Pullrequest,
+  PullrequestsApi,
+} from '../generated/api.js';
+
+export interface RepoContext {
+  workspace: string;
+  repoSlug: string;
+}
+
+/**
+ * Extract UUIDs from a reviewer collection in a type-safe way.
+ *
+ * The generated `Pullrequest.reviewers` is typed as `Array<Account>`,
+ * but the API may return a `Set` or other iterable — `Array.from`
+ * normalises this.  Each `Account` has an optional `uuid` field, so
+ * we filter out entries without one.
+ */
+export function extractReviewerUuids(
+  reviewers: Pullrequest['reviewers']
+): string[] {
+  if (!reviewers) {
+    return [];
+  }
+
+  const list: Account[] = Array.from(reviewers);
+  const uuids: string[] = [];
+
+  for (const reviewer of list) {
+    if (reviewer.uuid) {
+      uuids.push(reviewer.uuid);
+    }
+  }
+
+  return uuids;
+}
+
+/**
+ * Build a type-safe `Pullrequest` body containing only the reviewers
+ * field, suitable for a PUT update.
+ */
+export function buildReviewersUpdateBody(uuids: string[]): Pullrequest {
+  const body: Pullrequest = {
+    type: 'pullrequest',
+    reviewers: uuids.map((uuid) => ({ type: 'user', uuid }) as Account),
+  };
+  return body;
+}
+
+/**
+ * Fetch a pull request, apply a UUID-level transform to its reviewer
+ * list, and PUT the result back.  Returns the API response data.
+ */
+export async function updatePullRequestReviewers(
+  pullrequestsApi: PullrequestsApi,
+  repoContext: RepoContext,
+  prId: number,
+  transformUuids: (uuids: string[]) => string[]
+): Promise<Pullrequest> {
+  // Get current PR to see existing reviewers
+  const prResponse =
+    await pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
+      {
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pullRequestId: prId,
+      }
+    );
+  const pr = prResponse.data;
+
+  const currentUuids = extractReviewerUuids(pr.reviewers);
+  const updatedUuids = transformUuids(currentUuids);
+  const body = buildReviewersUpdateBody(updatedUuids);
+
+  const response =
+    await pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
+      {
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pullRequestId: prId,
+        body,
+      }
+    );
+
+  return response.data;
+}

--- a/tests/services/reviewer.service.test.ts
+++ b/tests/services/reviewer.service.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for reviewer service shared logic
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  Account,
+  Pullrequest,
+  PullrequestsApi,
+} from '../../src/generated/api.js';
+import type { AxiosResponse } from 'axios';
+import {
+  extractReviewerUuids,
+  buildReviewersUpdateBody,
+  updatePullRequestReviewers,
+} from '../../src/services/reviewer.service.js';
+
+function createAxiosResponse<T>(data: T): AxiosResponse<T> {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any,
+  };
+}
+
+const basePr: Pullrequest = {
+  type: 'pullrequest',
+  id: 1,
+  title: 'Test PR',
+  reviewers: [],
+};
+
+// ============================================================
+// extractReviewerUuids
+// ============================================================
+
+describe('extractReviewerUuids', () => {
+  it('should return empty array when reviewers is undefined', () => {
+    expect(extractReviewerUuids(undefined)).toEqual([]);
+  });
+
+  it('should return empty array when reviewers is empty array', () => {
+    expect(extractReviewerUuids([])).toEqual([]);
+  });
+
+  it('should return empty array when reviewers is empty Set', () => {
+    const reviewers = new Set<Account>() as Pullrequest['reviewers'];
+    expect(extractReviewerUuids(reviewers)).toEqual([]);
+  });
+
+  it('should extract uuids from an array of accounts', () => {
+    const reviewers: Account[] = [
+      { type: 'user', uuid: '{uuid-1}' },
+      { type: 'user', uuid: '{uuid-2}' },
+    ];
+    expect(extractReviewerUuids(reviewers)).toEqual(['{uuid-1}', '{uuid-2}']);
+  });
+
+  it('should extract uuids from a Set of accounts', () => {
+    const reviewers = new Set([
+      { type: 'user', uuid: '{uuid-1}' },
+      { type: 'user', uuid: '{uuid-2}' },
+    ]) as Pullrequest['reviewers'];
+    expect(extractReviewerUuids(reviewers)).toEqual(['{uuid-1}', '{uuid-2}']);
+  });
+
+  it('should skip reviewers without uuid', () => {
+    const reviewers: Account[] = [
+      { type: 'user', uuid: '{uuid-1}' },
+      { type: 'user' },
+      { type: 'user', uuid: '{uuid-3}' },
+    ];
+    expect(extractReviewerUuids(reviewers)).toEqual(['{uuid-1}', '{uuid-3}']);
+  });
+
+  it('should return empty array when all reviewers lack uuid', () => {
+    const reviewers: Account[] = [
+      { type: 'user' },
+      { type: 'user', display_name: 'No UUID' },
+    ];
+    expect(extractReviewerUuids(reviewers)).toEqual([]);
+  });
+});
+
+// ============================================================
+// buildReviewersUpdateBody
+// ============================================================
+
+describe('buildReviewersUpdateBody', () => {
+  it('should create a Pullrequest body with type and reviewers', () => {
+    const body = buildReviewersUpdateBody(['{uuid-1}', '{uuid-2}']);
+    expect(body.type).toBe('pullrequest');
+    expect(body.reviewers).toHaveLength(2);
+    expect(body.reviewers![0].uuid).toBe('{uuid-1}');
+    expect(body.reviewers![1].uuid).toBe('{uuid-2}');
+  });
+
+  it('should create body with empty reviewers for empty uuid list', () => {
+    const body = buildReviewersUpdateBody([]);
+    expect(body.type).toBe('pullrequest');
+    expect(body.reviewers).toEqual([]);
+  });
+
+  it('should set type to user on each reviewer account', () => {
+    const body = buildReviewersUpdateBody(['{uuid-1}']);
+    expect(body.reviewers![0].type).toBe('user');
+  });
+});
+
+// ============================================================
+// updatePullRequestReviewers
+// ============================================================
+
+describe('updatePullRequestReviewers', () => {
+  function createMockPullrequestsApi(pr: Pullrequest): {
+    api: PullrequestsApi;
+    lastPutBody: () => Pullrequest | undefined;
+  } {
+    let capturedBody: Pullrequest | undefined;
+
+    const api = {
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet() {
+        return createAxiosResponse(pr);
+      },
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(params: {
+        body?: Pullrequest;
+      }) {
+        capturedBody = params.body;
+        return createAxiosResponse({
+          ...pr,
+          reviewers: params.body?.reviewers ?? pr.reviewers,
+        });
+      },
+    } as unknown as PullrequestsApi;
+
+    return { api, lastPutBody: () => capturedBody };
+  }
+
+  const repoContext = { workspace: 'ws', repoSlug: 'repo' };
+
+  it('should add a new uuid via transform', async () => {
+    const pr: Pullrequest = {
+      ...basePr,
+      reviewers: [{ type: 'user', uuid: '{existing}' }],
+    };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) => [
+      ...uuids,
+      '{new-uuid}',
+    ]);
+
+    const body = lastPutBody()!;
+    expect(body.type).toBe('pullrequest');
+    expect(body.reviewers).toHaveLength(2);
+    expect(body.reviewers![0].uuid).toBe('{existing}');
+    expect(body.reviewers![1].uuid).toBe('{new-uuid}');
+  });
+
+  it('should remove a uuid via transform', async () => {
+    const pr: Pullrequest = {
+      ...basePr,
+      reviewers: [
+        { type: 'user', uuid: '{keep}' },
+        { type: 'user', uuid: '{remove}' },
+      ],
+    };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) =>
+      uuids.filter((u) => u !== '{remove}')
+    );
+
+    const body = lastPutBody()!;
+    expect(body.reviewers).toHaveLength(1);
+    expect(body.reviewers![0].uuid).toBe('{keep}');
+  });
+
+  it('should handle empty reviewer list', async () => {
+    const pr: Pullrequest = { ...basePr, reviewers: [] };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) => [
+      ...uuids,
+      '{first}',
+    ]);
+
+    const body = lastPutBody()!;
+    expect(body.reviewers).toHaveLength(1);
+    expect(body.reviewers![0].uuid).toBe('{first}');
+  });
+
+  it('should handle undefined reviewers on PR', async () => {
+    const pr: Pullrequest = { ...basePr, reviewers: undefined };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) => [
+      ...uuids,
+      '{added}',
+    ]);
+
+    const body = lastPutBody()!;
+    expect(body.reviewers).toHaveLength(1);
+    expect(body.reviewers![0].uuid).toBe('{added}');
+  });
+
+  it('should handle Set-based reviewers', async () => {
+    const pr: Pullrequest = {
+      ...basePr,
+      reviewers: new Set([
+        { type: 'user', uuid: '{set-uuid}' },
+      ]) as Pullrequest['reviewers'],
+    };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) => uuids);
+
+    const body = lastPutBody()!;
+    expect(body.reviewers).toHaveLength(1);
+    expect(body.reviewers![0].uuid).toBe('{set-uuid}');
+  });
+
+  it('should return the updated PR data', async () => {
+    const pr: Pullrequest = { ...basePr, reviewers: [] };
+    const { api } = createMockPullrequestsApi(pr);
+
+    const result = await updatePullRequestReviewers(
+      api,
+      repoContext,
+      1,
+      (uuids) => [...uuids, '{new}']
+    );
+
+    expect(result.type).toBe('pullrequest');
+    expect(result.reviewers).toHaveLength(1);
+  });
+
+  it('should propagate API errors from GET', async () => {
+    const api = {
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet() {
+        throw new Error('GET failed');
+      },
+    } as unknown as PullrequestsApi;
+
+    await expect(
+      updatePullRequestReviewers(api, repoContext, 1, (u) => u)
+    ).rejects.toThrow('GET failed');
+  });
+
+  it('should propagate API errors from PUT', async () => {
+    const api = {
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet() {
+        return createAxiosResponse(basePr);
+      },
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut() {
+        throw new Error('PUT failed');
+      },
+    } as unknown as PullrequestsApi;
+
+    await expect(
+      updatePullRequestReviewers(api, repoContext, 1, (u) => u)
+    ).rejects.toThrow('PUT failed');
+  });
+
+  it('should pass correct workspace and repoSlug to API calls', async () => {
+    let getParams: Record<string, unknown> = {};
+    let putParams: Record<string, unknown> = {};
+
+    const api = {
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
+        params: Record<string, unknown>
+      ) {
+        getParams = params;
+        return createAxiosResponse(basePr);
+      },
+      async repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(
+        params: Record<string, unknown>
+      ) {
+        putParams = params;
+        return createAxiosResponse(basePr);
+      },
+    } as unknown as PullrequestsApi;
+
+    await updatePullRequestReviewers(
+      api,
+      { workspace: 'my-ws', repoSlug: 'my-repo' },
+      99,
+      (u) => u
+    );
+
+    expect(getParams).toMatchObject({
+      workspace: 'my-ws',
+      repoSlug: 'my-repo',
+      pullRequestId: 99,
+    });
+    expect(putParams).toMatchObject({
+      workspace: 'my-ws',
+      repoSlug: 'my-repo',
+      pullRequestId: 99,
+    });
+  });
+
+  it('should not duplicate uuid when transform returns identity', async () => {
+    const pr: Pullrequest = {
+      ...basePr,
+      reviewers: [
+        { type: 'user', uuid: '{a}' },
+        { type: 'user', uuid: '{b}' },
+      ],
+    };
+    const { api, lastPutBody } = createMockPullrequestsApi(pr);
+
+    await updatePullRequestReviewers(api, repoContext, 1, (uuids) => uuids);
+
+    const body = lastPutBody()!;
+    expect(body.reviewers).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts shared reviewer update logic from `reviewers.add.command.ts` and `reviewers.remove.command.ts` into a new `reviewer.service.ts`
- Removes all `as unknown as Pullrequest` casts by constructing properly typed `Pullrequest` objects
- Replaces unsafe `(r as { uuid?: string }).uuid` with type-safe UUID extraction via `Account.uuid`

## Test plan

- [x] 20 new unit tests for `reviewer.service.ts` covering:
  - `extractReviewerUuids`: undefined/empty/Set/Array inputs, missing UUIDs
  - `buildReviewersUpdateBody`: correct structure, empty lists, Account type field
  - `updatePullRequestReviewers`: add/remove transforms, error propagation, API param forwarding
- [x] All 445 existing tests pass
- [x] `tsc --noEmit` clean — no type errors
- [x] `prettier --check .` passes

Closes #128