### PR TITLE
fix(pr): validate --strategy against merge strategy enum

### DIFF
--- a/.changeset/validate-pr-merge-strategy.md
+++ b/.changeset/validate-pr-merge-strategy.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Validate `bb pr merge --strategy` locally against the allowed merge strategies (`merge_commit`, `squash`, `fast_forward`, `squash_fast_forward`, `rebase_fast_forward`, `rebase_merge`). Invalid values now fail fast with a helpful `--strategy must be one of: …` message instead of surfacing as an opaque Bitbucket API error.

--- a/src/commands/pr/merge.command.ts
+++ b/src/commands/pr/merge.command.ts
@@ -8,11 +8,15 @@ import type {
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type {
-  PullrequestsApi,
+import {
   PullrequestMergeParametersMergeStrategyEnum,
+  type PullrequestsApi,
 } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+
+const VALID_STRATEGIES = Object.values(
+  PullrequestMergeParametersMergeStrategyEnum
+) as readonly PullrequestMergeParametersMergeStrategyEnum[];
 
 export interface MergePROptions extends GlobalOptions {
   message?: string;
@@ -64,8 +68,11 @@ export class MergePRCommand extends BaseCommand<
     }
 
     if (options.strategy) {
-      request.merge_strategy =
-        options.strategy as PullrequestMergeParametersMergeStrategyEnum;
+      request.merge_strategy = this.parseEnumOption(
+        options.strategy,
+        'strategy',
+        VALID_STRATEGIES
+      );
     }
 
     const response =

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1384,6 +1384,38 @@ describe('MergePRCommand', () => {
       command.execute({ id: '999' }, { globalOptions: {} })
     ).rejects.toThrow();
   });
+
+  it('should reject an invalid --strategy value', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new MergePRCommand(pullrequestsApi, contextService, output);
+
+    await expect(
+      command.execute({ id: '1', strategy: 'bogus' }, { globalOptions: {} })
+    ).rejects.toThrow(/--strategy must be one of/);
+  });
+
+  it('should accept a valid --strategy value', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new MergePRCommand(pullrequestsApi, contextService, output);
+    await command.execute(
+      { id: '1', strategy: 'squash' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs.some((log) => log.includes('Merged'))).toBe(true);
+  });
 });
 
 describe('ApprovePRCommand', () => {


### PR DESCRIPTION
## Summary
- Replace the unchecked cast of `--strategy` in [src/commands/pr/merge.command.ts](src/commands/pr/merge.command.ts) with `parseEnumOption()` against the generated `PullrequestMergeParametersMergeStrategyEnum`, so invalid values fail locally with `--strategy must be one of: …` instead of hitting the Bitbucket API.
- Mirrors the pattern already used by `bb snippet list --role` in [src/commands/snippet/list.command.ts](src/commands/snippet/list.command.ts).
- Adds tests in [tests/commands/pr.test.ts](tests/commands/pr.test.ts) for both the rejection path (`--strategy bogus`) and the happy path (`--strategy squash`).

Fixes #143

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test tests/commands/pr.test.ts` (93 pass)
- [x] Manual: `bun run dev pr merge 1 --strategy bogus` → local validation error
- [x] Manual: `bun run dev pr merge 1 --strategy squash` → request reaches API as before