### PR TITLE
fix(pr): standardize integer parsing, validate --type, drop redundant --json

### DIFF
--- a/.changeset/pr-command-hardening.md
+++ b/.changeset/pr-command-hardening.md
@@ -1,0 +1,9 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Harden PR commands:
+
+- `bb pr view`, `bb pr activity`, `bb pr merge`, and `bb pr checks` now validate `<id>` as an integer and fail fast with a clear `--id must be a valid integer` error instead of silently passing `NaN` to the Bitbucket API.
+- `bb pr activity --type` now rejects unknown activity types (e.g. `--type commetn`) with a `--type must be one of: …` error instead of silently returning zero results.
+- Removed the redundant local `--json` flag on `bb pr checks`; use the global `--json` option instead.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -561,7 +561,6 @@ prCmd
 prCmd
   .command('checks <id>')
   .description('Show CI/CD checks and build status for a pull request')
-  .option('--json', 'Output as JSON')
   .addHelpText(
     'after',
     buildHelpText({

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -17,6 +17,19 @@ import {
   type PullrequestActivity,
 } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+const VALID_ACTIVITY_TYPES = [
+  'comment',
+  'approval',
+  'changes_requested',
+  'merge',
+  'decline',
+  'commit',
+  'update',
+] as const;
+
+type ActivityType = (typeof VALID_ACTIVITY_TYPES)[number];
 
 export interface ActivityPROptions extends GlobalOptions {
   limit?: string;
@@ -47,7 +60,7 @@ export class ActivityPRCommand extends BaseCommand<
       ...options,
     });
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parseIntOption(options.id, 'id');
     const filterTypes = this.parseTypeFilter(options.type);
     const limit = parseLimit(options.limit);
 
@@ -74,7 +87,9 @@ export class ActivityPRCommand extends BaseCommand<
           return true;
         }
 
-        return filterTypes.includes(this.getActivityType(activity));
+        return (filterTypes as readonly string[]).includes(
+          this.getActivityType(activity)
+        );
       },
     });
 
@@ -114,15 +129,29 @@ export class ActivityPRCommand extends BaseCommand<
     this.output.table(['TYPE', 'ACTOR', 'DATE', 'DETAILS'], rows);
   }
 
-  private parseTypeFilter(typeOption?: string): string[] {
+  private parseTypeFilter(typeOption?: string): ActivityType[] {
     if (!typeOption) {
       return [];
     }
 
-    return typeOption
+    const requested = typeOption
       .split(',')
       .map((type) => type.trim().toLowerCase())
       .filter((type) => type.length > 0);
+
+    const invalid = requested.filter(
+      (type) => !VALID_ACTIVITY_TYPES.includes(type as ActivityType)
+    );
+
+    if (invalid.length > 0) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `--type must be one of: ${VALID_ACTIVITY_TYPES.join(', ')}`,
+        context: { invalid },
+      });
+    }
+
+    return requested as ActivityType[];
   }
 
   private getActivityType(activity: PullrequestActivity): string {

--- a/src/commands/pr/checks.command.ts
+++ b/src/commands/pr/checks.command.ts
@@ -11,9 +11,7 @@ import type {
 import type { CommitStatusesApi, Commitstatus } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
 
-export interface ChecksPROptions extends GlobalOptions {
-  json?: boolean;
-}
+export interface ChecksPROptions extends GlobalOptions {}
 
 export class ChecksPRCommand extends BaseCommand<
   { id: string } & ChecksPROptions,
@@ -40,7 +38,7 @@ export class ChecksPRCommand extends BaseCommand<
       ...options,
     });
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parseIntOption(options.id, 'id');
 
     const response =
       await this.commitStatusesApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdStatusesGet(
@@ -55,9 +53,7 @@ export class ChecksPRCommand extends BaseCommand<
     const statuses = data?.values ? Array.from(data.values) : [];
     const summary = this.getSummary(statuses);
 
-    const useJson = options.json || context.globalOptions.json;
-
-    if (useJson) {
+    if (context.globalOptions.json) {
       this.output.json({
         pullRequestId: prId,
         workspace: repoContext.workspace,

--- a/src/commands/pr/merge.command.ts
+++ b/src/commands/pr/merge.command.ts
@@ -48,7 +48,7 @@ export class MergePRCommand extends BaseCommand<
       ...options,
     });
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parseIntOption(options.id, 'id');
 
     const request: {
       type: 'pullrequest_merge_parameters';

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -37,7 +37,7 @@ export class ViewPRCommand extends BaseCommand<
       ...options,
     });
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parseIntOption(options.id, 'id');
 
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -856,6 +856,21 @@ describe('ViewPRCommand', () => {
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
+
+  it('should reject a non-integer --id', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ViewPRCommand(pullrequestsApi, contextService, output);
+
+    await expect(
+      command.execute({ id: 'abc' }, { globalOptions: {} })
+    ).rejects.toThrow(/--id must be a valid integer/);
+  });
 });
 
 describe('ActivityPRCommand', () => {
@@ -991,6 +1006,44 @@ describe('ActivityPRCommand', () => {
     const rows = getTableRows(output.logs);
     expect(rows).toHaveLength(1);
     expect(requestedPages).toEqual([1, 2]);
+  });
+
+  it('should reject a non-integer --id', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+
+    await expect(
+      command.execute({ id: 'abc' }, { globalOptions: {} })
+    ).rejects.toThrow(/--id must be a valid integer/);
+  });
+
+  it('should reject an invalid --type value', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+
+    await expect(
+      command.execute({ id: '1', type: 'commetn' }, { globalOptions: {} })
+    ).rejects.toThrow(/--type must be one of/);
   });
 });
 
@@ -1145,7 +1198,7 @@ describe('ChecksPRCommand', () => {
       contextService,
       output
     );
-    await command.execute({ id: '1', json: true }, { globalOptions: {} });
+    await command.execute({ id: '1' }, { globalOptions: { json: true } });
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
@@ -1415,6 +1468,21 @@ describe('MergePRCommand', () => {
     );
 
     expect(output.logs.some((log) => log.includes('Merged'))).toBe(true);
+  });
+
+  it('should reject a non-integer --id', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new MergePRCommand(pullrequestsApi, contextService, output);
+
+    await expect(
+      command.execute({ id: 'abc' }, { globalOptions: {} })
+    ).rejects.toThrow(/--id must be a valid integer/);
   });
 });
 


### PR DESCRIPTION
## Summary

PR command hardening pass covering the three items in #144:

- **Integer parsing** — `bb pr view`, `bb pr activity`, and `bb pr merge` now use `BaseCommand.parseIntOption()` for `<pr-id>` instead of raw `Number.parseInt`, matching the pattern already used by `bb pr comments delete`. Invalid input now throws a clean `--id must be a valid integer` error instead of silently passing `NaN` to the Bitbucket API. (Also applied to `bb pr checks` while touching it — same latent bug.)
- **Activity `--type` enum validation** — `bb pr activity --type` now rejects unknown types (e.g. `--type commetn`) with `--type must be one of: comment, approval, changes_requested, merge, decline, commit, update` instead of silently filtering to zero results.
- **Redundant `--json` on `pr checks`** — removed the local `.option('--json', ...)` and the corresponding `json?` field on `ChecksPROptions`. The global `--json` already covers it; no other command does this, and the local option only bloated `--help`.

Closes #144.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (579 pass, 0 fail)
- [x] `bun run format:check`
- [x] Added unit tests: NaN-rejection for view/activity/merge, invalid-type rejection for activity, and reworked the existing `pr checks` JSON test to use the global `--json` path.
- [x] Changeset added (`patch`)