### PR TITLE
docs: fix inaccuracies, trim bloat, and improve clarity

### DIFF
--- a/.changeset/docs-audit-improvements.md
+++ b/.changeset/docs-audit-improvements.md
@@ -1,0 +1,21 @@
+---
+"@pilatos/bitbucket-cli": patch
+---
+
+Fix documentation inaccuracies, remove bloat, and improve clarity across docs site
+
+- Fix hardcoded version 1.4.0 in Head.astro structured data (now reads from package.json)
+- Remove stale meta keywords tag (ignored by search engines since 2009)
+- Add missing `lastVersionCheck` config key to reference docs
+- Fix incorrect API token scope names in CI/CD and AI agents guides
+- Add warning about misleading `--app-password` flag name in auth docs
+- Add prominent caution about `--mine` filtering by reviewer, not author
+- Clarify Bun runtime requirement in README (installed via npm, runs on Bun)
+- Document built-in retry logic (3x exponential backoff on 429/502/503/504)
+- Document automatic OAuth token refresh behavior
+- Improve DEBUG environment variable description
+- Fix `repo delete --yes` docs (not an interactive prompt, flag is required)
+- Remove generic "Team Conventions" section from AI agents guide
+- Trim scripting guide (remove 2 complex examples and Python/Node.js sections)
+- Replace padding GitHub vs Bitbucket CLI comparison table in FAQ
+- Update stale version numbers in example notification output

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install -g @pilatos/bitbucket-cli
 bb --version
 ```
 
-> **Requires:** [Bun](https://bun.sh) runtime 1.0 or higher (Node.js is not supported)
+> **Requires:** [Bun](https://bun.sh) runtime 1.0 or higher. The CLI is installed via npm but runs on the Bun runtime — Node.js is not supported. Install Bun first: `curl -fsSL https://bun.sh/install | bash`
 
 ---
 
@@ -98,7 +98,7 @@ Full documentation: **[bitbucket-cli.paulvanderlei.com](https://bitbucket-cli.pa
 - Create a token: [Bitbucket API Tokens](https://bitbucket.org/account/settings/api-tokens/)
 - Authenticate: `bb auth login`
 
-> **Note:** Bitbucket app passwords are deprecated. Use API tokens instead.
+> **Note:** Bitbucket app passwords are [deprecated](https://bitbucket.org/blog/deprecating-app-passwords) (new ones can no longer be created). Use OAuth or API tokens instead.
 
 ---
 

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,6 +1,9 @@
 ---
 import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Head.astro';
+import { readFileSync } from 'node:fs';
+
+const cliVersion = JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf-8')).version;
 
 const { title, description, id, lastUpdated, entry } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -44,8 +47,6 @@ const metaDescription = description || (entry?.data?.description) || 'A powerful
 <meta name="robots" content="index, follow" />
 <meta name="googlebot" content="index, follow" />
 <meta name="author" content="Bitbucket CLI Contributors" />
-<meta name="keywords" content="bitbucket, cli, command line, git, pull requests, repository, automation, devtools" />
-
 <!-- Article metadata for guides/docs -->
 {id !== 'index' && (
   <>
@@ -84,7 +85,7 @@ const metaDescription = description || (entry?.data?.description) || 'A powerful
       "name": "Bitbucket CLI Contributors",
       "url": "https://github.com/0pilatos0/bitbucket-cli"
     },
-    "softwareVersion": "1.4.0",
+    "softwareVersion": cliVersion,
     "downloadUrl": "https://www.npmjs.com/package/@pilatos/bitbucket-cli",
     "codeRepository": "https://github.com/0pilatos0/bitbucket-cli",
     "license": "https://github.com/0pilatos0/bitbucket-cli/blob/main/LICENSE",

--- a/docs/src/content/docs/commands/auth.mdx
+++ b/docs/src/content/docs/commands/auth.mdx
@@ -21,7 +21,7 @@ bb auth login [options]
 |--------|-------------|
 | `-u, --username <username>` | Bitbucket username (implies API token auth) |
 | `-p, --password <password>` | Bitbucket API token (implies API token auth) |
-| `--app-password` | Use API token authentication instead of OAuth |
+| `--app-password` | Use API token authentication instead of OAuth (legacy flag name — uses API tokens, not app passwords) |
 | `--client-id <clientId>` | Custom OAuth consumer client ID |
 | `--client-secret <clientSecret>` | Custom OAuth consumer client secret |
 | `--json` | Output as JSON |
@@ -72,6 +72,10 @@ The CLI determines which flow to use based on flags:
 | `-u` or `-p` provided | API Token |
 | `--app-password` flag | API Token |
 | `BB_API_TOKEN` env var set | API Token |
+
+:::note
+The `--app-password` flag is a legacy name. It triggers API token authentication, not Bitbucket app passwords (which are deprecated). Prefer using `-u`/`-p` flags or environment variables instead.
+:::
 
 ### Required Scopes (API Token)
 

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -152,7 +152,13 @@ bb pr list --mine
 
 - Draft PRs are shown with a `[DRAFT]` prefix in the title
 - `--limit` is enforced across paginated API responses
-- `--mine` filters by PRs where the authenticated user is explicitly assigned as a reviewer (via `reviewers.uuid` on the Bitbucket API). It does not filter by author — only PRs you've been asked to review are shown.
+
+:::caution[`--mine` does not mean "my PRs"]
+`--mine` filters PRs where you are assigned as a **reviewer**, not PRs you authored. It uses the Bitbucket API's `reviewers.uuid` filter. To find PRs you created, use `--json` with `jq`:
+```bash
+bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "your-username")'
+```
+:::
 
 ---
 

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -181,16 +181,13 @@ bb repo delete <repository> [options]
 | Option | Description |
 |--------|-------------|
 | `-w, --workspace <workspace>` | Workspace |
-| `-y, --yes` | Skip confirmation prompt |
+| `-y, --yes` | Confirm deletion (required) |
 | `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
-# Delete with confirmation prompt
-bb repo delete myworkspace/myrepo
-
-# Delete without confirmation (use with caution!)
+# Delete a repository (--yes is required to confirm)
 bb repo delete myworkspace/myrepo --yes
 
 # Delete using explicit workspace option

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -249,36 +249,6 @@ AI:   [Runs: bb pr ready 48]
 
 ---
 
-## Team Conventions
-
-Encode your team's workflow rules in the instruction file so every team member's AI follows the same conventions:
-
-```markdown
-### Team Workflow
-
-**Branch naming:**
-- Features: `feat/<ticket>-<description>`
-- Bugs: `fix/<ticket>-<description>`
-- Hotfixes: `hotfix/<description>`
-
-**PR rules:**
-- Always create PRs with a descriptive body, not just a title
-- Use draft PRs for work-in-progress
-- Require at least one approval before merging
-- Always squash-merge feature branches: `--strategy squash`
-- Always delete source branches after merge: `--close-source-branch`
-
-**Review process:**
-1. `bb pr checkout <id>` — check out locally
-2. `bb pr diff <id>` — review the changes
-3. `bb pr approve <id>` — approve if satisfied
-4. `bb pr merge <id> --strategy squash --close-source-branch` — merge
-```
-
-Append this to your skill file, AGENTS.md, or cursor rule — wherever your team keeps AI instructions.
-
----
-
 ## Security
 
 <Aside type="caution">
@@ -299,14 +269,15 @@ bb auth login   # Reads from env vars automatically
 
 | Scope | Required for |
 |-------|-------------|
-| `account:read` | `bb auth status` — verify identity |
-| `repository:read` | `bb repo list`, `bb repo view` — browse repos |
-| `repository:write` | `bb repo create`, `bb repo delete` — manage repos |
-| `pullrequest:read` | `bb pr list`, `bb pr view`, `bb pr diff` — browse PRs |
-| `pullrequest:write` | `bb pr create`, `bb pr merge`, `bb pr approve` — manage PRs |
+| `read:user:bitbucket` | `bb auth status` — verify identity |
+| `read:repository:bitbucket` | `bb repo list`, `bb repo view` — browse repos |
+| `write:repository:bitbucket` | `bb repo create` — create repos |
+| `admin:repository:bitbucket` | `bb repo delete` — delete repos (optional) |
+| `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view`, `bb pr diff` — browse PRs |
+| `write:pullrequest:bitbucket` | `bb pr create`, `bb pr merge`, `bb pr approve` — manage PRs |
 
 <Aside type="tip">
-  For read-only workflows (listing and viewing PRs), you only need the `read` scopes.
+  For read-only workflows (listing and viewing PRs), you only need the `read` scopes. OAuth users don't need to select scopes manually — they are requested automatically.
 </Aside>
 
 ---

--- a/docs/src/content/docs/guides/cicd.mdx
+++ b/docs/src/content/docs/guides/cicd.mdx
@@ -409,11 +409,11 @@ Create a dedicated CI/CD token with minimal permissions:
 
 | Use Case | Required Scopes |
 |----------|----------------|
-| Verify identity | `account:read` |
-| Read-only checks | + `repository:read`, `pullrequest:read` |
-| Create/merge PRs | + `pullrequest:write` |
-| Create repos | + `repository:write` |
-| Delete repos | + `repository:admin` |
+| Verify identity | `read:user:bitbucket` |
+| Read-only checks | + `read:repository:bitbucket`, `read:pullrequest:bitbucket` |
+| Create/merge PRs | + `write:pullrequest:bitbucket` |
+| Create repos | + `write:repository:bitbucket` |
+| Delete repos | + `admin:repository:bitbucket` |
 
 ### Secrets Management
 

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -128,6 +128,24 @@ See [Environment Variables Reference](/reference/environment-variables/) for det
 
 ---
 
+## Built-in Resilience
+
+The CLI handles common transient failures automatically — you don't need to implement this yourself in most cases.
+
+### Automatic Retry
+
+API requests that fail with transient errors (HTTP 429, 502, 503, 504) are retried automatically up to 3 times with exponential backoff. This means rate-limited or temporarily unavailable responses are handled without any extra scripting.
+
+### OAuth Token Refresh
+
+OAuth access tokens expire after 2 hours. The CLI refreshes them automatically — both proactively (before expiry) and reactively (on 401 responses). Long-running scripts using OAuth don't need manual re-authentication.
+
+<Aside type="tip">
+The built-in retry covers most transient failures. Only add your own retry logic if you need custom behavior beyond 3 attempts.
+</Aside>
+
+---
+
 ## Scripting Best Practices
 
 ### Always Use Explicit Flags
@@ -142,41 +160,30 @@ bb pr list -w myworkspace -r myrepo --json
 bb pr list --json
 ```
 
-### Handle API Failures
+### Handle Persistent Failures
 
-Implement retry logic for transient failures:
+The CLI retries transient errors automatically (see [Built-in Resilience](#built-in-resilience) above). For persistent failures, handle the exit code:
 
 ```bash
 #!/bin/bash
 
-max_retries=3
-retry_delay=5
-
-for ((i=1; i<=max_retries; i++)); do
-  if bb pr list -w workspace -r repo --json > prs.json 2>error.json; then
-    break
-  fi
-
-  if [ $i -lt $max_retries ]; then
-    echo "Attempt $i failed, retrying in ${retry_delay}s..."
-    sleep $retry_delay
-  else
-    echo "All attempts failed"
-    exit 1
-  fi
-done
+if ! bb pr list -w workspace -r repo --json > prs.json 2>error.json; then
+  echo "Failed to list PRs"
+  cat error.json
+  exit 1
+fi
 ```
 
-### Respect Rate Limits
+### Add Delays in Loops
 
-Add delays between requests:
+When making many sequential API calls, add short delays to avoid hitting rate limits:
 
 ```bash
 #!/bin/bash
 
 for pr_id in $(bb pr list --json | jq -r '.pullRequests[].id'); do
   bb pr view "$pr_id" --json
-  sleep 1  # Rate limit protection
+  sleep 1
 done
 ```
 
@@ -265,120 +272,5 @@ for pr_id in $stale_prs; do
 done
 ```
 
-### Repository Backup Script
 
-Clone all repositories in a workspace:
 
-```bash
-#!/bin/bash
-set -e
-
-WORKSPACE="myworkspace"
-BACKUP_DIR="./bitbucket-backup-$(date +%Y%m%d)"
-
-mkdir -p "$BACKUP_DIR"
-cd "$BACKUP_DIR"
-
-echo "Fetching repository list..."
-repos=$(bb repo list -w "$WORKSPACE" --json | jq -r '.repositories[].name')
-
-for repo in $repos; do
-  echo "Cloning $repo..."
-  bb repo clone "$WORKSPACE/$repo" || echo "Failed to clone $repo"
-  sleep 1
-done
-
-echo "Backup complete: $BACKUP_DIR"
-```
-
-### PR Diff Analysis
-
-Analyze changes across all open PRs:
-
-```bash
-#!/bin/bash
-
-WORKSPACE="myworkspace"
-REPO="myrepo"
-
-echo "Analyzing open PRs..."
-echo ""
-
-total_files=0
-total_additions=0
-total_deletions=0
-
-for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[].id'); do
-  stats=$(bb pr diff "$pr_id" -w "$WORKSPACE" -r "$REPO" --stat --json 2>/dev/null)
-
-  if [ -n "$stats" ]; then
-    files=$(echo "$stats" | jq '.filesChanged // 0')
-    additions=$(echo "$stats" | jq '.totalAdditions // 0')
-    deletions=$(echo "$stats" | jq '.totalDeletions // 0')
-
-    echo "PR #$pr_id: $files files, +$additions -$deletions"
-
-    total_files=$((total_files + files))
-    total_additions=$((total_additions + additions))
-    total_deletions=$((total_deletions + deletions))
-  fi
-
-  sleep 1
-done
-
-echo ""
-echo "Total: $total_files files, +$total_additions -$total_deletions"
-```
-
----
-
-## Python Integration
-
-```python
-import subprocess
-import json
-
-def run_bb(args):
-    """Run bb command and return parsed JSON output."""
-    result = subprocess.run(
-        ['bb'] + args + ['--json'],
-        capture_output=True,
-        text=True
-    )
-    if result.returncode != 0:
-        error = json.loads(result.stderr)
-        raise Exception(f"bb command failed [{error['code']}]: {error['message']}")
-    return json.loads(result.stdout)
-
-# List PRs
-prs = run_bb(['pr', 'list', '-w', 'workspace', '-r', 'repo'])
-for pr in prs['pullRequests']:
-    print(f"#{pr['id']}: {pr['title']}")
-
-# Get PR details
-pr = run_bb(['pr', 'view', '42', '-w', 'workspace', '-r', 'repo'])
-print(f"State: {pr['state']}")
-```
-
----
-
-## Bun/Node.js Integration
-
-You can call the `bb` CLI from Bun or Node.js scripts. Note that the CLI itself requires Bun runtime, but you can invoke it from any JavaScript runtime.
-
-```javascript
-import { execSync } from 'child_process';
-
-function runBB(args) {
-  const result = execSync(`bb ${args.join(' ')} --json`, {
-    encoding: 'utf8'
-  });
-  return JSON.parse(result);
-}
-
-// List PRs
-const prs = runBB(['pr', 'list', '-w', 'workspace', '-r', 'repo']);
-prs.pullRequests.forEach(pr => {
-  console.log(`#${pr.id}: ${pr.title}`);
-});
-```

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -15,18 +15,7 @@ No. This is an **unofficial**, community-maintained CLI tool. It is not affiliat
 
 ### How does this compare to GitHub CLI (gh)?
 
-The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users:
-
-| Feature | GitHub CLI | Bitbucket CLI |
-|---------|-----------|---------------|
-| Authentication | OAuth/token | OAuth/API token |
-| Repository management | Yes | Yes |
-| Pull requests | Yes | Yes |
-| Issues | Yes | Not yet |
-| Actions/Pipelines | Yes | Not yet |
-| Gists/Snippets | Yes | Not yet |
-| JSON output | Yes | Yes |
-| Shell completion | Yes | Yes |
+The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, configuration, and shell completion. Features not yet supported include issues, pipelines, snippets, and branch permissions.
 
 ---
 

--- a/docs/src/content/docs/help/troubleshooting.mdx
+++ b/docs/src/content/docs/help/troubleshooting.mdx
@@ -258,9 +258,11 @@ Error: Rate limit exceeded
 
 **Solutions:**
 
-1. Wait a few minutes and retry
+1. The CLI automatically retries rate-limited requests (HTTP 429) up to 3 times with exponential backoff. If you still see this error, the rate limit is sustained.
 
-2. For scripts, implement delays:
+2. Wait a few minutes and retry
+
+3. For scripts, add delays between calls:
    ```bash
    for pr_id in 1 2 3 4 5; do
      bb pr view $pr_id

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -41,6 +41,7 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 | `defaultWorkspace` | string | Default workspace | `bb config set defaultWorkspace` |
 | `skipVersionCheck` | boolean | Disable update notifications | `bb config set` |
 | `versionCheckInterval` | number | Days between update checks (default: 1) | `bb config set` |
+| `lastVersionCheck` | string | Timestamp of last update check | Automatic |
 
 ### Example Configuration (OAuth)
 
@@ -152,7 +153,7 @@ The CLI automatically checks for updates when you run the bare `bb` command (wit
 ### Example Notification
 
 ```
-⚠ A new version is available: 1.5.0 (you have 1.4.0)
+⚠ A new version is available: 1.12.0 (you have 1.11.0)
   Run 'bun install -g @pilatos/bitbucket-cli' to update
   Or disable with 'bb config set skipVersionCheck true'
 ```

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -15,7 +15,7 @@ Environment variables allow you to configure the CLI without storing credentials
 | `BB_API_TOKEN` | Your Bitbucket API token | `ATBB...` |
 | `NO_COLOR` | Disable color output globally | `1` |
 | `FORCE_COLOR` | Force-enable color output globally | `1` |
-| `DEBUG` | Enable HTTP debug logging when set to `true` | `true` |
+| `DEBUG` | Enable HTTP debug logging (logs request method, URL, status, and response body for every API call) | `true` |
 
 ## Configuration Priority
 


### PR DESCRIPTION
## Summary

Comprehensive documentation audit that fixes factual errors, removes filler content, and improves accuracy across 12 files.

### Fixes
- **Head.astro**: Version in JSON-LD structured data was hardcoded to `1.4.0` (actual: `1.11.0`). Now dynamically reads from `package.json`
- **Head.astro**: Removed stale `keywords` meta tag (ignored by search engines since 2009)
- **Configuration reference**: Added missing `lastVersionCheck` key (12 keys exist, only 11 were documented)
- **CI/CD guide + AI agents guide**: Fixed incorrect API token scope names (e.g. `account:read` → `read:user:bitbucket`)
- **Repo commands**: `repo delete --yes` described as "skip confirmation prompt" but it's actually a required flag (no interactive prompt exists)
- **Configuration reference**: Updated stale version numbers in example notification output

### Clarifications
- **Auth commands**: Added warning that `--app-password` is a legacy flag name that triggers API token auth, not Bitbucket app passwords
- **PR list**: Added prominent caution box explaining `--mine` filters by reviewer assignment, not by author
- **README**: Clarified that CLI is installed via npm but requires Bun runtime, with install instructions
- **README**: Improved app password deprecation note with context
- **Scripting guide**: Documented built-in retry logic (3x exponential backoff on 429/502/503/504) and automatic OAuth token refresh
- **Environment variables**: Improved `DEBUG` variable description to explain what it actually outputs
- **Troubleshooting**: Added note about automatic rate limit retry behavior

### Trimmed content
- **AI agents guide**: Removed generic "Team Conventions" section (prompt engineering boilerplate, not CLI documentation)
- **Scripting guide**: Removed 2 overly complex example scripts (repo backup, diff analysis) and Python/Node.js integration sections
- **FAQ**: Replaced padding GitHub vs Bitbucket CLI comparison table with a concise paragraph

**Net change: -116 lines** (89 added, 205 removed)

## Test plan
- [ ] Verify docs site builds successfully (`cd docs && bun run build`)
- [ ] Verify Head.astro correctly reads version from package.json
- [ ] Spot-check edited pages render correctly in the docs site