### PR TITLE
fix(api-client): redact OAuth tokens from DEBUG response logs

### DIFF
--- a/.changeset/redact-debug-tokens.md
+++ b/.changeset/redact-debug-tokens.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Redact `access_token`, `refresh_token`, and other token-bearing fields from `DEBUG=true` HTTP response logs so OAuth secrets no longer leak into terminal output or CI logs when debugging.

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -17,6 +17,45 @@ const BASE_DELAY_MS = 1000;
 
 const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
 
+const SENSITIVE_KEYS = new Set([
+  'access_token',
+  'refresh_token',
+  'token',
+  'id_token',
+  'client_secret',
+  'password',
+  'authorization',
+]);
+
+const REDACTED = '[REDACTED]';
+
+function redactSensitive(
+  value: unknown,
+  seen = new WeakSet<object>()
+): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value as object)) {
+    return '[Circular]';
+  }
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item, seen));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      result[key] = REDACTED;
+    } else {
+      result[key] = redactSensitive(val, seen);
+    }
+  }
+  return result;
+}
+
 interface RetryableConfig extends InternalAxiosRequestConfig {
   __retryCount?: number;
   __tokenRefreshed?: boolean;
@@ -84,7 +123,7 @@ export function createApiClient(
         console.debug(`[HTTP] Response: ${response.status}`);
         console.debug(
           `[HTTP] Response Body:`,
-          JSON.stringify(response.data, null, 2)
+          JSON.stringify(redactSensitive(response.data), null, 2)
         );
       }
       return response;
@@ -95,7 +134,7 @@ export function createApiClient(
         if (error.response) {
           console.debug(
             `[HTTP] Error Response Body:`,
-            JSON.stringify(error.response.data, null, 2)
+            JSON.stringify(redactSensitive(error.response.data), null, 2)
           );
         }
       }

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -506,3 +506,127 @@ describe('createApiClient - retry/backoff', () => {
     expect(networkMock.getCallCount()).toBe(1);
   });
 });
+
+describe('createApiClient - DEBUG response logging redaction', () => {
+  let client: AxiosInstance;
+  let consoleDebugSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let originalDebug: string | undefined;
+
+  beforeEach(() => {
+    originalDebug = process.env.DEBUG;
+    consoleDebugSpy = spyOn(console, 'debug').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleDebugSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (originalDebug === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = originalDebug;
+    }
+  });
+
+  function allDebugOutput(): string {
+    return consoleDebugSpy.mock.calls
+      .map((args) => args.map((a) => String(a)).join(' '))
+      .join('\n');
+  }
+
+  it('redacts access_token and refresh_token from response body logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: {
+          access_token: 'secret-AT',
+          refresh_token: 'secret-RT',
+          expires_in: 7200,
+          scopes: 'repository',
+        },
+      },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] Response Body:');
+    expect(output).not.toContain('secret-AT');
+    expect(output).not.toContain('secret-RT');
+    expect(output).toContain('[REDACTED]');
+    // Non-sensitive fields still logged.
+    expect(output).toContain('expires_in');
+    expect(output).toContain('7200');
+    expect(output).toContain('scopes');
+  });
+
+  it('redacts tokens from error response body logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 400,
+        data: { error: 'invalid_grant', access_token: 'leaked' },
+      },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    try {
+      await client.get('/test');
+    } catch {
+      // expected
+    }
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] Error Response Body:');
+    expect(output).not.toContain('leaked');
+    expect(output).toContain('[REDACTED]');
+    expect(output).toContain('invalid_grant');
+  });
+
+  it('redacts sensitive keys nested inside arrays and objects', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: {
+          data: {
+            items: [
+              { id: 1, token: 'nested-secret' },
+              { id: 2, password: 'also-secret' },
+            ],
+          },
+        },
+      },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const output = allDebugOutput();
+    expect(output).not.toContain('nested-secret');
+    expect(output).not.toContain('also-secret');
+    expect(output).toContain('[REDACTED]');
+  });
+
+  it('does not log response bodies when DEBUG is not set', async () => {
+    delete process.env.DEBUG;
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: { access_token: 'should-never-log' },
+      },
+    ]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    expect(consoleDebugSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a recursive `redactSensitive()` helper in `src/services/api-client.service.ts` that replaces values of token-bearing keys (`access_token`, `refresh_token`, `token`, `id_token`, `client_secret`, `password`, `authorization`) with `[REDACTED]` before the response/error body is stringified for the `DEBUG=true` log lines.
- Applies the redactor on both the success and error paths of the response interceptor, so any axios response whose body happens to contain these fields no longer leaks them to terminal output or CI logs.
- Adds focused regression tests covering success bodies, error bodies, nested/array redaction, and the `DEBUG` off case.

Closes #142.

## Test plan

- [x] `bun test tests/services/api-client.test.ts`
- [x] `bun test` (full suite)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Manual: `DEBUG=true bun run dev repo list` against an authenticated workspace — confirm any `access_token`/`refresh_token`-shaped fields in logged bodies appear as `[REDACTED]`.