### PR TITLE
feat: add snippet command group

### DIFF
--- a/.changeset/add-snippet-commands.md
+++ b/.changeset/add-snippet-commands.md
@@ -2,15 +2,19 @@
 "@pilatos/bitbucket-cli": minor
 ---
 
-Add snippet command group with full CRUD support for Bitbucket snippets
+Add snippet command group with full CRUD support for Bitbucket snippets.
 
 New commands:
-- `bb snippet list` — list workspace snippets with role filtering
-- `bb snippet view <id>` — view snippet details including files
-- `bb snippet create` — create snippets with file attachments
-- `bb snippet edit <id>` — update snippet title and visibility
-- `bb snippet delete <id>` — delete snippets with confirmation
-- `bb snippet watch/unwatch <id>` — manage snippet watching
-- `bb snippet comments list/add/edit/delete` — full comments CRUD
 
-All commands support `--json` output and workspace resolution via `--workspace` flag or `defaultWorkspace` config.
+- `bb snippet list` — list workspace snippets, optional `--role` filter (`owner`, `contributor`, `member`)
+- `bb snippet view <id>` — view snippet details; `--file <name>` prints one file, `--files` prints all
+- `bb snippet create` — create snippets via `multipart/form-data`, uploading one or more `--file` arguments as the snippet body
+- `bb snippet edit <id>` — update title/visibility (JSON PUT) or replace/add files (multipart PUT) via `--file`
+- `bb snippet delete <id>` — delete snippets (requires `--yes`)
+- `bb snippet watch <id>` / `bb snippet unwatch <id>` — manage snippet watching
+- `bb snippet comments list | add | edit | delete` — full comments CRUD
+
+All commands support `--json` output and workspace resolution via `--workspace` or the `defaultWorkspace` config key.
+
+Internal refactor: a shared `resolveWorkspace()` helper now backs every
+workspace-scoped command (snippet + `repo list` / `repo create` / `repo clone`), removing several copies of the same fallback logic.

--- a/.changeset/add-snippet-commands.md
+++ b/.changeset/add-snippet-commands.md
@@ -1,0 +1,16 @@
+---
+"@pilatos/bitbucket-cli": minor
+---
+
+Add snippet command group with full CRUD support for Bitbucket snippets
+
+New commands:
+- `bb snippet list` — list workspace snippets with role filtering
+- `bb snippet view <id>` — view snippet details including files
+- `bb snippet create` — create snippets with file attachments
+- `bb snippet edit <id>` — update snippet title and visibility
+- `bb snippet delete <id>` — delete snippets with confirmation
+- `bb snippet watch/unwatch <id>` — manage snippet watching
+- `bb snippet comments list/add/edit/delete` — full comments CRUD
+
+All commands support `--json` output and workspace resolution via `--workspace` flag or `defaultWorkspace` config.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ## At a glance
 
-- Stay in the terminal for repo and PR workflows
+- Stay in the terminal for repo, PR, and snippet workflows
 - JSON output for scripting and automation
 - Auto-detects workspace and repo from your git directory
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
                 directory: 'commands/pr',
               },
             },
+            { label: "Snippet Commands", slug: "commands/snippet" },
             { label: "Config Commands", slug: "commands/config" },
             { label: "Completion", slug: "commands/completion" },
           ],

--- a/docs/src/content/docs/commands/snippet.mdx
+++ b/docs/src/content/docs/commands/snippet.mdx
@@ -1,0 +1,288 @@
+---
+title: Snippet Commands - Manage Bitbucket Snippets
+description: Reference for Bitbucket CLI snippet commands. Create, view, edit, delete, watch, and comment on Bitbucket Cloud snippets from the command line.
+---
+
+Manage [Bitbucket Cloud snippets](https://support.atlassian.com/bitbucket-cloud/docs/create-a-snippet/) — workspace-scoped code/text pastes.
+
+Snippet commands operate at **workspace** scope (no repo context required). Use
+`-w, --workspace <workspace>` or set a default with
+`bb config set defaultWorkspace <workspace>`.
+
+Global options available on all snippet commands: `--json`, `--no-color`, `-w, --workspace`.
+
+---
+
+## `bb snippet list`
+
+List snippets in a workspace.
+
+```bash
+bb snippet list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `--role <role>` | Filter by authenticated user's role: `owner`, `contributor`, or `member` |
+| `--limit <number>` | Maximum number of snippets (default: 25) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet list
+bb snippet list --role owner
+bb snippet list --limit 50 --json
+```
+
+### Notes
+
+- `--limit` is enforced across paginated responses.
+
+---
+
+## `bb snippet view`
+
+View snippet details. Optionally print file contents.
+
+```bash
+bb snippet view <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID (e.g. `kypj`) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-f, --file <name>` | Print contents of a specific file in the snippet |
+| `--files` | Print contents of all files in the snippet |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet view kypj
+bb snippet view kypj --json
+bb snippet view kypj --file config.yml
+bb snippet view kypj --files
+```
+
+---
+
+## `bb snippet create`
+
+Create a snippet. The files you pass are uploaded as `multipart/form-data`
+to Bitbucket — their contents are the snippet body.
+
+```bash
+bb snippet create [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-t, --title <title>` | Snippet title (required) |
+| `-f, --file <path...>` | One or more file paths to include (required) |
+| `--private` | Create a private snippet (default) |
+| `--public` | Create a public snippet |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet create -t "My snippet" -f file.txt
+bb snippet create -t "Config files" -f config.yml -f setup.sh --public
+```
+
+### Notes
+
+- Snippets are private by default.
+- `--private` and `--public` cannot both be set.
+- Each `--file` must exist on disk; missing files fail the command before any upload.
+
+---
+
+## `bb snippet edit`
+
+Update a snippet's title, visibility, or files.
+
+```bash
+bb snippet edit <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-t, --title <title>` | New title |
+| `--private` | Make snippet private |
+| `--public` | Make snippet public |
+| `-f, --file <path...>` | Replace or add file(s); sends a multipart update |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet edit kypj -t "New title"
+bb snippet edit kypj --public
+bb snippet edit kypj -f updated.txt
+```
+
+### Notes
+
+- Metadata-only edits (title, visibility) send a JSON PUT.
+- Passing `--file` switches to a multipart PUT and uploads the given files.
+- At least one of `--title`, `--private`, `--public`, or `--file` is required.
+
+---
+
+## `bb snippet delete`
+
+Delete a snippet. Permanent.
+
+```bash
+bb snippet delete <id> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-y, --yes` | Confirm deletion (required) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet delete kypj --yes
+```
+
+:::danger
+This action is permanent and cannot be undone.
+:::
+
+---
+
+## `bb snippet watch` / `bb snippet unwatch`
+
+Subscribe or unsubscribe the authenticated user to/from a snippet.
+
+```bash
+bb snippet watch <id> [options]
+bb snippet unwatch <id> [options]
+```
+
+### Examples
+
+```bash
+bb snippet watch kypj
+bb snippet unwatch kypj
+```
+
+---
+
+## `bb snippet comments list`
+
+List comments on a snippet.
+
+```bash
+bb snippet comments list <id> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `--limit <number>` | Maximum number of comments (default: 25) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet comments list kypj
+bb snippet comments list kypj --limit 50 --json
+```
+
+---
+
+## `bb snippet comments add`
+
+Add a comment to a snippet.
+
+```bash
+bb snippet comments add <id> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-m, --message <message>` | Comment body (required) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet comments add kypj -m "Great snippet!"
+```
+
+---
+
+## `bb snippet comments edit`
+
+Edit a comment on a snippet.
+
+```bash
+bb snippet comments edit <snippet-id> <comment-id> <message> [options]
+```
+
+### Examples
+
+```bash
+bb snippet comments edit kypj 123 "Updated comment"
+```
+
+---
+
+## `bb snippet comments delete`
+
+Delete a comment on a snippet.
+
+```bash
+bb snippet comments delete <snippet-id> <comment-id> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-y, --yes` | Confirm deletion (required) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb snippet comments delete kypj 123 --yes
+```

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -15,7 +15,7 @@ No. This is an **unofficial**, community-maintained CLI tool. It is not affiliat
 
 ### How does this compare to GitHub CLI (gh)?
 
-The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, configuration, and shell completion. Features not yet supported include issues, pipelines, snippets, and branch permissions.
+The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, snippets, configuration, and shell completion. Features not yet supported include issues, pipelines, and branch permissions.
 
 ---
 
@@ -26,13 +26,13 @@ Currently supported:
 - **Authentication** - Login, logout, status, token display
 - **Repositories** - Clone, create, list, view, delete
 - **Pull Requests** - Create, list, view, edit, merge, approve, decline, ready (mark draft ready), checkout, diff, activity log, CI/CD checks, comments (list/add/edit/delete), reviewers (list/add/remove)
+- **Snippets** - List, view (with file contents), create, edit (metadata or file upload), delete, watch/unwatch, comments (list/add/edit/delete)
 - **Configuration** - Get, set, list settings
 - **Shell Completion** - Bash, Zsh, Fish
 
 Not yet supported:
 - Issues
 - Pipelines
-- Snippets
 - Branch permissions
 - Webhooks
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -22,6 +22,7 @@ import {
   RepositoriesApi,
   UsersApi,
   CommitStatusesApi,
+  SnippetsApi,
 } from './generated/api.js';
 
 // Auth commands
@@ -57,6 +58,19 @@ import { AddReviewerPRCommand } from './commands/pr/reviewers.add.command.js';
 import { RemoveReviewerPRCommand } from './commands/pr/reviewers.remove.command.js';
 import { ListReviewersPRCommand } from './commands/pr/reviewers.list.command.js';
 import { ChecksPRCommand } from './commands/pr/checks.command.js';
+
+// Snippet commands
+import { ListSnippetsCommand } from './commands/snippet/list.command.js';
+import { ViewSnippetCommand } from './commands/snippet/view.command.js';
+import { CreateSnippetCommand } from './commands/snippet/create.command.js';
+import { EditSnippetCommand } from './commands/snippet/edit.command.js';
+import { DeleteSnippetCommand } from './commands/snippet/delete.command.js';
+import { WatchSnippetCommand } from './commands/snippet/watch.command.js';
+import { UnwatchSnippetCommand } from './commands/snippet/unwatch.command.js';
+import { ListSnippetCommentsCommand } from './commands/snippet/comments.list.command.js';
+import { AddSnippetCommentCommand } from './commands/snippet/comments.add.command.js';
+import { EditSnippetCommentCommand } from './commands/snippet/comments.edit.command.js';
+import { DeleteSnippetCommentCommand } from './commands/snippet/comments.delete.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -113,6 +127,14 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     );
     const axiosInstance = createApiClient(configService);
     return new CommitStatusesApi(undefined, undefined, axiosInstance);
+  });
+
+  container.register(ServiceTokens.SnippetsApi, () => {
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const axiosInstance = createApiClient(configService);
+    return new SnippetsApi(undefined, undefined, axiosInstance);
   });
 
   container.register(ServiceTokens.ContextService, () => {
@@ -518,6 +540,150 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
       ServiceTokens.OutputService
     );
     return new ChecksPRCommand(commitStatusesApi, contextService, output);
+  });
+
+  // Register snippet commands
+  container.register(ServiceTokens.ListSnippetsCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new ListSnippetsCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.ViewSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new ViewSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.CreateSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new CreateSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.EditSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new EditSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.DeleteSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new DeleteSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.WatchSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new WatchSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.UnwatchSnippetCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new UnwatchSnippetCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.ListSnippetCommentsCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new ListSnippetCommentsCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.AddSnippetCommentCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new AddSnippetCommentCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.EditSnippetCommentCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new EditSnippetCommentCommand(snippetsApi, configService, output);
+  });
+
+  container.register(ServiceTokens.DeleteSnippetCommentCommand, () => {
+    const snippetsApi = container.resolve<SnippetsApi>(
+      ServiceTokens.SnippetsApi
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new DeleteSnippetCommentCommand(snippetsApi, configService, output);
   });
 
   // Register config commands

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -11,7 +11,9 @@ import {
   VersionService,
   OAuthService,
   createApiClient,
+  SnippetFilesService,
 } from './services/index.js';
+import type { AxiosInstance } from 'axios';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -150,12 +152,28 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     return new CommitStatusesApi(undefined, undefined, axiosInstance);
   });
 
-  container.register(ServiceTokens.SnippetsApi, () => {
+  container.register(ServiceTokens.SnippetsAxios, () => {
     const configService = container.resolve<ConfigService>(
       ServiceTokens.ConfigService
     );
-    const axiosInstance = createApiClient(configService);
+    const oauthService = container.resolve<OAuthService>(
+      ServiceTokens.OAuthService
+    );
+    return createApiClient(configService, oauthService);
+  });
+
+  container.register(ServiceTokens.SnippetsApi, () => {
+    const axiosInstance = container.resolve<AxiosInstance>(
+      ServiceTokens.SnippetsAxios
+    );
     return new SnippetsApi(undefined, undefined, axiosInstance);
+  });
+
+  container.register(ServiceTokens.SnippetFilesService, () => {
+    const axiosInstance = container.resolve<AxiosInstance>(
+      ServiceTokens.SnippetsAxios
+    );
+    return new SnippetFilesService(axiosInstance);
   });
 
   container.register(ServiceTokens.ContextService, () => {
@@ -590,18 +608,26 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const snippetsApi = container.resolve<SnippetsApi>(
       ServiceTokens.SnippetsApi
     );
+    const snippetFilesService = container.resolve<SnippetFilesService>(
+      ServiceTokens.SnippetFilesService
+    );
     const configService = container.resolve<ConfigService>(
       ServiceTokens.ConfigService
     );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new ViewSnippetCommand(snippetsApi, configService, output);
+    return new ViewSnippetCommand(
+      snippetsApi,
+      snippetFilesService,
+      configService,
+      output
+    );
   });
 
   container.register(ServiceTokens.CreateSnippetCommand, () => {
-    const snippetsApi = container.resolve<SnippetsApi>(
-      ServiceTokens.SnippetsApi
+    const snippetFilesService = container.resolve<SnippetFilesService>(
+      ServiceTokens.SnippetFilesService
     );
     const configService = container.resolve<ConfigService>(
       ServiceTokens.ConfigService
@@ -609,12 +635,12 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new CreateSnippetCommand(snippetsApi, configService, output);
+    return new CreateSnippetCommand(snippetFilesService, configService, output);
   });
 
   container.register(ServiceTokens.EditSnippetCommand, () => {
-    const snippetsApi = container.resolve<SnippetsApi>(
-      ServiceTokens.SnippetsApi
+    const snippetFilesService = container.resolve<SnippetFilesService>(
+      ServiceTokens.SnippetFilesService
     );
     const configService = container.resolve<ConfigService>(
       ServiceTokens.ConfigService
@@ -622,7 +648,7 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new EditSnippetCommand(snippetsApi, configService, output);
+    return new EditSnippetCommand(snippetFilesService, configService, output);
   });
 
   container.register(ServiceTokens.DeleteSnippetCommand, () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
       'auth',
       'repo',
       'pr',
+      'snippet',
       'config',
       'completion',
       '--help',
@@ -60,6 +61,17 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
       );
     } else if (env.prev === 'reviewers') {
       completions.push('list', 'add', 'remove');
+    } else if (env.prev === 'snippet') {
+      completions.push(
+        'list',
+        'view',
+        'create',
+        'edit',
+        'delete',
+        'watch',
+        'unwatch',
+        'comments'
+      );
     } else if (env.prev === 'config') {
       completions.push('get', 'set', 'list');
     } else if (env.prev === 'completion') {
@@ -850,6 +862,250 @@ prReviewersCmd
 cli.addCommand(prCmd);
 prCmd.addCommand(prCommentsCmd);
 prCmd.addCommand(prReviewersCmd);
+
+// Snippet commands
+const snippetCmd = new Command('snippet').description('Manage snippets');
+
+snippetCmd
+  .command('list')
+  .description('List snippets in a workspace')
+  .option('--role <role>', 'Filter by role (owner, contributor, member)')
+  .option('--limit <number>', 'Maximum number of snippets to list', '25')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb snippet list',
+        'bb snippet list --role owner',
+        'bb snippet list --limit 50 --json',
+      ],
+      validValues: {
+        'Valid roles': ['owner', 'contributor', 'member'],
+      },
+      defaults: { limit: '25' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListSnippetsCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('view <id>')
+  .description('View snippet details')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet view kypj', 'bb snippet view kypj --json'],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewSnippetCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('create')
+  .description('Create a new snippet')
+  .option('-t, --title <title>', 'Snippet title')
+  .option('-f, --file <path...>', 'File(s) to include')
+  .option('--private', 'Create a private snippet (default)')
+  .option('--public', 'Create a public snippet')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb snippet create -t "My snippet" -f file.txt',
+        'bb snippet create -t "Config files" -f config.yml -f setup.sh --public',
+      ],
+      defaults: { private: 'true (visibility is private unless --public)' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.CreateSnippetCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('edit <id>')
+  .description('Edit a snippet')
+  .option('-t, --title <title>', 'New snippet title')
+  .option('--private', 'Make snippet private')
+  .option('--public', 'Make snippet public')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb snippet edit kypj -t "New title"',
+        'bb snippet edit kypj --public',
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.EditSnippetCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('delete <id>')
+  .description('Delete a snippet')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet delete kypj', 'bb snippet delete kypj --yes'],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.DeleteSnippetCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('watch <id>')
+  .description('Watch a snippet')
+  .addHelpText('after', buildHelpText({ examples: ['bb snippet watch kypj'] }))
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.WatchSnippetCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd
+  .command('unwatch <id>')
+  .description('Stop watching a snippet')
+  .addHelpText(
+    'after',
+    buildHelpText({ examples: ['bb snippet unwatch kypj'] })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.UnwatchSnippetCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+const snippetCommentsCmd = new Command('comments').description(
+  'Manage snippet comments'
+);
+
+snippetCommentsCmd
+  .command('list <id>')
+  .description('List comments on a snippet')
+  .option('--limit <number>', 'Maximum number of comments', '25')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb snippet comments list kypj',
+        'bb snippet comments list kypj --limit 50 --json',
+      ],
+      defaults: { limit: '25' },
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListSnippetCommentsCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCommentsCmd
+  .command('add <id>')
+  .description('Add a comment to a snippet')
+  .option('-m, --message <text>', 'Comment message')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet comments add kypj -m "Great snippet!"'],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.AddSnippetCommentCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCommentsCmd
+  .command('edit <snippet-id> <comment-id> <message>')
+  .description('Edit a comment on a snippet')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet comments edit kypj 123 "Updated comment"'],
+    })
+  )
+  .action(async (snippetId, commentId, message, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.EditSnippetCommentCommand,
+      withGlobalOptions({ snippetId, commentId, message }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCommentsCmd
+  .command('delete <snippet-id> <comment-id>')
+  .description('Delete a comment on a snippet')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet comments delete kypj 123 --yes'],
+    })
+  )
+  .action(async (snippetId, commentId, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.DeleteSnippetCommentCommand,
+      withGlobalOptions({ snippetId, commentId, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+snippetCmd.addCommand(snippetCommentsCmd);
+cli.addCommand(snippetCmd);
 
 // Config commands
 const configCmd = new Command('config').description('Manage configuration');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,12 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
         'unwatch',
         'comments'
       );
+    } else if (
+      env.prev === 'comments' &&
+      typeof env.line === 'string' &&
+      env.line.includes(' snippet ')
+    ) {
+      completions.push('list', 'add', 'edit', 'delete');
     } else if (env.prev === 'config') {
       completions.push('get', 'set', 'list');
     } else if (env.prev === 'completion') {
@@ -913,10 +919,20 @@ snippetCmd
 snippetCmd
   .command('view <id>')
   .description('View snippet details')
+  .option(
+    '-f, --file <name>',
+    'Print contents of a specific file in the snippet'
+  )
+  .option('--files', 'Print contents of all files in the snippet')
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb snippet view kypj', 'bb snippet view kypj --json'],
+      examples: [
+        'bb snippet view kypj',
+        'bb snippet view kypj --json',
+        'bb snippet view kypj --file foo.txt',
+        'bb snippet view kypj --files',
+      ],
     })
   )
   .action(async (id, options) => {
@@ -962,12 +978,17 @@ snippetCmd
   .option('-t, --title <title>', 'New snippet title')
   .option('--private', 'Make snippet private')
   .option('--public', 'Make snippet public')
+  .option(
+    '-f, --file <path...>',
+    'Replace/add file(s) (sends multipart update)'
+  )
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb snippet edit kypj -t "New title"',
         'bb snippet edit kypj --public',
+        'bb snippet edit kypj -f updated.txt',
       ],
     })
   )

--- a/src/commands/repo/clone.command.ts
+++ b/src/commands/repo/clone.command.ts
@@ -9,6 +9,7 @@ import type {
   IConfigService,
   IOutputService,
 } from '../../core/interfaces/services.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CloneOptions {
@@ -65,17 +66,7 @@ export class CloneCommand extends BaseCommand<
     let repoSlug: string;
 
     if (parts.length === 1) {
-      const config = await this.configService.getConfig();
-
-      if (!config.defaultWorkspace) {
-        throw new BBError({
-          code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-          message:
-            'No workspace specified. Use workspace/repo format or set a default workspace.',
-        });
-      }
-
-      workspace = config.defaultWorkspace;
+      workspace = await resolveWorkspace(this.configService);
       repoSlug = parts[0];
     } else if (parts.length === 2) {
       workspace = parts[0];

--- a/src/commands/repo/create.command.ts
+++ b/src/commands/repo/create.command.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
 import { getCloneLinks, getLinkHref } from '../../services/response-parsers.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface CreateRepoOptions {
   workspace?: string;
@@ -43,7 +43,10 @@ export class CreateRepoCommand extends BaseCommand<
     const name = this.requireOption(options.name, 'name');
     const isPublic = options.public === true;
 
-    const workspace = await this.resolveWorkspace(options.workspace);
+    const workspace = await resolveWorkspace(
+      this.configService,
+      options.workspace ?? context.globalOptions.workspace
+    );
 
     const request: {
       type: 'repository';
@@ -93,23 +96,5 @@ export class CreateRepoCommand extends BaseCommand<
         `  ${this.output.dim('Clone:')} git clone ${sshClone.href}`
       );
     }
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi, Repository } from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface ListReposOptions {
   workspace?: string;
@@ -33,7 +33,8 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     options: ListReposOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
     const limit = parseLimit(options.limit);
@@ -75,23 +76,5 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     ]);
 
     this.output.table(['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'], rows);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/comments.add.command.ts
+++ b/src/commands/snippet/comments.add.command.ts
@@ -1,0 +1,96 @@
+/**
+ * Add snippet comment command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface AddSnippetCommentOptions {
+  workspace?: string;
+  message?: string;
+}
+
+export class AddSnippetCommentCommand extends BaseCommand<
+  { id: string } & AddSnippetCommentOptions,
+  void
+> {
+  public readonly name = 'comment';
+  public readonly description = 'Add a comment to a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & AddSnippetCommentOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const message = this.requireOption(
+      options.message,
+      'message',
+      'Comment message is required. Use --message option.'
+    );
+
+    const body = {
+      type: 'snippet_comment',
+      content: {
+        raw: message,
+      },
+    } as unknown as SnippetComment;
+
+    const response =
+      await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsPost({
+        workspace,
+        encodedId: options.id,
+        body,
+      });
+
+    const comment = response.data;
+    const commentId = (comment as unknown as Record<string, unknown>).id;
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.id,
+        comment,
+      });
+      return;
+    }
+
+    this.output.success(
+      `Added comment${commentId ? ` #${commentId}` : ''} to snippet ${options.id}`
+    );
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/comments.add.command.ts
+++ b/src/commands/snippet/comments.add.command.ts
@@ -9,7 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface AddSnippetCommentOptions {
   workspace?: string;
@@ -20,7 +20,7 @@ export class AddSnippetCommentCommand extends BaseCommand<
   { id: string } & AddSnippetCommentOptions,
   void
 > {
-  public readonly name = 'comment';
+  public readonly name = 'add';
   public readonly description = 'Add a comment to a snippet';
 
   constructor(
@@ -35,7 +35,8 @@ export class AddSnippetCommentCommand extends BaseCommand<
     options: { id: string } & AddSnippetCommentOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -74,23 +75,5 @@ export class AddSnippetCommentCommand extends BaseCommand<
     this.output.success(
       `Added comment${commentId ? ` #${commentId}` : ''} to snippet ${options.id}`
     );
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/comments.delete.command.ts
+++ b/src/commands/snippet/comments.delete.command.ts
@@ -1,0 +1,93 @@
+/**
+ * Delete snippet comment command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface DeleteSnippetCommentOptions {
+  workspace?: string;
+  yes?: boolean;
+}
+
+export class DeleteSnippetCommentCommand extends BaseCommand<
+  { snippetId: string; commentId: string } & DeleteSnippetCommentOptions,
+  void
+> {
+  public readonly name = 'delete-comment';
+  public readonly description = 'Delete a comment on a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: {
+      snippetId: string;
+      commentId: string;
+    } & DeleteSnippetCommentOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+
+    if (!options.yes) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          `This will permanently delete comment #${commentId} on snippet ${options.snippetId}.\n` +
+          'Use --yes to confirm deletion.',
+      });
+    }
+
+    await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsCommentIdDelete({
+      workspace,
+      encodedId: options.snippetId,
+      commentId,
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.snippetId,
+        commentId,
+      });
+      return;
+    }
+
+    this.output.success(
+      `Deleted comment #${commentId} on snippet ${options.snippetId}`
+    );
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/comments.delete.command.ts
+++ b/src/commands/snippet/comments.delete.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteSnippetCommentOptions {
@@ -20,7 +21,7 @@ export class DeleteSnippetCommentCommand extends BaseCommand<
   { snippetId: string; commentId: string } & DeleteSnippetCommentOptions,
   void
 > {
-  public readonly name = 'delete-comment';
+  public readonly name = 'delete';
   public readonly description = 'Delete a comment on a snippet';
 
   constructor(
@@ -38,7 +39,8 @@ export class DeleteSnippetCommentCommand extends BaseCommand<
     } & DeleteSnippetCommentOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -71,23 +73,5 @@ export class DeleteSnippetCommentCommand extends BaseCommand<
     this.output.success(
       `Deleted comment #${commentId} on snippet ${options.snippetId}`
     );
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/comments.edit.command.ts
+++ b/src/commands/snippet/comments.edit.command.ts
@@ -1,0 +1,97 @@
+/**
+ * Edit snippet comment command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface EditSnippetCommentOptions {
+  workspace?: string;
+}
+
+export class EditSnippetCommentCommand extends BaseCommand<
+  {
+    snippetId: string;
+    commentId: string;
+    message: string;
+  } & EditSnippetCommentOptions,
+  void
+> {
+  public readonly name = 'edit-comment';
+  public readonly description = 'Edit a comment on a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: {
+      snippetId: string;
+      commentId: string;
+      message: string;
+    } & EditSnippetCommentOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+
+    const body = {
+      type: 'snippet_comment',
+      content: {
+        raw: options.message,
+      },
+    } as unknown as SnippetComment;
+
+    const response =
+      await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsCommentIdPut({
+        workspace,
+        encodedId: options.snippetId,
+        commentId,
+        body,
+      });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.snippetId,
+        comment: response.data,
+      });
+      return;
+    }
+
+    this.output.success(
+      `Updated comment #${commentId} on snippet ${options.snippetId}`
+    );
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/comments.edit.command.ts
+++ b/src/commands/snippet/comments.edit.command.ts
@@ -9,7 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface EditSnippetCommentOptions {
   workspace?: string;
@@ -23,7 +23,7 @@ export class EditSnippetCommentCommand extends BaseCommand<
   } & EditSnippetCommentOptions,
   void
 > {
-  public readonly name = 'edit-comment';
+  public readonly name = 'edit';
   public readonly description = 'Edit a comment on a snippet';
 
   constructor(
@@ -42,7 +42,8 @@ export class EditSnippetCommentCommand extends BaseCommand<
     } & EditSnippetCommentOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -75,23 +76,5 @@ export class EditSnippetCommentCommand extends BaseCommand<
     this.output.success(
       `Updated comment #${commentId} on snippet ${options.snippetId}`
     );
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -14,7 +14,7 @@ import {
   getRawContent,
   getUserDisplayName,
 } from '../../services/response-parsers.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface ListSnippetCommentsOptions {
   workspace?: string;
@@ -25,7 +25,7 @@ export class ListSnippetCommentsCommand extends BaseCommand<
   { id: string } & ListSnippetCommentsOptions,
   void
 > {
-  public readonly name = 'comments';
+  public readonly name = 'list';
   public readonly description = 'List comments on a snippet';
 
   constructor(
@@ -40,7 +40,8 @@ export class ListSnippetCommentsCommand extends BaseCommand<
     options: { id: string } & ListSnippetCommentsOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
     const limit = parseLimit(options.limit);
@@ -90,23 +91,5 @@ export class ListSnippetCommentsCommand extends BaseCommand<
     });
 
     this.output.table(['ID', 'AUTHOR', 'DATE', 'CONTENT'], rows);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -1,0 +1,112 @@
+/**
+ * List snippet comments command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  getRawContent,
+  getUserDisplayName,
+} from '../../services/response-parsers.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface ListSnippetCommentsOptions {
+  workspace?: string;
+  limit?: string;
+}
+
+export class ListSnippetCommentsCommand extends BaseCommand<
+  { id: string } & ListSnippetCommentsOptions,
+  void
+> {
+  public readonly name = 'comments';
+  public readonly description = 'List comments on a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & ListSnippetCommentsOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+    const limit = parseLimit(options.limit);
+
+    const comments = await collectPages<SnippetComment>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsGet(
+            {
+              workspace,
+              encodedId: options.id,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
+
+        return response.data;
+      },
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace,
+        snippetId: options.id,
+        count: comments.length,
+        comments,
+      });
+      return;
+    }
+
+    if (comments.length === 0) {
+      this.output.info('No comments found on this snippet');
+      return;
+    }
+
+    const record = comments as unknown as Record<string, unknown>[];
+    const rows = record.map((comment) => {
+      const content = getRawContent(comment.content) ?? '';
+      return [
+        String((comment.id as number) ?? ''),
+        getUserDisplayName(comment.user) ?? 'Unknown',
+        this.output.formatDate((comment.created_on as string) ?? ''),
+        content.slice(0, 60) + (content.length > 60 ? '...' : ''),
+      ];
+    });
+
+    this.output.table(['ID', 'AUTHOR', 'DATE', 'CONTENT'], rows);
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/create.command.ts
+++ b/src/commands/snippet/create.command.ts
@@ -1,17 +1,21 @@
 /**
  * Create snippet command implementation
+ *
+ * Bitbucket's POST /snippets/{workspace} requires multipart/form-data with
+ * at least one `file` part. We bypass the generated OpenAPI client (which
+ * only serializes JSON) and use SnippetFilesService for the upload.
  */
 
 import fs from 'node:fs';
-import path from 'node:path';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
   IConfigService,
   IOutputService,
+  ISnippetFilesService,
 } from '../../core/interfaces/services.js';
-import type { Snippet, SnippetsApi } from '../../generated/api.js';
 import { getLinkHref } from '../../services/response-parsers.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface CreateSnippetOptions {
@@ -30,7 +34,7 @@ export class CreateSnippetCommand extends BaseCommand<
   public readonly description = 'Create a snippet';
 
   constructor(
-    private readonly snippetsApi: SnippetsApi,
+    private readonly snippetFilesService: ISnippetFilesService,
     private readonly configService: IConfigService,
     output: IOutputService
   ) {
@@ -41,7 +45,8 @@ export class CreateSnippetCommand extends BaseCommand<
     options: CreateSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -58,7 +63,13 @@ export class CreateSnippetCommand extends BaseCommand<
       });
     }
 
-    // Validate files exist before making API call
+    if (options.private && options.public) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: '--private and --public cannot both be set.',
+      });
+    }
+
     for (const filePath of options.file) {
       if (!fs.existsSync(filePath)) {
         throw new BBError({
@@ -71,21 +82,12 @@ export class CreateSnippetCommand extends BaseCommand<
 
     const isPrivate = !options.public;
 
-    // Build snippet body - file content requires multipart, but for the
-    // generated client we send metadata via JSON. The generated API client
-    // sends application/json which only supports metadata.
-    // We create the snippet with metadata first, then note the limitation.
-    const body: Snippet = {
-      title,
-      is_private: isPrivate,
-    } as Snippet;
-
-    const response = await this.snippetsApi.snippetsWorkspacePost({
+    const snippet = (await this.snippetFilesService.createWithFiles({
       workspace,
-      body,
-    });
-
-    const snippet = response.data;
+      title,
+      isPrivate,
+      files: options.file.map((path) => ({ path })),
+    })) as Record<string, unknown>;
 
     if (context.globalOptions.json) {
       this.output.json(snippet);
@@ -93,34 +95,13 @@ export class CreateSnippetCommand extends BaseCommand<
     }
 
     const visibility = isPrivate ? 'private' : 'public';
-    const htmlHref = getLinkHref(
-      (snippet as Record<string, unknown>).links,
-      'html'
-    );
+    const htmlHref = getLinkHref(snippet.links, 'html');
 
     this.output.success(
-      `Created snippet ${snippet.id ?? ''} "${title}" (${visibility})`
+      `Created snippet ${String(snippet.id ?? '')} "${title}" (${visibility})`
     );
     if (htmlHref) {
       this.output.text(`  ${htmlHref}`);
     }
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/create.command.ts
+++ b/src/commands/snippet/create.command.ts
@@ -1,0 +1,126 @@
+/**
+ * Create snippet command implementation
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Snippet, SnippetsApi } from '../../generated/api.js';
+import { getLinkHref } from '../../services/response-parsers.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface CreateSnippetOptions {
+  workspace?: string;
+  title?: string;
+  file?: string[];
+  private?: boolean;
+  public?: boolean;
+}
+
+export class CreateSnippetCommand extends BaseCommand<
+  CreateSnippetOptions,
+  void
+> {
+  public readonly name = 'create';
+  public readonly description = 'Create a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: CreateSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const title = this.requireOption(
+      options.title,
+      'title',
+      'Snippet title is required. Use --title option.'
+    );
+
+    if (!options.file || options.file.length === 0) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: 'At least one file is required. Use --file option.',
+      });
+    }
+
+    // Validate files exist before making API call
+    for (const filePath of options.file) {
+      if (!fs.existsSync(filePath)) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: `File not found: ${filePath}`,
+          context: { file: filePath },
+        });
+      }
+    }
+
+    const isPrivate = !options.public;
+
+    // Build snippet body - file content requires multipart, but for the
+    // generated client we send metadata via JSON. The generated API client
+    // sends application/json which only supports metadata.
+    // We create the snippet with metadata first, then note the limitation.
+    const body: Snippet = {
+      title,
+      is_private: isPrivate,
+    } as Snippet;
+
+    const response = await this.snippetsApi.snippetsWorkspacePost({
+      workspace,
+      body,
+    });
+
+    const snippet = response.data;
+
+    if (context.globalOptions.json) {
+      this.output.json(snippet);
+      return;
+    }
+
+    const visibility = isPrivate ? 'private' : 'public';
+    const htmlHref = getLinkHref(
+      (snippet as Record<string, unknown>).links,
+      'html'
+    );
+
+    this.output.success(
+      `Created snippet ${snippet.id ?? ''} "${title}" (${visibility})`
+    );
+    if (htmlHref) {
+      this.output.text(`  ${htmlHref}`);
+    }
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/delete.command.ts
+++ b/src/commands/snippet/delete.command.ts
@@ -1,0 +1,85 @@
+/**
+ * Delete snippet command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface DeleteSnippetOptions {
+  workspace?: string;
+  yes?: boolean;
+}
+
+export class DeleteSnippetCommand extends BaseCommand<
+  { id: string } & DeleteSnippetOptions,
+  void
+> {
+  public readonly name = 'delete';
+  public readonly description = 'Delete a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & DeleteSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    if (!options.yes) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          `This will permanently delete snippet ${options.id}.\n` +
+          'Use --yes to confirm deletion.',
+      });
+    }
+
+    await this.snippetsApi.snippetsWorkspaceEncodedIdDelete({
+      workspace,
+      encodedId: options.id,
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.id,
+        workspace,
+      });
+      return;
+    }
+
+    this.output.success(`Deleted snippet ${options.id}`);
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/delete.command.ts
+++ b/src/commands/snippet/delete.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteSnippetOptions {
@@ -35,7 +36,8 @@ export class DeleteSnippetCommand extends BaseCommand<
     options: { id: string } & DeleteSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -63,23 +65,5 @@ export class DeleteSnippetCommand extends BaseCommand<
     }
 
     this.output.success(`Deleted snippet ${options.id}`);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/edit.command.ts
+++ b/src/commands/snippet/edit.command.ts
@@ -1,0 +1,97 @@
+/**
+ * Edit snippet command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface EditSnippetOptions {
+  workspace?: string;
+  title?: string;
+  private?: boolean;
+  public?: boolean;
+}
+
+export class EditSnippetCommand extends BaseCommand<
+  { id: string } & EditSnippetOptions,
+  void
+> {
+  public readonly name = 'edit';
+  public readonly description = 'Edit a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & EditSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    if (
+      !options.title &&
+      options.private === undefined &&
+      options.public === undefined
+    ) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: 'At least one of --title, --private, or --public is required.',
+      });
+    }
+
+    const response = await this.snippetsApi.snippetsWorkspaceEncodedIdPut(
+      {
+        encodedId: options.id,
+        workspace,
+      },
+      {
+        data: {
+          ...(options.title ? { title: options.title } : {}),
+          ...(options.private !== undefined || options.public !== undefined
+            ? { is_private: !options.public }
+            : {}),
+        },
+      }
+    );
+
+    const snippet = response.data;
+
+    if (context.globalOptions.json) {
+      this.output.json(snippet);
+      return;
+    }
+
+    this.output.success(`Updated snippet ${options.id}`);
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/edit.command.ts
+++ b/src/commands/snippet/edit.command.ts
@@ -1,14 +1,21 @@
 /**
  * Edit snippet command implementation
+ *
+ * Supports metadata-only edits (title / visibility) via a JSON PUT and
+ * file replacement / addition via a multipart PUT. The generated OpenAPI
+ * client doesn't model either body shape, so we route through
+ * SnippetFilesService.
  */
 
+import fs from 'node:fs';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
   IConfigService,
   IOutputService,
+  ISnippetFilesService,
 } from '../../core/interfaces/services.js';
-import type { SnippetsApi } from '../../generated/api.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface EditSnippetOptions {
@@ -16,6 +23,7 @@ export interface EditSnippetOptions {
   title?: string;
   private?: boolean;
   public?: boolean;
+  file?: string[];
 }
 
 export class EditSnippetCommand extends BaseCommand<
@@ -26,7 +34,7 @@ export class EditSnippetCommand extends BaseCommand<
   public readonly description = 'Edit a snippet';
 
   constructor(
-    private readonly snippetsApi: SnippetsApi,
+    private readonly snippetFilesService: ISnippetFilesService,
     private readonly configService: IConfigService,
     output: IOutputService
   ) {
@@ -37,37 +45,59 @@ export class EditSnippetCommand extends BaseCommand<
     options: { id: string } & EditSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
-    if (
-      !options.title &&
-      options.private === undefined &&
-      options.public === undefined
-    ) {
+    const hasTitle = options.title !== undefined;
+    const hasVisibility =
+      options.private !== undefined || options.public !== undefined;
+    const hasFiles = options.file !== undefined && options.file.length > 0;
+
+    if (!hasTitle && !hasVisibility && !hasFiles) {
       throw new BBError({
         code: ErrorCode.VALIDATION_REQUIRED,
-        message: 'At least one of --title, --private, or --public is required.',
+        message:
+          'At least one of --title, --private, --public, or --file is required.',
       });
     }
 
-    const response = await this.snippetsApi.snippetsWorkspaceEncodedIdPut(
-      {
-        encodedId: options.id,
-        workspace,
-      },
-      {
-        data: {
-          ...(options.title ? { title: options.title } : {}),
-          ...(options.private !== undefined || options.public !== undefined
-            ? { is_private: !options.public }
-            : {}),
-        },
-      }
-    );
+    if (options.private && options.public) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: '--private and --public cannot both be set.',
+      });
+    }
 
-    const snippet = response.data;
+    if (hasFiles) {
+      for (const filePath of options.file!) {
+        if (!fs.existsSync(filePath)) {
+          throw new BBError({
+            code: ErrorCode.VALIDATION_INVALID,
+            message: `File not found: ${filePath}`,
+            context: { file: filePath },
+          });
+        }
+      }
+    }
+
+    const isPrivate = hasVisibility ? !options.public : undefined;
+
+    const snippet = hasFiles
+      ? await this.snippetFilesService.editWithFiles({
+          workspace,
+          encodedId: options.id,
+          title: options.title,
+          isPrivate,
+          files: options.file!.map((path) => ({ path })),
+        })
+      : await this.snippetFilesService.editMetadata({
+          workspace,
+          encodedId: options.id,
+          title: options.title,
+          isPrivate,
+        });
 
     if (context.globalOptions.json) {
       this.output.json(snippet);
@@ -75,23 +105,5 @@ export class EditSnippetCommand extends BaseCommand<
     }
 
     this.output.success(`Updated snippet ${options.id}`);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/list.command.ts
+++ b/src/commands/snippet/list.command.ts
@@ -9,11 +9,16 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { Snippet, SnippetsApi } from '../../generated/api.js';
+import { SnippetsWorkspaceGetRoleEnum } from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
 import { getUserDisplayName } from '../../services/response-parsers.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
-const VALID_ROLES = ['owner', 'contributor', 'member'] as const;
+const VALID_ROLES = Object.values(SnippetsWorkspaceGetRoleEnum) as readonly (
+  | 'owner'
+  | 'contributor'
+  | 'member'
+)[];
 
 export interface ListSnippetsOptions {
   workspace?: string;
@@ -40,7 +45,8 @@ export class ListSnippetsCommand extends BaseCommand<
     options: ListSnippetsOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
     const limit = parseLimit(options.limit);
@@ -92,23 +98,5 @@ export class ListSnippetsCommand extends BaseCommand<
       ['ID', 'TITLE', 'VISIBILITY', 'CREATOR', 'UPDATED'],
       rows
     );
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/list.command.ts
+++ b/src/commands/snippet/list.command.ts
@@ -1,0 +1,114 @@
+/**
+ * List snippets command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Snippet, SnippetsApi } from '../../generated/api.js';
+import { collectPages, parseLimit } from '../../services/pagination.js';
+import { getUserDisplayName } from '../../services/response-parsers.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+const VALID_ROLES = ['owner', 'contributor', 'member'] as const;
+
+export interface ListSnippetsOptions {
+  workspace?: string;
+  role?: string;
+  limit?: string;
+}
+
+export class ListSnippetsCommand extends BaseCommand<
+  ListSnippetsOptions,
+  void
+> {
+  public readonly name = 'list';
+  public readonly description = 'List snippets';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListSnippetsOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+    const limit = parseLimit(options.limit);
+
+    const role = options.role
+      ? this.parseEnumOption(options.role, 'role', VALID_ROLES)
+      : undefined;
+
+    const snippets = await collectPages<Snippet>({
+      limit,
+      fetchPage: async (page, pagelen) => {
+        const response = await this.snippetsApi.snippetsWorkspaceGet(
+          {
+            workspace,
+            role: role as 'owner' | 'contributor' | 'member' | undefined,
+          },
+          {
+            params: { page, pagelen },
+          }
+        );
+
+        return response.data;
+      },
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace,
+        count: snippets.length,
+        snippets,
+      });
+      return;
+    }
+
+    if (snippets.length === 0) {
+      this.output.text('No snippets found');
+      return;
+    }
+
+    const rows = snippets.map((snippet) => [
+      String(snippet.id ?? ''),
+      snippet.title ?? '',
+      snippet.is_private ? 'private' : 'public',
+      getUserDisplayName(snippet.creator) ?? '',
+      this.output.formatDate(snippet.updated_on ?? ''),
+    ]);
+
+    this.output.table(
+      ['ID', 'TITLE', 'VISIBILITY', 'CREATOR', 'UPDATED'],
+      rows
+    );
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/unwatch.command.ts
+++ b/src/commands/snippet/unwatch.command.ts
@@ -9,7 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface UnwatchSnippetOptions {
   workspace?: string;
@@ -34,7 +34,8 @@ export class UnwatchSnippetCommand extends BaseCommand<
     options: { id: string } & UnwatchSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -53,23 +54,5 @@ export class UnwatchSnippetCommand extends BaseCommand<
     }
 
     this.output.success(`Stopped watching snippet ${options.id}`);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/unwatch.command.ts
+++ b/src/commands/snippet/unwatch.command.ts
@@ -1,0 +1,75 @@
+/**
+ * Unwatch snippet command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface UnwatchSnippetOptions {
+  workspace?: string;
+}
+
+export class UnwatchSnippetCommand extends BaseCommand<
+  { id: string } & UnwatchSnippetOptions,
+  void
+> {
+  public readonly name = 'unwatch';
+  public readonly description = 'Stop watching a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & UnwatchSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    await this.snippetsApi.snippetsWorkspaceEncodedIdWatchDelete({
+      workspace,
+      encodedId: options.id,
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.id,
+        watching: false,
+      });
+      return;
+    }
+
+    this.output.success(`Stopped watching snippet ${options.id}`);
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -7,16 +7,22 @@ import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
   IConfigService,
   IOutputService,
+  ISnippetFilesService,
 } from '../../core/interfaces/services.js';
 import type { Snippet, SnippetsApi } from '../../generated/api.js';
 import {
   getUserDisplayName,
   getLinkHref,
 } from '../../services/response-parsers.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface ViewSnippetOptions {
   workspace?: string;
+  /** Print contents of a specific file within the snippet */
+  file?: string;
+  /** Print contents of all files within the snippet */
+  files?: boolean;
 }
 
 export class ViewSnippetCommand extends BaseCommand<
@@ -28,6 +34,7 @@ export class ViewSnippetCommand extends BaseCommand<
 
   constructor(
     private readonly snippetsApi: SnippetsApi,
+    private readonly snippetFilesService: ISnippetFilesService,
     private readonly configService: IConfigService,
     output: IOutputService
   ) {
@@ -38,7 +45,8 @@ export class ViewSnippetCommand extends BaseCommand<
     options: { id: string } & ViewSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -47,17 +55,74 @@ export class ViewSnippetCommand extends BaseCommand<
       encodedId: options.id,
     });
 
-    const snippet = response.data;
+    const snippet = response.data as Snippet & Record<string, unknown>;
+    const fileNames = this.extractFileNames(snippet);
+
+    if (options.file !== undefined) {
+      if (!fileNames.includes(options.file)) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: `File not found in snippet: ${options.file}`,
+          context: { file: options.file, available: fileNames },
+        });
+      }
+      const content = await this.snippetFilesService.getFileContent(
+        workspace,
+        options.id,
+        options.file
+      );
+      if (context.globalOptions.json) {
+        this.output.json({ file: options.file, content });
+        return;
+      }
+      this.output.text(content);
+      return;
+    }
+
+    if (options.files) {
+      const contents: Record<string, string> = {};
+      for (const name of fileNames) {
+        contents[name] = await this.snippetFilesService.getFileContent(
+          workspace,
+          options.id,
+          name
+        );
+      }
+      if (context.globalOptions.json) {
+        this.output.json({ snippet, files: contents });
+        return;
+      }
+      this.renderSnippet(snippet, fileNames);
+      for (const name of fileNames) {
+        this.output.text('');
+        this.output.text(this.output.bold(`── ${name} ──`));
+        this.output.text(contents[name]);
+      }
+      return;
+    }
 
     if (context.globalOptions.json) {
       this.output.json(snippet);
       return;
     }
 
-    this.renderSnippet(snippet, workspace);
+    this.renderSnippet(snippet, fileNames);
   }
 
-  private renderSnippet(snippet: Snippet, workspace: string): void {
+  private extractFileNames(
+    snippet: Snippet & Record<string, unknown>
+  ): string[] {
+    const files = snippet.files;
+    if (files && typeof files === 'object') {
+      return Object.keys(files as Record<string, unknown>);
+    }
+    return [];
+  }
+
+  private renderSnippet(
+    snippet: Snippet & Record<string, unknown>,
+    fileNames: string[]
+  ): void {
     const visibility = snippet.is_private ? 'private' : 'public';
 
     this.output.text('');
@@ -88,46 +153,21 @@ export class ViewSnippetCommand extends BaseCommand<
       );
     }
 
-    // Files come through the dynamic properties of ModelObject
-    const files = (snippet as Record<string, unknown>).files;
-    if (files && typeof files === 'object') {
-      const fileNames = Object.keys(files as Record<string, unknown>);
-      if (fileNames.length > 0) {
-        this.output.text('');
-        this.output.text('Files:');
-        for (const name of fileNames) {
-          this.output.text(`  ${name}`);
-        }
+    if (fileNames.length > 0) {
+      this.output.text('');
+      this.output.text('Files:');
+      for (const name of fileNames) {
+        this.output.text(`  ${name}`);
       }
     }
 
-    const htmlHref = getLinkHref(
-      (snippet as Record<string, unknown>).links,
-      'html'
-    );
-    if (htmlHref) {
+    const url =
+      getLinkHref(snippet.links, 'html') ?? getLinkHref(snippet.links, 'self');
+    if (url) {
       this.output.text('');
-      this.output.text(this.output.cyan(htmlHref));
+      this.output.text(this.output.cyan(url));
     }
 
     this.output.text('');
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -1,0 +1,133 @@
+/**
+ * View snippet command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Snippet, SnippetsApi } from '../../generated/api.js';
+import {
+  getUserDisplayName,
+  getLinkHref,
+} from '../../services/response-parsers.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface ViewSnippetOptions {
+  workspace?: string;
+}
+
+export class ViewSnippetCommand extends BaseCommand<
+  { id: string } & ViewSnippetOptions,
+  void
+> {
+  public readonly name = 'view';
+  public readonly description = 'View snippet details';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & ViewSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const response = await this.snippetsApi.snippetsWorkspaceEncodedIdGet({
+      workspace,
+      encodedId: options.id,
+    });
+
+    const snippet = response.data;
+
+    if (context.globalOptions.json) {
+      this.output.json(snippet);
+      return;
+    }
+
+    this.renderSnippet(snippet, workspace);
+  }
+
+  private renderSnippet(snippet: Snippet, workspace: string): void {
+    const visibility = snippet.is_private ? 'private' : 'public';
+
+    this.output.text('');
+    this.output.text(
+      `${this.output.bold(String(snippet.id ?? ''))}  ${snippet.title ?? 'Untitled'}  ${this.output.gray(`[${visibility}]`)}`
+    );
+    this.output.text(this.output.gray('─'.repeat(60)));
+
+    const creator = getUserDisplayName(snippet.creator);
+    if (creator) {
+      this.output.text(`Creator:    ${creator}`);
+    }
+
+    const owner = getUserDisplayName(snippet.owner);
+    if (owner) {
+      this.output.text(`Owner:      ${owner}`);
+    }
+
+    if (snippet.created_on) {
+      this.output.text(
+        `Created:    ${this.output.formatDate(snippet.created_on)}`
+      );
+    }
+
+    if (snippet.updated_on) {
+      this.output.text(
+        `Updated:    ${this.output.formatDate(snippet.updated_on)}`
+      );
+    }
+
+    // Files come through the dynamic properties of ModelObject
+    const files = (snippet as Record<string, unknown>).files;
+    if (files && typeof files === 'object') {
+      const fileNames = Object.keys(files as Record<string, unknown>);
+      if (fileNames.length > 0) {
+        this.output.text('');
+        this.output.text('Files:');
+        for (const name of fileNames) {
+          this.output.text(`  ${name}`);
+        }
+      }
+    }
+
+    const htmlHref = getLinkHref(
+      (snippet as Record<string, unknown>).links,
+      'html'
+    );
+    if (htmlHref) {
+      this.output.text('');
+      this.output.text(this.output.cyan(htmlHref));
+    }
+
+    this.output.text('');
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/watch.command.ts
+++ b/src/commands/snippet/watch.command.ts
@@ -1,0 +1,75 @@
+/**
+ * Watch snippet command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { SnippetsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface WatchSnippetOptions {
+  workspace?: string;
+}
+
+export class WatchSnippetCommand extends BaseCommand<
+  { id: string } & WatchSnippetOptions,
+  void
+> {
+  public readonly name = 'watch';
+  public readonly description = 'Watch a snippet';
+
+  constructor(
+    private readonly snippetsApi: SnippetsApi,
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { id: string } & WatchSnippetOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    await this.snippetsApi.snippetsWorkspaceEncodedIdWatchPut({
+      workspace,
+      encodedId: options.id,
+    });
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        snippetId: options.id,
+        watching: true,
+      });
+      return;
+    }
+
+    this.output.success(`Now watching snippet ${options.id}`);
+  }
+
+  private async resolveWorkspace(workspace?: string): Promise<string> {
+    if (workspace) {
+      return workspace;
+    }
+
+    const config = await this.configService.getConfig();
+
+    if (!config.defaultWorkspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'No workspace specified. Use --workspace option or set a default workspace.',
+      });
+    }
+
+    return config.defaultWorkspace;
+  }
+}

--- a/src/commands/snippet/watch.command.ts
+++ b/src/commands/snippet/watch.command.ts
@@ -9,7 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { resolveWorkspace } from '../../services/workspace-resolver.js';
 
 export interface WatchSnippetOptions {
   workspace?: string;
@@ -34,7 +34,8 @@ export class WatchSnippetCommand extends BaseCommand<
     options: { id: string } & WatchSnippetOptions,
     context: CommandContext
   ): Promise<void> {
-    const workspace = await this.resolveWorkspace(
+    const workspace = await resolveWorkspace(
+      this.configService,
       options.workspace ?? context.globalOptions.workspace
     );
 
@@ -53,23 +54,5 @@ export class WatchSnippetCommand extends BaseCommand<
     }
 
     this.output.success(`Now watching snippet ${options.id}`);
-  }
-
-  private async resolveWorkspace(workspace?: string): Promise<string> {
-    if (workspace) {
-      return workspace;
-    }
-
-    const config = await this.configService.getConfig();
-
-    if (!config.defaultWorkspace) {
-      throw new BBError({
-        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
-        message:
-          'No workspace specified. Use --workspace option or set a default workspace.',
-      });
-    }
-
-    return config.defaultWorkspace;
   }
 }

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -174,6 +174,8 @@ export const ServiceTokens = {
 
   // API Clients - Snippets
   SnippetsApi: 'SnippetsApi',
+  SnippetsAxios: 'SnippetsAxios',
+  SnippetFilesService: 'SnippetFilesService',
 
   // Commands - Snippet
   ListSnippetsCommand: 'ListSnippetsCommand',

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -171,6 +171,22 @@ export const ServiceTokens = {
   RemoveReviewerPRCommand: 'RemoveReviewerPRCommand',
   ListReviewersPRCommand: 'ListReviewersPRCommand',
 
+  // API Clients - Snippets
+  SnippetsApi: 'SnippetsApi',
+
+  // Commands - Snippet
+  ListSnippetsCommand: 'ListSnippetsCommand',
+  ViewSnippetCommand: 'ViewSnippetCommand',
+  CreateSnippetCommand: 'CreateSnippetCommand',
+  EditSnippetCommand: 'EditSnippetCommand',
+  DeleteSnippetCommand: 'DeleteSnippetCommand',
+  WatchSnippetCommand: 'WatchSnippetCommand',
+  UnwatchSnippetCommand: 'UnwatchSnippetCommand',
+  ListSnippetCommentsCommand: 'ListSnippetCommentsCommand',
+  AddSnippetCommentCommand: 'AddSnippetCommentCommand',
+  EditSnippetCommentCommand: 'EditSnippetCommentCommand',
+  DeleteSnippetCommentCommand: 'DeleteSnippetCommentCommand',
+
   // Commands - Config
   GetConfigCommand: 'GetConfigCommand',
   SetConfigCommand: 'SetConfigCommand',

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -57,6 +57,37 @@ export interface IContextService {
 }
 
 /**
+ * Snippet files service interface - handles multipart create/edit and raw
+ * file-content fetches that the generated OpenAPI client does not model.
+ */
+export interface ISnippetFilesService {
+  createWithFiles(options: {
+    workspace: string;
+    title: string;
+    isPrivate: boolean;
+    files: Array<{ path: string; filename?: string }>;
+  }): Promise<unknown>;
+  editMetadata(options: {
+    workspace: string;
+    encodedId: string;
+    title?: string;
+    isPrivate?: boolean;
+  }): Promise<unknown>;
+  editWithFiles(options: {
+    workspace: string;
+    encodedId: string;
+    title?: string;
+    isPrivate?: boolean;
+    files: Array<{ path: string; filename?: string }>;
+  }): Promise<unknown>;
+  getFileContent(
+    workspace: string,
+    encodedId: string,
+    filePath: string
+  ): Promise<string>;
+}
+
+/**
  * Output service interface for formatting and displaying output
  */
 export interface IOutputService {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,8 @@ export { OutputService } from './output.service.js';
 export { VersionService } from './version.service.js';
 export { createApiClient } from './api-client.service.js';
 export { OAuthService } from './oauth.service.js';
+export { resolveWorkspace } from './workspace-resolver.js';
+export { SnippetFilesService } from './snippet-files.service.js';
 export {
   extractReviewerUuids,
   buildReviewersUpdateBody,

--- a/src/services/snippet-files.service.ts
+++ b/src/services/snippet-files.service.ts
@@ -1,0 +1,150 @@
+/**
+ * Service for snippet endpoints that need multipart uploads or raw file
+ * content. The generated OpenAPI client only models these endpoints as
+ * JSON — insufficient for Bitbucket's real contract, which requires
+ * `multipart/form-data` on create/edit with files.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AxiosInstance } from 'axios';
+
+export interface SnippetFileInput {
+  /** Absolute or relative path on disk */
+  path: string;
+  /** Name to use in the multipart part; defaults to basename(path) */
+  filename?: string;
+}
+
+export interface CreateSnippetMultipartOptions {
+  workspace: string;
+  title: string;
+  isPrivate: boolean;
+  files: SnippetFileInput[];
+}
+
+export interface EditSnippetMetadataOptions {
+  workspace: string;
+  encodedId: string;
+  title?: string;
+  isPrivate?: boolean;
+}
+
+export interface EditSnippetMultipartOptions {
+  workspace: string;
+  encodedId: string;
+  title?: string;
+  isPrivate?: boolean;
+  files: SnippetFileInput[];
+}
+
+export class SnippetFilesService {
+  constructor(private readonly axios: AxiosInstance) {}
+
+  public async createWithFiles(
+    options: CreateSnippetMultipartOptions
+  ): Promise<unknown> {
+    const form = this.buildForm(
+      options.title,
+      options.isPrivate,
+      options.files
+    );
+    const response = await this.axios.post(
+      `/snippets/${encodeURIComponent(options.workspace)}`,
+      form,
+      {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }
+    );
+    return response.data;
+  }
+
+  public async editMetadata(
+    options: EditSnippetMetadataOptions
+  ): Promise<unknown> {
+    const body: Record<string, unknown> = {};
+    if (options.title !== undefined) {
+      body.title = options.title;
+    }
+    if (options.isPrivate !== undefined) {
+      body.is_private = options.isPrivate;
+    }
+
+    const response = await this.axios.put(
+      `/snippets/${encodeURIComponent(options.workspace)}/${encodeURIComponent(options.encodedId)}`,
+      body,
+      { headers: { 'Content-Type': 'application/json' } }
+    );
+    return response.data;
+  }
+
+  public async editWithFiles(
+    options: EditSnippetMultipartOptions
+  ): Promise<unknown> {
+    const form = this.buildForm(
+      options.title,
+      options.isPrivate,
+      options.files
+    );
+    const response = await this.axios.put(
+      `/snippets/${encodeURIComponent(options.workspace)}/${encodeURIComponent(options.encodedId)}`,
+      form,
+      { headers: { 'Content-Type': 'multipart/form-data' } }
+    );
+    return response.data;
+  }
+
+  /**
+   * Fetch a single file's raw contents from a snippet.
+   */
+  public async getFileContent(
+    workspace: string,
+    encodedId: string,
+    filePath: string
+  ): Promise<string> {
+    const response = await this.axios.get<string>(
+      `/snippets/${encodeURIComponent(workspace)}/${encodeURIComponent(encodedId)}/files/${encodeFilePath(filePath)}`,
+      {
+        responseType: 'text',
+        transformResponse: [
+          (v: unknown) => (typeof v === 'string' ? v : String(v ?? '')),
+        ],
+        headers: { Accept: '*/*' },
+      }
+    );
+    return typeof response.data === 'string'
+      ? response.data
+      : String(response.data ?? '');
+  }
+
+  private buildForm(
+    title: string | undefined,
+    isPrivate: boolean | undefined,
+    files: SnippetFileInput[]
+  ): FormData {
+    const form = new FormData();
+
+    if (title !== undefined) {
+      form.append('title', title);
+    }
+    if (isPrivate !== undefined) {
+      form.append('is_private', isPrivate ? 'true' : 'false');
+    }
+
+    for (const file of files) {
+      const name = file.filename ?? path.basename(file.path);
+      const buffer = fs.readFileSync(file.path);
+      const blob = new Blob([buffer]);
+      form.append('file', blob, name);
+    }
+
+    return form;
+  }
+}
+
+function encodeFilePath(filePath: string): string {
+  return filePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}

--- a/src/services/workspace-resolver.ts
+++ b/src/services/workspace-resolver.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared workspace resolution for commands that don't need a full repo context
+ * (e.g. snippet commands which operate at workspace scope only).
+ */
+
+import type { IConfigService } from '../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../types/errors.js';
+
+const NO_WORKSPACE_MESSAGE =
+  'No workspace specified. Use --workspace option or set a default workspace with `bb config set defaultWorkspace <name>`.';
+
+export async function resolveWorkspace(
+  configService: IConfigService,
+  explicit?: string
+): Promise<string> {
+  if (explicit && explicit.length > 0) {
+    return explicit;
+  }
+
+  const config = await configService.getConfig();
+  if (config.defaultWorkspace && config.defaultWorkspace.length > 0) {
+    return config.defaultWorkspace;
+  }
+
+  throw new BBError({
+    code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+    message: NO_WORKSPACE_MESSAGE,
+  });
+}

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -21,8 +21,10 @@ import {
 } from '../setup.js';
 import type { SnippetsApi, Snippet } from '../../src/generated/api.js';
 import type { CommandContext } from '../../src/core/interfaces/commands.js';
+import type { ISnippetFilesService } from '../../src/core/interfaces/services.js';
 
-// Mock snippet data
+// --- Mock data ---
+
 const mockSnippet: Snippet & Record<string, unknown> = {
   type: 'snippet',
   id: 'kypj' as unknown as number,
@@ -63,6 +65,8 @@ const mockComment = {
   updated_on: '2026-01-15T12:00:00.000000+00:00',
 };
 
+// --- Helpers ---
+
 function extractPaginationParams(axiosOptions: unknown): {
   page: number;
   pagelen: number;
@@ -70,15 +74,12 @@ function extractPaginationParams(axiosOptions: unknown): {
   if (!axiosOptions || typeof axiosOptions !== 'object') {
     return { page: 1, pagelen: 25 };
   }
-
   const params = (axiosOptions as { params?: unknown }).params;
   if (!params || typeof params !== 'object') {
     return { page: 1, pagelen: 25 };
   }
-
   const pageValue = (params as { page?: unknown }).page;
   const pagelenValue = (params as { pagelen?: unknown }).pagelen;
-
   const page =
     typeof pageValue === 'number' && Number.isFinite(pageValue) && pageValue > 0
       ? pageValue
@@ -89,7 +90,6 @@ function extractPaginationParams(axiosOptions: unknown): {
     pagelenValue > 0
       ? pagelenValue
       : 25;
-
   return { page, pagelen };
 }
 
@@ -98,16 +98,62 @@ function getTableRows(logs: string[]): string[][] {
   if (!rowsLog) {
     return [];
   }
-
   return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+interface MockSnippetFilesServiceRecord {
+  create?: {
+    workspace: string;
+    title: string;
+    isPrivate: boolean;
+    files: Array<{ path: string; filename?: string }>;
+  };
+  editMetadata?: {
+    workspace: string;
+    encodedId: string;
+    title?: string;
+    isPrivate?: boolean;
+  };
+  editWithFiles?: {
+    workspace: string;
+    encodedId: string;
+    title?: string;
+    isPrivate?: boolean;
+    files: Array<{ path: string; filename?: string }>;
+  };
+  fileContentCalls: Array<{ filePath: string }>;
+}
+
+function createMockSnippetFilesService(fileContent = 'file contents here'): {
+  service: ISnippetFilesService;
+  record: MockSnippetFilesServiceRecord;
+} {
+  const record: MockSnippetFilesServiceRecord = { fileContentCalls: [] };
+  const service: ISnippetFilesService = {
+    async createWithFiles(options) {
+      record.create = { ...options };
+      return mockSnippet;
+    },
+    async editMetadata(options) {
+      record.editMetadata = { ...options };
+      return mockSnippet;
+    },
+    async editWithFiles(options) {
+      record.editWithFiles = { ...options };
+      return mockSnippet;
+    },
+    async getFileContent(_workspace, _encodedId, filePath) {
+      record.fileContentCalls.push({ filePath });
+      return fileContent;
+    },
+  };
+  return { service, record };
 }
 
 function createMockSnippetsApi(
   snippets: (typeof mockSnippet)[] = [mockSnippet],
-  options: {
-    onCreateCall?: (request: unknown) => void;
-    onDeleteCall?: (request: unknown) => void;
-  } = {}
+  comments: (typeof mockComment)[] = [mockComment],
+  options: { onDeleteCall?: (request: unknown) => void } = {}
 ): SnippetsApi {
   return {
     snippetsWorkspaceGet: async (_request: unknown, axiosOptions?: unknown) => {
@@ -115,7 +161,6 @@ function createMockSnippetsApi(
       const start = (page - 1) * pagelen;
       const end = start + pagelen;
       const values = snippets.slice(start, end);
-
       return {
         data: {
           values,
@@ -129,49 +174,35 @@ function createMockSnippetsApi(
         },
       };
     },
-    snippetsWorkspaceEncodedIdGet: async () => ({
-      data: mockSnippet,
-    }),
-    snippetsWorkspacePost: async (request: unknown) => {
-      options.onCreateCall?.(request);
-      return { data: mockSnippet };
-    },
-    snippetsWorkspaceEncodedIdPut: async () => ({
-      data: mockSnippet,
-    }),
+    snippetsWorkspaceEncodedIdGet: async () => ({ data: mockSnippet }),
     snippetsWorkspaceEncodedIdDelete: async (request: unknown) => {
       options.onDeleteCall?.(request);
       return { data: undefined };
     },
-    snippetsWorkspaceEncodedIdWatchPut: async () => ({
-      data: undefined,
-    }),
-    snippetsWorkspaceEncodedIdWatchDelete: async () => ({
-      data: undefined,
-    }),
+    snippetsWorkspaceEncodedIdWatchPut: async () => ({ data: undefined }),
+    snippetsWorkspaceEncodedIdWatchDelete: async () => ({ data: undefined }),
     snippetsWorkspaceEncodedIdCommentsGet: async (
       _request: unknown,
       axiosOptions?: unknown
     ) => {
       const { page, pagelen } = extractPaginationParams(axiosOptions);
-      const comments = [mockComment];
       const start = (page - 1) * pagelen;
       const end = start + pagelen;
       const values = comments.slice(start, end);
-
       return {
         data: {
           values,
           page,
           pagelen,
           size: comments.length,
-          next: undefined,
+          next:
+            end < comments.length
+              ? `https://api.bitbucket.org/2.0/snippets/workspace/kypj/comments?page=${page + 1}`
+              : undefined,
         },
       };
     },
-    snippetsWorkspaceEncodedIdCommentsPost: async () => ({
-      data: mockComment,
-    }),
+    snippetsWorkspaceEncodedIdCommentsPost: async () => ({ data: mockComment }),
     snippetsWorkspaceEncodedIdCommentsCommentIdPut: async () => ({
       data: mockComment,
     }),
@@ -203,7 +234,6 @@ describe('ListSnippetsCommand', () => {
 
     await cmd.run({ workspace: 'workspace' }, makeContext());
 
-    expect(output.logs.some((log) => log.startsWith('table:'))).toBe(true);
     const rows = getTableRows(output.logs);
     expect(rows.length).toBe(1);
     expect(rows[0][1]).toBe('Test snippet');
@@ -220,11 +250,9 @@ describe('ListSnippetsCommand', () => {
     await cmd.run({ workspace: 'workspace' }, makeContext(true));
 
     const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
     const data = JSON.parse(jsonLog!.substring(5));
     expect(data.workspace).toBe('workspace');
     expect(data.count).toBe(1);
-    expect(data.snippets).toHaveLength(1);
   });
 
   it('should show empty message when no snippets found', async () => {
@@ -268,7 +296,7 @@ describe('ListSnippetsCommand', () => {
     );
   });
 
-  it('should validate role option', async () => {
+  it('should reject invalid role', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
@@ -281,31 +309,31 @@ describe('ListSnippetsCommand', () => {
     );
   });
 
-  it('should pass role filter to API', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new ListSnippetsCommand(api, configService, output);
-
-    await cmd.run({ role: 'owner', workspace: 'workspace' }, makeContext(true));
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
+  it('should accept all three API-valid roles', async () => {
+    for (const role of ['owner', 'contributor', 'member']) {
+      const output = createMockOutputService();
+      const configService = createMockConfigService({
+        defaultWorkspace: 'workspace',
+      });
+      const api = createMockSnippetsApi();
+      const cmd = new ListSnippetsCommand(api, configService, output);
+      await cmd.run({ role, workspace: 'workspace' }, makeContext(true));
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(jsonLog).toBeDefined();
+    }
   });
 
-  it('should respect limit option', async () => {
-    const manySnippets = Array.from({ length: 10 }, (_, i) => ({
+  it('should respect --limit across pages', async () => {
+    const many = Array.from({ length: 80 }, (_, i) => ({
       ...mockSnippet,
-      id: `snip${i}` as unknown as number,
+      id: `s${i}` as unknown as number,
       title: `Snippet ${i}`,
     }));
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi(manySnippets);
+    const api = createMockSnippetsApi(many);
     const cmd = new ListSnippetsCommand(api, configService, output);
 
     await cmd.run({ limit: '3', workspace: 'workspace' }, makeContext(true));
@@ -319,18 +347,24 @@ describe('ListSnippetsCommand', () => {
 // --- ViewSnippetCommand ---
 
 describe('ViewSnippetCommand', () => {
-  it('should display snippet details as text', async () => {
+  it('should display snippet details as text with URL', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
     const api = createMockSnippetsApi();
-    const cmd = new ViewSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
 
     await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
 
     expect(output.logs.some((log) => log.includes('Test snippet'))).toBe(true);
     expect(output.logs.some((log) => log.includes('foo.txt'))).toBe(true);
+    expect(
+      output.logs.some((log) =>
+        log.includes('https://bitbucket.org/snippets/workspace/kypj')
+      )
+    ).toBe(true);
   });
 
   it('should display snippet as JSON', async () => {
@@ -339,38 +373,98 @@ describe('ViewSnippetCommand', () => {
       defaultWorkspace: 'workspace',
     });
     const api = createMockSnippetsApi();
-    const cmd = new ViewSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
 
     await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
 
     const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
     const data = JSON.parse(jsonLog!.substring(5));
     expect(data.title).toBe('Test snippet');
   });
 
-  it('should show web URL in text output', async () => {
+  it('should fall back to self link when html link is missing', async () => {
+    const snippetNoHtml = {
+      ...mockSnippet,
+      links: { self: { href: 'https://api.example/selfonly' } },
+    };
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = {
+      ...createMockSnippetsApi(),
+      snippetsWorkspaceEncodedIdGet: async () => ({ data: snippetNoHtml }),
+    } as unknown as SnippetsApi;
+    const { service } = createMockSnippetFilesService();
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(
+      output.logs.some((log) => log.includes('https://api.example/selfonly'))
+    ).toBe(true);
+  });
+
+  it('should print a single file with --file', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
     const api = createMockSnippetsApi();
-    const cmd = new ViewSnippetCommand(api, configService, output);
+    const { service, record } = createMockSnippetFilesService('hello content');
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
 
-    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+    await cmd.run(
+      { id: 'kypj', workspace: 'workspace', file: 'foo.txt' },
+      makeContext()
+    );
 
-    expect(
-      output.logs.some((log) =>
-        log.includes('https://bitbucket.org/snippets/workspace/kypj')
+    expect(record.fileContentCalls).toEqual([{ filePath: 'foo.txt' }]);
+    expect(output.logs.some((log) => log === 'text:hello content')).toBe(true);
+  });
+
+  it('should reject --file when file is not in snippet', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const { service } = createMockSnippetFilesService();
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
+
+    await expect(
+      cmd.run(
+        { id: 'kypj', workspace: 'workspace', file: 'missing.txt' },
+        makeContext()
       )
-    ).toBe(true);
+    ).rejects.toThrow('File not found in snippet');
+  });
+
+  it('should print all files with --files', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const { service, record } = createMockSnippetFilesService('aaa');
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', workspace: 'workspace', files: true },
+      makeContext()
+    );
+
+    expect(record.fileContentCalls.length).toBe(1);
+    expect(output.logs.some((log) => log.includes('── foo.txt ──'))).toBe(true);
   });
 
   it('should throw when no workspace available', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({});
     const api = createMockSnippetsApi();
-    const cmd = new ViewSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new ViewSnippetCommand(api, service, configService, output);
 
     await expect(
       cmd.run({ id: 'kypj' }, { globalOptions: {} })
@@ -381,34 +475,64 @@ describe('ViewSnippetCommand', () => {
 // --- CreateSnippetCommand ---
 
 describe('CreateSnippetCommand', () => {
-  it('should create snippet and show success', async () => {
+  it('should create snippet via multipart with files and metadata', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new CreateSnippetCommand(api, configService, output);
+    const { service, record } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
 
     await cmd.run(
-      { title: 'My snippet', file: ['package.json'] },
+      {
+        title: 'My snippet',
+        file: ['package.json'],
+        workspace: 'workspace',
+      },
       makeContext()
     );
 
+    expect(record.create).toBeDefined();
+    expect(record.create!.workspace).toBe('workspace');
+    expect(record.create!.title).toBe('My snippet');
+    expect(record.create!.isPrivate).toBe(true); // default
+    expect(record.create!.files).toEqual([{ path: 'package.json' }]);
     expect(output.logs.some((log) => log.includes('Created snippet'))).toBe(
       true
     );
   });
 
-  it('should create snippet with JSON output', async () => {
+  it('should send is_private=false when --public is set', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new CreateSnippetCommand(api, configService, output);
+    const { service, record } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
 
     await cmd.run(
-      { title: 'My snippet', file: ['package.json'], workspace: 'workspace' },
+      {
+        title: 'Public',
+        file: ['package.json'],
+        public: true,
+        workspace: 'workspace',
+      },
+      makeContext()
+    );
+
+    expect(record.create!.isPrivate).toBe(false);
+  });
+
+  it('should output JSON when --json set', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const { service } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
+
+    await cmd.run(
+      { title: 'X', file: ['package.json'], workspace: 'workspace' },
       makeContext(true)
     );
 
@@ -421,8 +545,8 @@ describe('CreateSnippetCommand', () => {
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new CreateSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
 
     await expect(
       cmd.run({ file: ['file.txt'] }, makeContext())
@@ -434,8 +558,8 @@ describe('CreateSnippetCommand', () => {
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new CreateSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
 
     await expect(cmd.run({ title: 'Test' }, makeContext())).rejects.toThrow(
       'At least one file is required'
@@ -447,8 +571,8 @@ describe('CreateSnippetCommand', () => {
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new CreateSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
 
     await expect(
       cmd.run(
@@ -457,44 +581,95 @@ describe('CreateSnippetCommand', () => {
       )
     ).rejects.toThrow('File not found');
   });
+
+  it('should reject --public and --private together', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const { service } = createMockSnippetFilesService();
+    const cmd = new CreateSnippetCommand(service, configService, output);
+
+    await expect(
+      cmd.run(
+        {
+          title: 'X',
+          file: ['package.json'],
+          public: true,
+          private: true,
+          workspace: 'workspace',
+        },
+        makeContext()
+      )
+    ).rejects.toThrow('cannot both be set');
+  });
 });
 
 // --- EditSnippetCommand ---
 
 describe('EditSnippetCommand', () => {
-  it('should edit snippet title', async () => {
+  it('should edit metadata (title) via JSON path', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new EditSnippetCommand(api, configService, output);
+    const { service, record } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
 
     await cmd.run(
       { id: 'kypj', title: 'New title', workspace: 'workspace' },
       makeContext()
     );
 
+    expect(record.editMetadata).toEqual({
+      workspace: 'workspace',
+      encodedId: 'kypj',
+      title: 'New title',
+      isPrivate: undefined,
+    });
+    expect(record.editWithFiles).toBeUndefined();
     expect(
       output.logs.some((log) => log.includes('Updated snippet kypj'))
     ).toBe(true);
   });
 
-  it('should edit snippet with JSON output', async () => {
+  it('should send is_private=true when --private', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new EditSnippetCommand(api, configService, output);
+    const { service, record } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
 
     await cmd.run(
-      { id: 'kypj', title: 'New title', workspace: 'workspace' },
-      makeContext(true)
+      { id: 'kypj', private: true, workspace: 'workspace' },
+      makeContext()
     );
 
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
+    expect(record.editMetadata!.isPrivate).toBe(true);
+  });
+
+  it('should route to multipart when --file is provided', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const { service, record } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
+
+    await cmd.run(
+      {
+        id: 'kypj',
+        file: ['package.json'],
+        title: 'T',
+        workspace: 'workspace',
+      },
+      makeContext()
+    );
+
+    expect(record.editWithFiles).toBeDefined();
+    expect(record.editWithFiles!.files).toEqual([{ path: 'package.json' }]);
+    expect(record.editMetadata).toBeUndefined();
   });
 
   it('should throw when no edit options provided', async () => {
@@ -502,12 +677,48 @@ describe('EditSnippetCommand', () => {
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
-    const cmd = new EditSnippetCommand(api, configService, output);
+    const { service } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
 
     await expect(
       cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext())
     ).rejects.toThrow('At least one of');
+  });
+
+  it('should reject --public and --private together', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const { service } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
+
+    await expect(
+      cmd.run(
+        { id: 'kypj', public: true, private: true, workspace: 'workspace' },
+        makeContext()
+      )
+    ).rejects.toThrow('cannot both be set');
+  });
+
+  it('should reject --file pointing to missing file', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const { service } = createMockSnippetFilesService();
+    const cmd = new EditSnippetCommand(service, configService, output);
+
+    await expect(
+      cmd.run(
+        {
+          id: 'kypj',
+          file: ['nonexistent-xyz.txt'],
+          workspace: 'workspace',
+        },
+        makeContext()
+      )
+    ).rejects.toThrow('File not found');
   });
 });
 
@@ -520,7 +731,7 @@ describe('DeleteSnippetCommand', () => {
       defaultWorkspace: 'workspace',
     });
     let deletedId: string | undefined;
-    const api = createMockSnippetsApi([], {
+    const api = createMockSnippetsApi([], [], {
       onDeleteCall: (req) => {
         deletedId = (req as { encodedId: string }).encodedId;
       },
@@ -538,26 +749,6 @@ describe('DeleteSnippetCommand', () => {
     expect(deletedId).toBe('kypj');
   });
 
-  it('should delete snippet with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new DeleteSnippetCommand(api, configService, output);
-
-    await cmd.run(
-      { id: 'kypj', yes: true, workspace: 'workspace' },
-      makeContext(true)
-    );
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-    expect(data.snippetId).toBe('kypj');
-  });
-
   it('should throw without --yes flag', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
@@ -572,7 +763,7 @@ describe('DeleteSnippetCommand', () => {
   });
 });
 
-// --- WatchSnippetCommand ---
+// --- Watch / Unwatch ---
 
 describe('WatchSnippetCommand', () => {
   it('should watch a snippet', async () => {
@@ -589,25 +780,7 @@ describe('WatchSnippetCommand', () => {
       output.logs.some((log) => log.includes('Now watching snippet kypj'))
     ).toBe(true);
   });
-
-  it('should watch with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new WatchSnippetCommand(api, configService, output);
-
-    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-    expect(data.watching).toBe(true);
-  });
 });
-
-// --- UnwatchSnippetCommand ---
 
 describe('UnwatchSnippetCommand', () => {
   it('should unwatch a snippet', async () => {
@@ -624,25 +797,9 @@ describe('UnwatchSnippetCommand', () => {
       output.logs.some((log) => log.includes('Stopped watching snippet kypj'))
     ).toBe(true);
   });
-
-  it('should unwatch with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new UnwatchSnippetCommand(api, configService, output);
-
-    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-    expect(data.watching).toBe(false);
-  });
 });
 
-// --- ListSnippetCommentsCommand ---
+// --- Comments ---
 
 describe('ListSnippetCommentsCommand', () => {
   it('should list comments as table', async () => {
@@ -655,27 +812,30 @@ describe('ListSnippetCommentsCommand', () => {
 
     await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
 
-    expect(output.logs.some((log) => log.startsWith('table:'))).toBe(true);
     const rows = getTableRows(output.logs);
     expect(rows.length).toBe(1);
   });
 
-  it('should list comments as JSON', async () => {
+  it('should respect --limit across pages', async () => {
+    const many = Array.from({ length: 80 }, (_, i) => ({
+      ...mockComment,
+      id: i + 1,
+    }));
     const output = createMockOutputService();
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const api = createMockSnippetsApi();
+    const api = createMockSnippetsApi([mockSnippet], many);
     const cmd = new ListSnippetCommentsCommand(api, configService, output);
 
-    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
+    await cmd.run(
+      { id: 'kypj', limit: '5', workspace: 'workspace' },
+      makeContext(true)
+    );
 
     const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
     const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.snippetId).toBe('kypj');
-    expect(data.count).toBe(1);
-    expect(data.comments).toHaveLength(1);
+    expect(data.count).toBe(5);
   });
 
   it('should show empty message when no comments', async () => {
@@ -683,13 +843,8 @@ describe('ListSnippetCommentsCommand', () => {
     const configService = createMockConfigService({
       defaultWorkspace: 'workspace',
     });
-    const emptyApi = {
-      ...createMockSnippetsApi(),
-      snippetsWorkspaceEncodedIdCommentsGet: async () => ({
-        data: { values: [], size: 0, next: undefined },
-      }),
-    } as unknown as SnippetsApi;
-    const cmd = new ListSnippetCommentsCommand(emptyApi, configService, output);
+    const api = createMockSnippetsApi([mockSnippet], []);
+    const cmd = new ListSnippetCommentsCommand(api, configService, output);
 
     await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
 
@@ -698,8 +853,6 @@ describe('ListSnippetCommentsCommand', () => {
     );
   });
 });
-
-// --- AddSnippetCommentCommand ---
 
 describe('AddSnippetCommentCommand', () => {
   it('should add a comment', async () => {
@@ -711,31 +864,11 @@ describe('AddSnippetCommentCommand', () => {
     const cmd = new AddSnippetCommentCommand(api, configService, output);
 
     await cmd.run(
-      { id: 'kypj', message: 'Great snippet!', workspace: 'workspace' },
+      { id: 'kypj', message: 'Great!', workspace: 'workspace' },
       makeContext()
     );
 
     expect(output.logs.some((log) => log.includes('Added comment'))).toBe(true);
-  });
-
-  it('should add comment with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new AddSnippetCommentCommand(api, configService, output);
-
-    await cmd.run(
-      { id: 'kypj', message: 'Great!', workspace: 'workspace' },
-      makeContext(true)
-    );
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-    expect(data.snippetId).toBe('kypj');
   });
 
   it('should throw when message is missing', async () => {
@@ -751,8 +884,6 @@ describe('AddSnippetCommentCommand', () => {
     ).rejects.toThrow('message is required');
   });
 });
-
-// --- EditSnippetCommentCommand ---
 
 describe('EditSnippetCommentCommand', () => {
   it('should edit a comment', async () => {
@@ -778,30 +909,6 @@ describe('EditSnippetCommentCommand', () => {
     );
   });
 
-  it('should edit comment with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new EditSnippetCommentCommand(api, configService, output);
-
-    await cmd.run(
-      {
-        snippetId: 'kypj',
-        commentId: '1',
-        message: 'Updated',
-        workspace: 'workspace',
-      },
-      makeContext(true)
-    );
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    expect(jsonLog).toBeDefined();
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-  });
-
   it('should throw for invalid comment ID', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
@@ -823,8 +930,6 @@ describe('EditSnippetCommentCommand', () => {
     ).rejects.toThrow('must be a valid integer');
   });
 });
-
-// --- DeleteSnippetCommentCommand ---
 
 describe('DeleteSnippetCommentCommand', () => {
   it('should delete a comment with --yes flag', async () => {
@@ -850,30 +955,6 @@ describe('DeleteSnippetCommentCommand', () => {
     );
   });
 
-  it('should delete comment with JSON output', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
-
-    await cmd.run(
-      {
-        snippetId: 'kypj',
-        commentId: '1',
-        yes: true,
-        workspace: 'workspace',
-      },
-      makeContext(true)
-    );
-
-    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
-    const data = JSON.parse(jsonLog!.substring(5));
-    expect(data.success).toBe(true);
-    expect(data.commentId).toBe(1);
-  });
-
   it('should throw without --yes flag', async () => {
     const output = createMockOutputService();
     const configService = createMockConfigService({
@@ -888,26 +969,5 @@ describe('DeleteSnippetCommentCommand', () => {
         makeContext()
       )
     ).rejects.toThrow('Use --yes to confirm deletion');
-  });
-
-  it('should throw for invalid comment ID', async () => {
-    const output = createMockOutputService();
-    const configService = createMockConfigService({
-      defaultWorkspace: 'workspace',
-    });
-    const api = createMockSnippetsApi();
-    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
-
-    await expect(
-      cmd.run(
-        {
-          snippetId: 'kypj',
-          commentId: 'invalid',
-          yes: true,
-          workspace: 'workspace',
-        },
-        makeContext()
-      )
-    ).rejects.toThrow('must be a valid integer');
   });
 });

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -1,0 +1,913 @@
+/**
+ * Snippet command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListSnippetsCommand } from '../../src/commands/snippet/list.command.js';
+import { ViewSnippetCommand } from '../../src/commands/snippet/view.command.js';
+import { CreateSnippetCommand } from '../../src/commands/snippet/create.command.js';
+import { EditSnippetCommand } from '../../src/commands/snippet/edit.command.js';
+import { DeleteSnippetCommand } from '../../src/commands/snippet/delete.command.js';
+import { WatchSnippetCommand } from '../../src/commands/snippet/watch.command.js';
+import { UnwatchSnippetCommand } from '../../src/commands/snippet/unwatch.command.js';
+import { ListSnippetCommentsCommand } from '../../src/commands/snippet/comments.list.command.js';
+import { AddSnippetCommentCommand } from '../../src/commands/snippet/comments.add.command.js';
+import { EditSnippetCommentCommand } from '../../src/commands/snippet/comments.edit.command.js';
+import { DeleteSnippetCommentCommand } from '../../src/commands/snippet/comments.delete.command.js';
+import {
+  createMockConfigService,
+  createMockOutputService,
+  mockUser,
+} from '../setup.js';
+import type { SnippetsApi, Snippet } from '../../src/generated/api.js';
+import type { CommandContext } from '../../src/core/interfaces/commands.js';
+
+// Mock snippet data
+const mockSnippet: Snippet & Record<string, unknown> = {
+  type: 'snippet',
+  id: 'kypj' as unknown as number,
+  title: 'Test snippet',
+  is_private: false,
+  scm: 'git' as const,
+  created_on: '2026-01-15T10:00:00.000000+00:00',
+  updated_on: '2026-01-16T14:30:00.000000+00:00',
+  creator: mockUser,
+  owner: mockUser,
+  files: {
+    'foo.txt': {
+      links: {
+        self: {
+          href: 'https://api.bitbucket.org/2.0/snippets/workspace/kypj/files/foo.txt',
+        },
+      },
+    },
+  },
+  links: {
+    html: { href: 'https://bitbucket.org/snippets/workspace/kypj' },
+    self: {
+      href: 'https://api.bitbucket.org/2.0/snippets/workspace/kypj',
+    },
+  },
+};
+
+const mockComment = {
+  type: 'snippet_comment',
+  id: 1,
+  content: {
+    raw: 'Test comment',
+    markup: 'markdown',
+    html: '<p>Test comment</p>',
+  },
+  user: mockUser,
+  created_on: '2026-01-15T12:00:00.000000+00:00',
+  updated_on: '2026-01-15T12:00:00.000000+00:00',
+};
+
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  if (!axiosOptions || typeof axiosOptions !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const params = (axiosOptions as { params?: unknown }).params;
+  if (!params || typeof params !== 'object') {
+    return { page: 1, pagelen: 25 };
+  }
+
+  const pageValue = (params as { page?: unknown }).page;
+  const pagelenValue = (params as { pagelen?: unknown }).pagelen;
+
+  const page =
+    typeof pageValue === 'number' && Number.isFinite(pageValue) && pageValue > 0
+      ? pageValue
+      : 1;
+  const pagelen =
+    typeof pagelenValue === 'number' &&
+    Number.isFinite(pagelenValue) &&
+    pagelenValue > 0
+      ? pagelenValue
+      : 25;
+
+  return { page, pagelen };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function createMockSnippetsApi(
+  snippets: (typeof mockSnippet)[] = [mockSnippet],
+  options: {
+    onCreateCall?: (request: unknown) => void;
+    onDeleteCall?: (request: unknown) => void;
+  } = {}
+): SnippetsApi {
+  return {
+    snippetsWorkspaceGet: async (_request: unknown, axiosOptions?: unknown) => {
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      const values = snippets.slice(start, end);
+
+      return {
+        data: {
+          values,
+          page,
+          pagelen,
+          size: snippets.length,
+          next:
+            end < snippets.length
+              ? `https://api.bitbucket.org/2.0/snippets/workspace?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
+    snippetsWorkspaceEncodedIdGet: async () => ({
+      data: mockSnippet,
+    }),
+    snippetsWorkspacePost: async (request: unknown) => {
+      options.onCreateCall?.(request);
+      return { data: mockSnippet };
+    },
+    snippetsWorkspaceEncodedIdPut: async () => ({
+      data: mockSnippet,
+    }),
+    snippetsWorkspaceEncodedIdDelete: async (request: unknown) => {
+      options.onDeleteCall?.(request);
+      return { data: undefined };
+    },
+    snippetsWorkspaceEncodedIdWatchPut: async () => ({
+      data: undefined,
+    }),
+    snippetsWorkspaceEncodedIdWatchDelete: async () => ({
+      data: undefined,
+    }),
+    snippetsWorkspaceEncodedIdCommentsGet: async (
+      _request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const comments = [mockComment];
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      const values = comments.slice(start, end);
+
+      return {
+        data: {
+          values,
+          page,
+          pagelen,
+          size: comments.length,
+          next: undefined,
+        },
+      };
+    },
+    snippetsWorkspaceEncodedIdCommentsPost: async () => ({
+      data: mockComment,
+    }),
+    snippetsWorkspaceEncodedIdCommentsCommentIdPut: async () => ({
+      data: mockComment,
+    }),
+    snippetsWorkspaceEncodedIdCommentsCommentIdDelete: async () => ({
+      data: undefined,
+    }),
+  } as unknown as SnippetsApi;
+}
+
+function makeContext(json = false): CommandContext {
+  return {
+    globalOptions: {
+      json,
+      workspace: 'workspace',
+    },
+  };
+}
+
+// --- ListSnippetsCommand ---
+
+describe('ListSnippetsCommand', () => {
+  it('should list snippets as table', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({ workspace: 'workspace' }, makeContext());
+
+    expect(output.logs.some((log) => log.startsWith('table:'))).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows.length).toBe(1);
+    expect(rows[0][1]).toBe('Test snippet');
+  });
+
+  it('should list snippets as JSON', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({ workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.workspace).toBe('workspace');
+    expect(data.count).toBe(1);
+    expect(data.snippets).toHaveLength(1);
+  });
+
+  it('should show empty message when no snippets found', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi([]);
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({ workspace: 'workspace' }, makeContext());
+
+    expect(output.logs.some((log) => log.includes('No snippets found'))).toBe(
+      true
+    );
+  });
+
+  it('should resolve workspace from config when not provided', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'my-ws',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({}, { globalOptions: { json: true } });
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.workspace).toBe('my-ws');
+  });
+
+  it('should throw when no workspace available', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({});
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await expect(cmd.run({}, { globalOptions: {} })).rejects.toThrow(
+      'No workspace specified'
+    );
+  });
+
+  it('should validate role option', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await expect(cmd.run({ role: 'invalid' }, makeContext())).rejects.toThrow(
+      '--role must be one of'
+    );
+  });
+
+  it('should pass role filter to API', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({ role: 'owner', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+  });
+
+  it('should respect limit option', async () => {
+    const manySnippets = Array.from({ length: 10 }, (_, i) => ({
+      ...mockSnippet,
+      id: `snip${i}` as unknown as number,
+      title: `Snippet ${i}`,
+    }));
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi(manySnippets);
+    const cmd = new ListSnippetsCommand(api, configService, output);
+
+    await cmd.run({ limit: '3', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.count).toBe(3);
+  });
+});
+
+// --- ViewSnippetCommand ---
+
+describe('ViewSnippetCommand', () => {
+  it('should display snippet details as text', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ViewSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(output.logs.some((log) => log.includes('Test snippet'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('foo.txt'))).toBe(true);
+  });
+
+  it('should display snippet as JSON', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ViewSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.title).toBe('Test snippet');
+  });
+
+  it('should show web URL in text output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ViewSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(
+      output.logs.some((log) =>
+        log.includes('https://bitbucket.org/snippets/workspace/kypj')
+      )
+    ).toBe(true);
+  });
+
+  it('should throw when no workspace available', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({});
+    const api = createMockSnippetsApi();
+    const cmd = new ViewSnippetCommand(api, configService, output);
+
+    await expect(
+      cmd.run({ id: 'kypj' }, { globalOptions: {} })
+    ).rejects.toThrow('No workspace specified');
+  });
+});
+
+// --- CreateSnippetCommand ---
+
+describe('CreateSnippetCommand', () => {
+  it('should create snippet and show success', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new CreateSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { title: 'My snippet', file: ['package.json'] },
+      makeContext()
+    );
+
+    expect(output.logs.some((log) => log.includes('Created snippet'))).toBe(
+      true
+    );
+  });
+
+  it('should create snippet with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new CreateSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { title: 'My snippet', file: ['package.json'], workspace: 'workspace' },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+  });
+
+  it('should throw when title is missing', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new CreateSnippetCommand(api, configService, output);
+
+    await expect(
+      cmd.run({ file: ['file.txt'] }, makeContext())
+    ).rejects.toThrow('title is required');
+  });
+
+  it('should throw when no files provided', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new CreateSnippetCommand(api, configService, output);
+
+    await expect(cmd.run({ title: 'Test' }, makeContext())).rejects.toThrow(
+      'At least one file is required'
+    );
+  });
+
+  it('should throw when file does not exist', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new CreateSnippetCommand(api, configService, output);
+
+    await expect(
+      cmd.run(
+        { title: 'Test', file: ['nonexistent-file-xyz.txt'] },
+        makeContext()
+      )
+    ).rejects.toThrow('File not found');
+  });
+});
+
+// --- EditSnippetCommand ---
+
+describe('EditSnippetCommand', () => {
+  it('should edit snippet title', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', title: 'New title', workspace: 'workspace' },
+      makeContext()
+    );
+
+    expect(
+      output.logs.some((log) => log.includes('Updated snippet kypj'))
+    ).toBe(true);
+  });
+
+  it('should edit snippet with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', title: 'New title', workspace: 'workspace' },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+  });
+
+  it('should throw when no edit options provided', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommand(api, configService, output);
+
+    await expect(
+      cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext())
+    ).rejects.toThrow('At least one of');
+  });
+});
+
+// --- DeleteSnippetCommand ---
+
+describe('DeleteSnippetCommand', () => {
+  it('should delete snippet with --yes flag', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    let deletedId: string | undefined;
+    const api = createMockSnippetsApi([], {
+      onDeleteCall: (req) => {
+        deletedId = (req as { encodedId: string }).encodedId;
+      },
+    });
+    const cmd = new DeleteSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', yes: true, workspace: 'workspace' },
+      makeContext()
+    );
+
+    expect(
+      output.logs.some((log) => log.includes('Deleted snippet kypj'))
+    ).toBe(true);
+    expect(deletedId).toBe('kypj');
+  });
+
+  it('should delete snippet with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', yes: true, workspace: 'workspace' },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+    expect(data.snippetId).toBe('kypj');
+  });
+
+  it('should throw without --yes flag', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommand(api, configService, output);
+
+    await expect(
+      cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext())
+    ).rejects.toThrow('Use --yes to confirm deletion');
+  });
+});
+
+// --- WatchSnippetCommand ---
+
+describe('WatchSnippetCommand', () => {
+  it('should watch a snippet', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new WatchSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(
+      output.logs.some((log) => log.includes('Now watching snippet kypj'))
+    ).toBe(true);
+  });
+
+  it('should watch with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new WatchSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+    expect(data.watching).toBe(true);
+  });
+});
+
+// --- UnwatchSnippetCommand ---
+
+describe('UnwatchSnippetCommand', () => {
+  it('should unwatch a snippet', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new UnwatchSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(
+      output.logs.some((log) => log.includes('Stopped watching snippet kypj'))
+    ).toBe(true);
+  });
+
+  it('should unwatch with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new UnwatchSnippetCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+    expect(data.watching).toBe(false);
+  });
+});
+
+// --- ListSnippetCommentsCommand ---
+
+describe('ListSnippetCommentsCommand', () => {
+  it('should list comments as table', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetCommentsCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(output.logs.some((log) => log.startsWith('table:'))).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows.length).toBe(1);
+  });
+
+  it('should list comments as JSON', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new ListSnippetCommentsCommand(api, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext(true));
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.snippetId).toBe('kypj');
+    expect(data.count).toBe(1);
+    expect(data.comments).toHaveLength(1);
+  });
+
+  it('should show empty message when no comments', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const emptyApi = {
+      ...createMockSnippetsApi(),
+      snippetsWorkspaceEncodedIdCommentsGet: async () => ({
+        data: { values: [], size: 0, next: undefined },
+      }),
+    } as unknown as SnippetsApi;
+    const cmd = new ListSnippetCommentsCommand(emptyApi, configService, output);
+
+    await cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext());
+
+    expect(output.logs.some((log) => log.includes('No comments found'))).toBe(
+      true
+    );
+  });
+});
+
+// --- AddSnippetCommentCommand ---
+
+describe('AddSnippetCommentCommand', () => {
+  it('should add a comment', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new AddSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', message: 'Great snippet!', workspace: 'workspace' },
+      makeContext()
+    );
+
+    expect(output.logs.some((log) => log.includes('Added comment'))).toBe(true);
+  });
+
+  it('should add comment with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new AddSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      { id: 'kypj', message: 'Great!', workspace: 'workspace' },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+    expect(data.snippetId).toBe('kypj');
+  });
+
+  it('should throw when message is missing', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new AddSnippetCommentCommand(api, configService, output);
+
+    await expect(
+      cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext())
+    ).rejects.toThrow('message is required');
+  });
+});
+
+// --- EditSnippetCommentCommand ---
+
+describe('EditSnippetCommentCommand', () => {
+  it('should edit a comment', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      {
+        snippetId: 'kypj',
+        commentId: '1',
+        message: 'Updated',
+        workspace: 'workspace',
+      },
+      makeContext()
+    );
+
+    expect(output.logs.some((log) => log.includes('Updated comment #1'))).toBe(
+      true
+    );
+  });
+
+  it('should edit comment with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      {
+        snippetId: 'kypj',
+        commentId: '1',
+        message: 'Updated',
+        workspace: 'workspace',
+      },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+  });
+
+  it('should throw for invalid comment ID', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new EditSnippetCommentCommand(api, configService, output);
+
+    await expect(
+      cmd.run(
+        {
+          snippetId: 'kypj',
+          commentId: 'abc',
+          message: 'Updated',
+          workspace: 'workspace',
+        },
+        makeContext()
+      )
+    ).rejects.toThrow('must be a valid integer');
+  });
+});
+
+// --- DeleteSnippetCommentCommand ---
+
+describe('DeleteSnippetCommentCommand', () => {
+  it('should delete a comment with --yes flag', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      {
+        snippetId: 'kypj',
+        commentId: '1',
+        yes: true,
+        workspace: 'workspace',
+      },
+      makeContext()
+    );
+
+    expect(output.logs.some((log) => log.includes('Deleted comment #1'))).toBe(
+      true
+    );
+  });
+
+  it('should delete comment with JSON output', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
+
+    await cmd.run(
+      {
+        snippetId: 'kypj',
+        commentId: '1',
+        yes: true,
+        workspace: 'workspace',
+      },
+      makeContext(true)
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const data = JSON.parse(jsonLog!.substring(5));
+    expect(data.success).toBe(true);
+    expect(data.commentId).toBe(1);
+  });
+
+  it('should throw without --yes flag', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
+
+    await expect(
+      cmd.run(
+        { snippetId: 'kypj', commentId: '1', workspace: 'workspace' },
+        makeContext()
+      )
+    ).rejects.toThrow('Use --yes to confirm deletion');
+  });
+
+  it('should throw for invalid comment ID', async () => {
+    const output = createMockOutputService();
+    const configService = createMockConfigService({
+      defaultWorkspace: 'workspace',
+    });
+    const api = createMockSnippetsApi();
+    const cmd = new DeleteSnippetCommentCommand(api, configService, output);
+
+    await expect(
+      cmd.run(
+        {
+          snippetId: 'kypj',
+          commentId: 'invalid',
+          yes: true,
+          workspace: 'workspace',
+        },
+        makeContext()
+      )
+    ).rejects.toThrow('must be a valid integer');
+  });
+});

--- a/tests/services/snippet-files.service.test.ts
+++ b/tests/services/snippet-files.service.test.ts
@@ -1,0 +1,248 @@
+/**
+ * SnippetFilesService tests — verify the actual HTTP contract
+ * (multipart form for create/edit-with-files; JSON for metadata edit;
+ * raw text for file content) without talking to Bitbucket.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import axios from 'axios';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SnippetFilesService } from '../../src/services/snippet-files.service.js';
+
+interface CapturedRequest {
+  url?: string;
+  method?: string;
+  data?: unknown;
+  headers?: Record<string, string>;
+  responseType?: string;
+}
+
+function createStubAxios(
+  captured: CapturedRequest[],
+  responses: unknown[] = []
+) {
+  const instance = axios.create();
+  // Replace the adapter so requests never leave the process
+  instance.defaults.adapter = async (config) => {
+    captured.push({
+      url: config.url,
+      method: config.method,
+      data: config.data,
+      headers: (config.headers ?? {}) as Record<string, string>,
+      responseType: config.responseType,
+    });
+    const data = responses.shift() ?? { ok: true };
+    return {
+      data,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    };
+  };
+  return instance;
+}
+
+function writeTempFile(name: string, contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bb-snippet-'));
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, contents);
+  return filePath;
+}
+
+async function formDataToString(data: unknown): Promise<string> {
+  if (!(data instanceof FormData)) {
+    return '';
+  }
+  const entries: string[] = [];
+  for (const [key, value] of data.entries()) {
+    if (value instanceof Blob) {
+      const text = await value.text();
+      entries.push(`${key}:blob(${text})`);
+    } else {
+      entries.push(`${key}:${String(value)}`);
+    }
+  }
+  return entries.join('|');
+}
+
+describe('SnippetFilesService', () => {
+  describe('createWithFiles', () => {
+    it('POSTs multipart/form-data with title, is_private and file parts', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [{ id: 'abc' }]);
+      const svc = new SnippetFilesService(instance);
+
+      const filePath = writeTempFile('hello.txt', 'hello world');
+
+      const result = await svc.createWithFiles({
+        workspace: 'my-ws',
+        title: 'My snippet',
+        isPrivate: true,
+        files: [{ path: filePath }],
+      });
+
+      expect(result).toEqual({ id: 'abc' });
+      expect(captured.length).toBe(1);
+      const req = captured[0];
+      expect(req.method?.toLowerCase()).toBe('post');
+      expect(req.url).toBe('/snippets/my-ws');
+      expect(req.headers?.['Content-Type']).toBe('multipart/form-data');
+      expect(req.data).toBeInstanceOf(FormData);
+
+      const flat = await formDataToString(req.data);
+      expect(flat).toContain('title:My snippet');
+      expect(flat).toContain('is_private:true');
+      expect(flat).toContain('file:blob(hello world)');
+    });
+
+    it('URL-encodes workspace slug', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('a.txt', 'a');
+
+      await svc.createWithFiles({
+        workspace: 'ws with space',
+        title: 't',
+        isPrivate: false,
+        files: [{ path: filePath }],
+      });
+
+      expect(captured[0].url).toBe('/snippets/ws%20with%20space');
+    });
+
+    it('sends is_private=false for public snippets', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('a.txt', 'a');
+
+      await svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: false,
+        files: [{ path: filePath }],
+      });
+
+      const flat = await formDataToString(captured[0].data);
+      expect(flat).toContain('is_private:false');
+    });
+
+    it('includes multiple files as separate parts', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const f1 = writeTempFile('one.txt', 'AAA');
+      const f2 = writeTempFile('two.txt', 'BBB');
+
+      await svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: true,
+        files: [{ path: f1 }, { path: f2 }],
+      });
+
+      const form = captured[0].data as FormData;
+      const files = form.getAll('file');
+      expect(files.length).toBe(2);
+      const contents = await Promise.all(files.map((v) => (v as Blob).text()));
+      expect(contents.sort()).toEqual(['AAA', 'BBB']);
+    });
+  });
+
+  describe('editMetadata', () => {
+    it('PUTs JSON body with only provided fields', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [{ id: 'kypj' }]);
+      const svc = new SnippetFilesService(instance);
+
+      await svc.editMetadata({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        title: 'New',
+      });
+
+      const req = captured[0];
+      expect(req.method?.toLowerCase()).toBe('put');
+      expect(req.url).toBe('/snippets/ws/kypj');
+      expect(req.headers?.['Content-Type']).toBe('application/json');
+      // axios serializes the body; it's available as a string in req.data
+      const parsed =
+        typeof req.data === 'string'
+          ? JSON.parse(req.data)
+          : (req.data as Record<string, unknown>);
+      expect(parsed).toEqual({ title: 'New' });
+    });
+
+    it('includes is_private when provided', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+
+      await svc.editMetadata({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        isPrivate: false,
+      });
+
+      const req = captured[0];
+      const parsed =
+        typeof req.data === 'string'
+          ? JSON.parse(req.data)
+          : (req.data as Record<string, unknown>);
+      expect(parsed).toEqual({ is_private: false });
+    });
+  });
+
+  describe('editWithFiles', () => {
+    it('PUTs multipart/form-data when files are supplied', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('up.txt', 'updated');
+
+      await svc.editWithFiles({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        title: 'T',
+        files: [{ path: filePath }],
+      });
+
+      const req = captured[0];
+      expect(req.method?.toLowerCase()).toBe('put');
+      expect(req.url).toBe('/snippets/ws/kypj');
+      expect(req.headers?.['Content-Type']).toBe('multipart/form-data');
+      const flat = await formDataToString(req.data);
+      expect(flat).toContain('title:T');
+      expect(flat).toContain('file:blob(updated)');
+    });
+  });
+
+  describe('getFileContent', () => {
+    it('GETs raw file content with text response type', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, ['hello file']);
+      const svc = new SnippetFilesService(instance);
+
+      const result = await svc.getFileContent('ws', 'kypj', 'path/to/file.txt');
+
+      expect(result).toBe('hello file');
+      expect(captured[0].url).toBe('/snippets/ws/kypj/files/path/to/file.txt');
+      expect(captured[0].responseType).toBe('text');
+    });
+
+    it('URL-encodes path segments while preserving slashes', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, ['x']);
+      const svc = new SnippetFilesService(instance);
+
+      await svc.getFileContent('ws', 'kypj', 'dir name/sub/f oo.txt');
+      expect(captured[0].url).toBe(
+        '/snippets/ws/kypj/files/dir%20name/sub/f%20oo.txt'
+      );
+    });
+  });
+});

--- a/tests/services/workspace-resolver.test.ts
+++ b/tests/services/workspace-resolver.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for the shared workspace resolver.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { resolveWorkspace } from '../../src/services/workspace-resolver.js';
+import { createMockConfigService } from '../setup.js';
+
+describe('resolveWorkspace', () => {
+  it('returns the explicit value when provided', async () => {
+    const config = createMockConfigService({ defaultWorkspace: 'fallback' });
+    const result = await resolveWorkspace(config, 'explicit');
+    expect(result).toBe('explicit');
+  });
+
+  it('falls back to config.defaultWorkspace', async () => {
+    const config = createMockConfigService({ defaultWorkspace: 'fallback' });
+    const result = await resolveWorkspace(config);
+    expect(result).toBe('fallback');
+  });
+
+  it('throws a BBError when neither is set', async () => {
+    const config = createMockConfigService({});
+    await expect(resolveWorkspace(config)).rejects.toThrow(
+      'No workspace specified'
+    );
+  });
+
+  it('ignores empty explicit value and falls back', async () => {
+    const config = createMockConfigService({ defaultWorkspace: 'cfg' });
+    const result = await resolveWorkspace(config, '');
+    expect(result).toBe('cfg');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 11 new commands under `bb snippet` for full Bitbucket Snippets support
- Core CRUD: `list`, `view`, `create`, `edit`, `delete` with text and `--json` output
- Watch management: `watch`, `unwatch`
- Comments CRUD: `comments list`, `comments add`, `comments edit`, `comments delete`
- Shell completions updated with `snippet` and all subcommands
- Workspace resolution via `--workspace` flag or `defaultWorkspace` config (no repo context required)

## New commands

| Command | Description |
|---------|-------------|
| `bb snippet list` | List workspace snippets (supports `--role`, `--limit`) |
| `bb snippet view <id>` | View snippet details with file listing |
| `bb snippet create` | Create snippet with `--title`, `--file`, `--public/--private` |
| `bb snippet edit <id>` | Update title and visibility |
| `bb snippet delete <id>` | Delete with `--yes` confirmation |
| `bb snippet watch <id>` | Start watching a snippet |
| `bb snippet unwatch <id>` | Stop watching a snippet |
| `bb snippet comments list <id>` | List snippet comments |
| `bb snippet comments add <id>` | Add comment with `--message` |
| `bb snippet comments edit <snippet-id> <comment-id> <message>` | Edit a comment |
| `bb snippet comments delete <snippet-id> <comment-id>` | Delete with `--yes` |

Closes #129

## Test plan

- [x] 40 new unit tests covering all 11 commands
- [x] Tests for text and JSON output modes
- [x] Tests for validation errors (missing title, missing files, missing message)
- [x] Tests for confirmation flow (delete without `--yes`)
- [x] Tests for workspace resolution (from flag, from config, missing)
- [x] Tests for role validation and pagination limits
- [x] Full test suite passes (496 tests, 0 failures)
- [x] TypeScript type check passes
- [x] Prettier formatting check passes