### PR TITLE
fix(pr): require --yes to delete PR comments

### DIFF
--- a/.changeset/pr-comments-delete-yes-guard.md
+++ b/.changeset/pr-comments-delete-yes-guard.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+`bb pr comments delete` now requires `--yes` to confirm deletion, matching the guardrail on other destructive commands (`bb repo delete`, `bb snippet delete`, `bb snippet comments delete`).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -807,17 +807,18 @@ prCommentsCmd
 prCommentsCmd
   .command('delete <pr-id> <comment-id>')
   .description('Delete a comment on a pull request')
+  .option('-y, --yes', 'Skip confirmation prompt')
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb pr comments delete 42 12345'],
+      examples: ['bb pr comments delete 42 12345 --yes'],
     })
   )
   .action(async (prId, commentId, options) => {
     const context = createContext(cli);
     await runCommand(
       ServiceTokens.DeleteCommentPRCommand,
-      withGlobalOptions({ prId, commentId }, context),
+      withGlobalOptions({ prId, commentId, ...options }, context),
       cli,
       context
     );

--- a/src/commands/pr/comments.delete.command.ts
+++ b/src/commands/pr/comments.delete.command.ts
@@ -10,8 +10,11 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
-export interface DeleteCommentPROptions extends GlobalOptions {}
+export interface DeleteCommentPROptions extends GlobalOptions {
+  yes?: boolean;
+}
 
 export class DeleteCommentPRCommand extends BaseCommand<
   { prId: string; commentId: string } & DeleteCommentPROptions,
@@ -39,6 +42,15 @@ export class DeleteCommentPRCommand extends BaseCommand<
 
     const prId = this.parseIntOption(options.prId, 'pr-id');
     const commentId = this.parseIntOption(options.commentId, 'comment-id');
+
+    if (!options.yes) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          `This will permanently delete comment #${commentId} on PR #${prId}.\n` +
+          'Use --yes to confirm deletion.',
+      });
+    }
 
     await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsCommentIdDelete(
       {

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -2321,7 +2321,7 @@ describe('DeleteCommentPRCommand', () => {
       output
     );
     await command.execute(
-      { prId: '42', commentId: '7' },
+      { prId: '42', commentId: '7', yes: true },
       { globalOptions: {} }
     );
 
@@ -2344,7 +2344,7 @@ describe('DeleteCommentPRCommand', () => {
       output
     );
     await command.execute(
-      { prId: '42', commentId: '7' },
+      { prId: '42', commentId: '7', yes: true },
       { globalOptions: { json: true } }
     );
 
@@ -2373,7 +2373,10 @@ describe('DeleteCommentPRCommand', () => {
     );
 
     await expect(
-      command.execute({ prId: '42', commentId: '7' }, { globalOptions: {} })
+      command.execute(
+        { prId: '42', commentId: '7', yes: true },
+        { globalOptions: {} }
+      )
     ).rejects.toThrow('API Error');
   });
 
@@ -2389,8 +2392,30 @@ describe('DeleteCommentPRCommand', () => {
     );
 
     await expect(
-      command.execute({ prId: '42', commentId: '7' }, { globalOptions: {} })
+      command.execute(
+        { prId: '42', commentId: '7', yes: true },
+        { globalOptions: {} }
+      )
     ).rejects.toThrow();
+  });
+
+  it('should throw without --yes flag', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new DeleteCommentPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+
+    await expect(
+      command.execute({ prId: '42', commentId: '7' }, { globalOptions: {} })
+    ).rejects.toThrow('Use --yes to confirm deletion');
   });
 });
 


### PR DESCRIPTION
## Summary

- `bb pr comments delete <pr-id> <comment-id>` now requires `-y/--yes` before deleting, matching `bb repo delete`, `bb snippet delete`, and `bb snippet comments delete`.
- Without `--yes`, the command throws `VALIDATION_REQUIRED` with a clear "Use --yes to confirm deletion." message instead of silently destroying the comment.
- Added a unit test mirroring the snippet-comments guard test; updated the existing success / JSON / error / missing-context cases to pass `yes: true`.
- Includes a `patch` changeset.

Closes #141

## Test plan

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test tests/commands/pr.test.ts` (92 pass)
- [x] `bun test` full suite (569 pass)
- [x] Manual: `bun run dev pr comments delete 42 12345` → rejects with guard message
- [x] Manual: `bun run dev pr comments delete 42 12345 --yes` → proceeds to API call