### PR TITLE
feat(pr): support default reviewers (closes #139)

### DIFF
--- a/.changeset/default-reviewers-support.md
+++ b/.changeset/default-reviewers-support.md
@@ -1,0 +1,13 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add support for Bitbucket Default Reviewers (closes #139).
+
+- New `bb repo default-reviewers list|add|remove` commands to inspect and manage the default reviewers of a repository. `list` shows the effective set (repo-level plus project-inherited) by default; pass `--direct` for only repo-level entries. `remove` requires `--yes` to confirm.
+- `bb pr create` gains opt-in support for default reviewers:
+  - `--default-reviewers` fetches and attaches the repository's effective default reviewers (matching the web UI behavior).
+  - `--reviewer <username>` (repeatable) adds explicit reviewers independent of the defaults.
+  - `--no-default-reviewers` skips defaults when the config key enables them.
+  - The PR author is automatically excluded from the reviewer list.
+- New config key `prCreateIncludeDefaultReviewers` (boolean, default `false`) makes `--default-reviewers` the default behavior on `bb pr create`.

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -25,6 +25,7 @@ The configuration file stores your CLI settings and authentication credentials.
 | `defaultWorkspace` | Default workspace for commands |
 | `skipVersionCheck` | Disable update notifications (default: false) |
 | `versionCheckInterval` | Days between update checks (default: 1) |
+| `prCreateIncludeDefaultReviewers` | Auto-add the repo's default reviewers on `bb pr create` (default: false) |
 
 ### Configuration File Format
 
@@ -36,7 +37,8 @@ The config file is stored as JSON:
   "apiToken": "***",
   "defaultWorkspace": "myworkspace",
   "skipVersionCheck": false,
-  "versionCheckInterval": 1
+  "versionCheckInterval": 1,
+  "prCreateIncludeDefaultReviewers": false
 }
 ```
 
@@ -103,6 +105,7 @@ bb config set <key> <value>
 | `defaultWorkspace` | Any string | string |
 | `skipVersionCheck` | `true` or `false` | boolean |
 | `versionCheckInterval` | Positive integer (`>= 1`) | number |
+| `prCreateIncludeDefaultReviewers` | `true` or `false` | boolean |
 
 ### Examples
 

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -29,7 +29,7 @@ bb pr create [options]
 | `-r, --repo <repo>` | Repository |
 | `--close-source-branch` | Close source branch after merge |
 | `--draft` | Create the pull request as draft |
-| `--reviewer <username>` | Add a reviewer by username (repeatable) |
+| `--reviewer <user>` | Add a reviewer by account ID or `{uuid}` (repeatable) |
 | `--default-reviewers` | Include the repository's default reviewers (opt-in) |
 | `--no-default-reviewers` | Skip default reviewers even when the config key enables them |
 | `--json` | Output as JSON |
@@ -52,11 +52,14 @@ bb pr create -t "WIP: Add feature" --draft
 # Auto-add the repo's default reviewers (matches the Bitbucket web UI)
 bb pr create -t "Add new feature" --default-reviewers
 
-# Add specific reviewers (repeatable)
-bb pr create -t "Add new feature" --reviewer jdoe --reviewer asmith
+# Add specific reviewers (repeatable; accepts account ID or {uuid})
+bb pr create -t "Add new feature" \
+  --reviewer "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" \
+  --reviewer "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
 
 # Combine defaults + explicit additions (duplicates are de-duped)
-bb pr create -t "Add new feature" --default-reviewers --reviewer jdoe
+bb pr create -t "Add new feature" --default-reviewers \
+  --reviewer "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
 ```
 
 ### Reviewers
@@ -64,7 +67,7 @@ bb pr create -t "Add new feature" --default-reviewers --reviewer jdoe
 By default `bb pr create` does **not** attach reviewers to the PR — this differs from the Bitbucket web UI, which auto-populates the repository's default reviewers.
 
 - `--default-reviewers` opts in per-invocation. The command fetches the repository's *effective* default reviewers (repo-level + project-inherited) and attaches them.
-- `--reviewer <username>` adds specific reviewers regardless of the defaults and can be passed multiple times.
+- `--reviewer <user>` adds specific reviewers regardless of the defaults and can be passed multiple times. Accepts an **account ID** (e.g. `712020:3cfed7e0-...`) or a **UUID** in curly braces (e.g. `{c1cb1bb5-...}`). Bitbucket Cloud's GDPR changes retired username lookups, so nicknames are not accepted.
 - The PR author is automatically excluded from the reviewer list — Bitbucket rejects PRs that list the author as a reviewer.
 - To make `--default-reviewers` the default behavior, set the config key:
   ```bash

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -29,6 +29,9 @@ bb pr create [options]
 | `-r, --repo <repo>` | Repository |
 | `--close-source-branch` | Close source branch after merge |
 | `--draft` | Create the pull request as draft |
+| `--reviewer <username>` | Add a reviewer by username (repeatable) |
+| `--default-reviewers` | Include the repository's default reviewers (opt-in) |
+| `--no-default-reviewers` | Skip default reviewers even when the config key enables them |
 | `--json` | Output as JSON |
 
 ### Examples
@@ -45,7 +48,32 @@ bb pr create -t "Hotfix: Critical bug" --close-source-branch
 
 # Create a draft PR
 bb pr create -t "WIP: Add feature" --draft
+
+# Auto-add the repo's default reviewers (matches the Bitbucket web UI)
+bb pr create -t "Add new feature" --default-reviewers
+
+# Add specific reviewers (repeatable)
+bb pr create -t "Add new feature" --reviewer jdoe --reviewer asmith
+
+# Combine defaults + explicit additions (duplicates are de-duped)
+bb pr create -t "Add new feature" --default-reviewers --reviewer jdoe
 ```
+
+### Reviewers
+
+By default `bb pr create` does **not** attach reviewers to the PR — this differs from the Bitbucket web UI, which auto-populates the repository's default reviewers.
+
+- `--default-reviewers` opts in per-invocation. The command fetches the repository's *effective* default reviewers (repo-level + project-inherited) and attaches them.
+- `--reviewer <username>` adds specific reviewers regardless of the defaults and can be passed multiple times.
+- The PR author is automatically excluded from the reviewer list — Bitbucket rejects PRs that list the author as a reviewer.
+- To make `--default-reviewers` the default behavior, set the config key:
+  ```bash
+  bb config set prCreateIncludeDefaultReviewers true
+  ```
+  Pass `--no-default-reviewers` to skip defaults for a single invocation when this is enabled.
+- If the default-reviewer fetch fails (network error, permission issue, etc.), the PR is still created without reviewers and a warning is printed — the failure does not block the creation.
+
+See [`bb repo default-reviewers`](/commands/repo/#bb-repo-default-reviewers) to inspect or manage the underlying default reviewer list.
 
 ---
 

--- a/docs/src/content/docs/commands/pr/index.mdx
+++ b/docs/src/content/docs/commands/pr/index.mdx
@@ -58,6 +58,7 @@ Global options available on all PR commands: `--json`, `--no-color`, `-w, --work
 | Task | Command |
 |------|---------|
 | Create a PR | `bb pr create -t "Add feature"` |
+| Create a PR with the repo's default reviewers | `bb pr create -t "Add feature" --default-reviewers` |
 | List open PRs | `bb pr list` |
 | List PRs where you are a reviewer | `bb pr list --mine` |
 | View PR details | `bb pr view 42` |

--- a/docs/src/content/docs/commands/pr/reviewers.mdx
+++ b/docs/src/content/docs/commands/pr/reviewers.mdx
@@ -9,6 +9,10 @@ Manage pull request reviewers.
 
 Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
 
+:::tip[Looking for repo-level defaults?]
+This page covers reviewers on **existing** pull requests. To manage the repository's **default reviewers** — the list Bitbucket auto-suggests when someone opens a PR — see [`bb repo default-reviewers`](/commands/repo/#bb-repo-default-reviewers). `bb pr create` can also auto-apply them via `--default-reviewers` or the `prCreateIncludeDefaultReviewers` config key.
+:::
+
 ## `bb pr reviewers`
 
 ### Subcommands

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -209,8 +209,8 @@ Inspect and manage the default reviewers configured on a repository. Default rev
 | Subcommand | Description |
 |------------|-------------|
 | `list` | List the default reviewers for a repository |
-| `add <username>` | Add a default reviewer |
-| `remove <username>` | Remove a default reviewer (requires `--yes`) |
+| `add <user>` | Add a default reviewer (accepts account ID or `{uuid}`) |
+| `remove <user>` | Remove a default reviewer (accepts account ID or `{uuid}`, requires `--yes`) |
 
 ### `bb repo default-reviewers list`
 
@@ -239,25 +239,32 @@ bb repo default-reviewers list --json
 ### `bb repo default-reviewers add`
 
 ```bash
-bb repo default-reviewers add <username>
+bb repo default-reviewers add <user>
 ```
 
 Adds a user as a default reviewer on the repository. Requires repository admin permission.
 
+The `<user>` argument accepts either an **account ID** (e.g. `712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f`) or a **UUID** in curly braces (e.g. `{c1cb1bb5-2e32-456e-a373-43978dc12aa1}`). Bitbucket Cloud's GDPR changes retired username lookups, so nicknames like `jdoe` are no longer accepted.
+
+You can find a user's account ID from the Bitbucket web UI under their profile, or by running `bb pr reviewers list <pr-id> --json` on a PR they've reviewed.
+
 ```bash
-bb repo default-reviewers add jdoe
+bb repo default-reviewers add "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
+bb repo default-reviewers add "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
 ```
 
 ### `bb repo default-reviewers remove`
 
 ```bash
-bb repo default-reviewers remove <username> --yes
+bb repo default-reviewers remove <user> --yes
 ```
 
 Removes a user from the repository's default reviewers. `--yes` is required to confirm. Requires repository admin permission.
 
+`<user>` accepts the same identifiers as `add` (account ID or `{uuid}`).
+
 ```bash
-bb repo default-reviewers remove jdoe --yes
+bb repo default-reviewers remove "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --yes
 ```
 
 ### Notes

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -222,7 +222,7 @@ By default the **effective** reviewer list is shown — this includes reviewers 
 
 | Option | Description |
 |--------|-------------|
-| `--direct` | Only show reviewers configured on the repository (exclude project-inherited) |
+| `--repo-only` | Only show reviewers configured on the repository (exclude project-inherited) |
 | `--json` | Output as JSON |
 
 ```bash
@@ -230,7 +230,7 @@ By default the **effective** reviewer list is shown — this includes reviewers 
 bb repo default-reviewers list
 
 # Only repo-level entries
-bb repo default-reviewers list --direct
+bb repo default-reviewers list --repo-only
 
 # JSON for scripting
 bb repo default-reviewers list --json

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -197,3 +197,70 @@ bb repo delete myrepo -w myworkspace --yes
 :::danger
 This action is permanent and cannot be undone! All repository data, including code, issues, and pull requests will be deleted.
 :::
+
+---
+
+## `bb repo default-reviewers`
+
+Inspect and manage the default reviewers configured on a repository. Default reviewers in Bitbucket Cloud are automatically suggested when someone opens a pull request through the web UI; this command group lets you see and edit that list from the CLI.
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List the default reviewers for a repository |
+| `add <username>` | Add a default reviewer |
+| `remove <username>` | Remove a default reviewer (requires `--yes`) |
+
+### `bb repo default-reviewers list`
+
+```bash
+bb repo default-reviewers list [options]
+```
+
+By default the **effective** reviewer list is shown — this includes reviewers configured directly on the repository *and* reviewers inherited from the parent project, matching what Bitbucket's web UI would auto-populate.
+
+| Option | Description |
+|--------|-------------|
+| `--direct` | Only show reviewers configured on the repository (exclude project-inherited) |
+| `--json` | Output as JSON |
+
+```bash
+# Effective list (repo + project-inherited)
+bb repo default-reviewers list
+
+# Only repo-level entries
+bb repo default-reviewers list --direct
+
+# JSON for scripting
+bb repo default-reviewers list --json
+```
+
+### `bb repo default-reviewers add`
+
+```bash
+bb repo default-reviewers add <username>
+```
+
+Adds a user as a default reviewer on the repository. Requires repository admin permission.
+
+```bash
+bb repo default-reviewers add jdoe
+```
+
+### `bb repo default-reviewers remove`
+
+```bash
+bb repo default-reviewers remove <username> --yes
+```
+
+Removes a user from the repository's default reviewers. `--yes` is required to confirm. Requires repository admin permission.
+
+```bash
+bb repo default-reviewers remove jdoe --yes
+```
+
+### Notes
+
+- Project-inherited reviewers can only be removed by editing the parent project, not the repository.
+- Related: [`bb pr create --default-reviewers`](/commands/pr/create-and-edit/) applies these reviewers when opening a pull request.

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -75,6 +75,8 @@ Pick your editor and paste the command:
 
     **Pull Requests:**
     - `bb pr create -t "title" -b "body"` - Create PR from current branch
+    - `bb pr create --default-reviewers` - Also attach the repo's default reviewers
+    - `bb pr create --reviewer <uuid>` - Add a specific reviewer (repeatable)
     - `bb pr list` - List open PRs (`--mine` for your reviews, `--json` for scripts)
     - `bb pr view <id>` / `bb pr diff <id>` - Inspect a PR
     - `bb pr checkout <id>` - Check out PR locally
@@ -82,10 +84,11 @@ Pick your editor and paste the command:
     - `bb pr merge <id> --strategy squash --close-source-branch` - Merge
     - `bb pr ready <id>` - Mark draft as ready
     - `bb pr comments add <id> "text"` - Add comment
-    - `bb pr reviewers add <id> <uuid>` - Add reviewer
+    - `bb pr reviewers add <id> <uuid>` - Add reviewer to an existing PR
 
     **Repositories:**
     - `bb repo list` / `bb repo view` / `bb repo clone workspace/repo`
+    - `bb repo default-reviewers list` / `add <uuid>` / `remove <uuid> --yes` - Manage repo default reviewers
 
     **Configuration:**
     - `bb config set defaultWorkspace myworkspace`

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -24,8 +24,8 @@ The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide
 Currently supported:
 
 - **Authentication** - Login, logout, status, token display
-- **Repositories** - Clone, create, list, view, delete
-- **Pull Requests** - Create, list, view, edit, merge, approve, decline, ready (mark draft ready), checkout, diff, activity log, CI/CD checks, comments (list/add/edit/delete), reviewers (list/add/remove)
+- **Repositories** - Clone, create, list, view, delete, default reviewers (list/add/remove)
+- **Pull Requests** - Create (with optional default-reviewer attachment), list, view, edit, merge, approve, decline, ready (mark draft ready), checkout, diff, activity log, CI/CD checks, comments (list/add/edit/delete), reviewers (list/add/remove)
 - **Snippets** - List, view (with file contents), create, edit (metadata or file upload), delete, watch/unwatch, comments (list/add/edit/delete)
 - **Configuration** - Get, set, list settings
 - **Shell Completion** - Bash, Zsh, Fish

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -41,6 +41,7 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 | `defaultWorkspace` | string | Default workspace | `bb config set defaultWorkspace` |
 | `skipVersionCheck` | boolean | Disable update notifications | `bb config set` |
 | `versionCheckInterval` | number | Days between update checks (default: 1) | `bb config set` |
+| `prCreateIncludeDefaultReviewers` | boolean | Auto-add the repo's default reviewers on `bb pr create` (default: false) | `bb config set` |
 | `lastVersionCheck` | string | Timestamp of last update check | Automatic |
 
 ### Example Configuration (OAuth)
@@ -113,6 +114,7 @@ Typed key validation:
 
 - `skipVersionCheck` accepts only `true` or `false`
 - `versionCheckInterval` accepts only positive integers (`>= 1`)
+- `prCreateIncludeDefaultReviewers` accepts only `true` or `false`
 
 Values are stored as native JSON types, so `bb config get <key> --json` returns booleans/numbers for these keys.
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -329,26 +329,38 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const service = container.resolve<DefaultReviewerService>(
       ServiceTokens.DefaultReviewerService
     );
+    const usersApi = container.resolve<UsersApi>(ServiceTokens.UsersApi);
     const contextService = container.resolve<ContextService>(
       ServiceTokens.ContextService
     );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new AddDefaultReviewerCommand(service, contextService, output);
+    return new AddDefaultReviewerCommand(
+      service,
+      usersApi,
+      contextService,
+      output
+    );
   });
 
   container.register(ServiceTokens.RemoveDefaultReviewerCommand, () => {
     const service = container.resolve<DefaultReviewerService>(
       ServiceTokens.DefaultReviewerService
     );
+    const usersApi = container.resolve<UsersApi>(ServiceTokens.UsersApi);
     const contextService = container.resolve<ContextService>(
       ServiceTokens.ContextService
     );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
-    return new RemoveDefaultReviewerCommand(service, contextService, output);
+    return new RemoveDefaultReviewerCommand(
+      service,
+      usersApi,
+      contextService,
+      output
+    );
   });
 
   // Register PR commands

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -12,6 +12,7 @@ import {
   OAuthService,
   createApiClient,
   SnippetFilesService,
+  DefaultReviewerService,
 } from './services/index.js';
 import type { AxiosInstance } from 'axios';
 import { createRequire } from 'node:module';
@@ -40,6 +41,9 @@ import { CreateRepoCommand } from './commands/repo/create.command.js';
 import { ListReposCommand } from './commands/repo/list.command.js';
 import { ViewRepoCommand } from './commands/repo/view.command.js';
 import { DeleteRepoCommand } from './commands/repo/delete.command.js';
+import { ListDefaultReviewersCommand } from './commands/repo/default-reviewers.list.command.js';
+import { AddDefaultReviewerCommand } from './commands/repo/default-reviewers.add.command.js';
+import { RemoveDefaultReviewerCommand } from './commands/repo/default-reviewers.remove.command.js';
 
 // PR commands
 import { CreatePRCommand } from './commands/pr/create.command.js';
@@ -300,22 +304,79 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     return new DeleteRepoCommand(repositoriesApi, contextService, output);
   });
 
+  // Register default reviewer service
+  container.register(ServiceTokens.DefaultReviewerService, () => {
+    const pullrequestsApi = container.resolve<PullrequestsApi>(
+      ServiceTokens.PullrequestsApi
+    );
+    return new DefaultReviewerService(pullrequestsApi);
+  });
+
+  container.register(ServiceTokens.ListDefaultReviewersCommand, () => {
+    const service = container.resolve<DefaultReviewerService>(
+      ServiceTokens.DefaultReviewerService
+    );
+    const contextService = container.resolve<ContextService>(
+      ServiceTokens.ContextService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new ListDefaultReviewersCommand(service, contextService, output);
+  });
+
+  container.register(ServiceTokens.AddDefaultReviewerCommand, () => {
+    const service = container.resolve<DefaultReviewerService>(
+      ServiceTokens.DefaultReviewerService
+    );
+    const contextService = container.resolve<ContextService>(
+      ServiceTokens.ContextService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new AddDefaultReviewerCommand(service, contextService, output);
+  });
+
+  container.register(ServiceTokens.RemoveDefaultReviewerCommand, () => {
+    const service = container.resolve<DefaultReviewerService>(
+      ServiceTokens.DefaultReviewerService
+    );
+    const contextService = container.resolve<ContextService>(
+      ServiceTokens.ContextService
+    );
+    const output = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return new RemoveDefaultReviewerCommand(service, contextService, output);
+  });
+
   // Register PR commands
   container.register(ServiceTokens.CreatePRCommand, () => {
     const pullrequestsApi = container.resolve<PullrequestsApi>(
       ServiceTokens.PullrequestsApi
     );
+    const usersApi = container.resolve<UsersApi>(ServiceTokens.UsersApi);
     const contextService = container.resolve<ContextService>(
       ServiceTokens.ContextService
     );
     const gitService = container.resolve<GitService>(ServiceTokens.GitService);
+    const defaultReviewerService = container.resolve<DefaultReviewerService>(
+      ServiceTokens.DefaultReviewerService
+    );
+    const configService = container.resolve<ConfigService>(
+      ServiceTokens.ConfigService
+    );
     const output = container.resolve<OutputService>(
       ServiceTokens.OutputService
     );
     return new CreatePRCommand(
       pullrequestsApi,
+      usersApi,
       contextService,
       gitService,
+      defaultReviewerService,
+      configService,
       output
     );
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -445,7 +445,7 @@ repoDefaultReviewersCmd
   .command('list')
   .description('List default reviewers for a repository')
   .option(
-    '--direct',
+    '--repo-only',
     'Only show reviewers configured on the repository (exclude project-inherited)'
   )
   .addHelpText(
@@ -453,7 +453,7 @@ repoDefaultReviewersCmd
     buildHelpText({
       examples: [
         'bb repo default-reviewers list',
-        'bb repo default-reviewers list --direct',
+        'bb repo default-reviewers list --repo-only',
         'bb repo default-reviewers list --json',
       ],
     })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,16 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
     if (env.prev === 'auth') {
       completions.push('login', 'logout', 'status', 'token');
     } else if (env.prev === 'repo') {
-      completions.push('clone', 'create', 'list', 'view', 'delete');
+      completions.push(
+        'clone',
+        'create',
+        'list',
+        'view',
+        'delete',
+        'default-reviewers'
+      );
+    } else if (env.prev === 'default-reviewers') {
+      completions.push('list', 'add', 'remove');
     } else if (env.prev === 'pr') {
       completions.push(
         'create',
@@ -428,6 +437,78 @@ repoCmd
     );
   });
 
+const repoDefaultReviewersCmd = new Command('default-reviewers').description(
+  'Manage default reviewers for a repository'
+);
+
+repoDefaultReviewersCmd
+  .command('list')
+  .description('List default reviewers for a repository')
+  .option(
+    '--direct',
+    'Only show reviewers configured on the repository (exclude project-inherited)'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb repo default-reviewers list',
+        'bb repo default-reviewers list --direct',
+        'bb repo default-reviewers list --json',
+      ],
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListDefaultReviewersCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+repoDefaultReviewersCmd
+  .command('add <username>')
+  .description('Add a default reviewer to a repository')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb repo default-reviewers add jdoe'],
+    })
+  )
+  .action(async (username, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.AddDefaultReviewerCommand,
+      withGlobalOptions({ username, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+repoDefaultReviewersCmd
+  .command('remove <username>')
+  .description('Remove a default reviewer from a repository')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb repo default-reviewers remove jdoe --yes'],
+    })
+  )
+  .action(async (username, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.RemoveDefaultReviewerCommand,
+      withGlobalOptions({ username, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+repoCmd.addCommand(repoDefaultReviewersCmd);
+
 cli.addCommand(repoCmd);
 
 // PR commands
@@ -442,6 +523,16 @@ prCmd
   .option('-d, --destination <branch>', 'Destination branch (default: main)')
   .option('--close-source-branch', 'Close source branch after merge')
   .option('--draft', 'Create the pull request as draft')
+  .option(
+    '--reviewer <username>',
+    'Add a reviewer by username (repeatable)',
+    (value: string, previous: string[]) => previous.concat([value]),
+    [] as string[]
+  )
+  .option(
+    '--default-reviewers',
+    "Include the repository's default reviewers (pass --no-default-reviewers to skip when the config key is enabled)"
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -450,10 +541,14 @@ prCmd
         'bb pr create -t "My PR" --draft',
         'bb pr create -t "My PR" -s feature -d develop',
         'bb pr create -t "My PR" --close-source-branch',
+        'bb pr create -t "My PR" --default-reviewers',
+        'bb pr create -t "My PR" --reviewer jdoe --reviewer asmith',
       ],
       defaults: {
         source: 'current git branch',
         destination: 'main',
+        'default-reviewers':
+          'false (override with --default-reviewers or config key prCreateIncludeDefaultReviewers)',
       },
     })
   )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -469,12 +469,17 @@ repoDefaultReviewersCmd
   });
 
 repoDefaultReviewersCmd
-  .command('add <username>')
-  .description('Add a default reviewer to a repository')
+  .command('add <user>')
+  .description(
+    'Add a default reviewer to a repository (accepts account ID or {uuid})'
+  )
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb repo default-reviewers add jdoe'],
+      examples: [
+        'bb repo default-reviewers add "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"',
+        'bb repo default-reviewers add "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"',
+      ],
     })
   )
   .action(async (username, options) => {
@@ -488,13 +493,17 @@ repoDefaultReviewersCmd
   });
 
 repoDefaultReviewersCmd
-  .command('remove <username>')
-  .description('Remove a default reviewer from a repository')
+  .command('remove <user>')
+  .description(
+    'Remove a default reviewer from a repository (accepts account ID or {uuid})'
+  )
   .option('-y, --yes', 'Skip confirmation prompt')
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb repo default-reviewers remove jdoe --yes'],
+      examples: [
+        'bb repo default-reviewers remove "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --yes',
+      ],
     })
   )
   .action(async (username, options) => {
@@ -524,8 +533,8 @@ prCmd
   .option('--close-source-branch', 'Close source branch after merge')
   .option('--draft', 'Create the pull request as draft')
   .option(
-    '--reviewer <username>',
-    'Add a reviewer by username (repeatable)',
+    '--reviewer <user>',
+    'Add a reviewer by account ID or {uuid} (repeatable)',
     (value: string, previous: string[]) => previous.concat([value]),
     [] as string[]
   )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -529,9 +529,10 @@ prCmd
     (value: string, previous: string[]) => previous.concat([value]),
     [] as string[]
   )
+  .option('--default-reviewers', "Include the repository's default reviewers")
   .option(
-    '--default-reviewers',
-    "Include the repository's default reviewers (pass --no-default-reviewers to skip when the config key is enabled)"
+    '--no-default-reviewers',
+    "Skip the repository's default reviewers even when prCreateIncludeDefaultReviewers is true"
   )
   .addHelpText(
     'after',

--- a/src/commands/config/list.command.ts
+++ b/src/commands/config/list.command.ts
@@ -9,7 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import {
-  coerceSkipVersionCheckValue,
+  coerceBooleanConfigValue,
   coerceVersionCheckIntervalValue,
 } from '../../types/config.js';
 
@@ -19,6 +19,7 @@ export interface ConfigDisplay {
   apiToken?: string;
   skipVersionCheck?: boolean;
   versionCheckInterval?: number;
+  prCreateIncludeDefaultReviewers?: boolean;
 }
 
 export class ListConfigCommand extends BaseCommand<void, void> {
@@ -49,7 +50,7 @@ export class ListConfigCommand extends BaseCommand<void, void> {
       displayConfig.apiToken = '********';
     }
 
-    const skipVersionCheck = coerceSkipVersionCheckValue(
+    const skipVersionCheck = coerceBooleanConfigValue(
       config.skipVersionCheck as unknown
     );
     if (skipVersionCheck !== undefined) {
@@ -61,6 +62,14 @@ export class ListConfigCommand extends BaseCommand<void, void> {
     );
     if (versionCheckInterval !== undefined) {
       displayConfig.versionCheckInterval = versionCheckInterval;
+    }
+
+    const prCreateIncludeDefaultReviewers = coerceBooleanConfigValue(
+      config.prCreateIncludeDefaultReviewers as unknown
+    );
+    if (prCreateIncludeDefaultReviewers !== undefined) {
+      displayConfig.prCreateIncludeDefaultReviewers =
+        prCreateIncludeDefaultReviewers;
     }
 
     if (context.globalOptions.json) {

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -5,11 +5,18 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
+  IConfigService,
   IContextService,
   IGitService,
   IOutputService,
 } from '../../core/interfaces/services.js';
-import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
+import type {
+  Account,
+  PullrequestsApi,
+  Pullrequest,
+  UsersApi,
+} from '../../generated/api.js';
+import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
 
@@ -20,6 +27,13 @@ export interface CreatePROptions extends GlobalOptions {
   destination?: string;
   closeSourceBranch?: boolean;
   draft?: boolean;
+  reviewer?: string[];
+  defaultReviewers?: boolean;
+}
+
+interface ResolvedReviewer {
+  uuid: string;
+  label: string;
 }
 
 export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
@@ -28,8 +42,11 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
 
   constructor(
     private readonly pullrequestsApi: PullrequestsApi,
+    private readonly usersApi: UsersApi,
     private readonly contextService: IContextService,
     private readonly gitService: IGitService,
+    private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly configService: IConfigService,
     output: IOutputService
   ) {
     super(output);
@@ -58,6 +75,14 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
 
     const destinationBranch = options.destination || 'main';
 
+    const includeDefaults = await this.shouldIncludeDefaults(options);
+    const explicitUsernames = options.reviewer ?? [];
+    const reviewers = await this.resolveReviewers(
+      repoContext,
+      includeDefaults,
+      explicitUsernames
+    );
+
     const request: Pullrequest = {
       type: 'pullrequest',
       title: options.title,
@@ -81,6 +106,12 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
       request.draft = true;
     }
 
+    if (reviewers.length > 0) {
+      request.reviewers = reviewers.map(
+        (r) => ({ type: 'user', uuid: r.uuid }) as Account
+      );
+    }
+
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPost({
         workspace: repoContext.workspace,
@@ -99,5 +130,87 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
     this.output.success(`Created pull request #${pr.id}`);
     this.output.text(`  ${this.output.dim('Title:')} ${pr.title}`);
     this.output.text(`  ${this.output.dim('URL:')} ${links?.html?.href}`);
+    if (reviewers.length > 0) {
+      const labels = reviewers.map((r) => r.label).join(', ');
+      this.output.text(`  ${this.output.dim('Reviewers:')} ${labels}`);
+    }
+  }
+
+  private async shouldIncludeDefaults(
+    options: CreatePROptions
+  ): Promise<boolean> {
+    if (typeof options.defaultReviewers === 'boolean') {
+      return options.defaultReviewers;
+    }
+
+    const config = await this.configService.getConfig();
+    return config.prCreateIncludeDefaultReviewers === true;
+  }
+
+  private async resolveReviewers(
+    repoContext: { workspace: string; repoSlug: string },
+    includeDefaults: boolean,
+    explicitUsernames: string[]
+  ): Promise<ResolvedReviewer[]> {
+    const byUuid = new Map<string, ResolvedReviewer>();
+
+    if (includeDefaults) {
+      try {
+        const defaults = await this.defaultReviewerService.list(
+          repoContext,
+          'effective'
+        );
+        for (const entry of defaults) {
+          if (!entry.uuid) {
+            continue;
+          }
+          byUuid.set(entry.uuid, {
+            uuid: entry.uuid,
+            label: entry.displayName ?? entry.nickname ?? entry.uuid,
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.output.warning(
+          `Could not fetch default reviewers: ${message}. Continuing without them.`
+        );
+      }
+    }
+
+    for (const username of explicitUsernames) {
+      const userResponse = await this.usersApi.usersSelectedUserGet({
+        selectedUser: username,
+      });
+      const user = userResponse.data;
+      if (!user.uuid) {
+        continue;
+      }
+      byUuid.set(user.uuid, {
+        uuid: user.uuid,
+        label: user.display_name ?? username,
+      });
+    }
+
+    if (byUuid.size === 0) {
+      return [];
+    }
+
+    const authorUuid = await this.getAuthorUuid();
+    if (authorUuid) {
+      byUuid.delete(authorUuid);
+    }
+
+    return Array.from(byUuid.values());
+  }
+
+  private async getAuthorUuid(): Promise<string | undefined> {
+    try {
+      const response = await this.usersApi.userGet();
+      return response.data.uuid;
+    } catch {
+      // If the /user lookup fails we accept the risk that Bitbucket will
+      // reject the PR with a 400 — better than failing the whole create.
+      return undefined;
+    }
   }
 }

--- a/src/commands/repo/default-reviewers.add.command.ts
+++ b/src/commands/repo/default-reviewers.add.command.ts
@@ -1,0 +1,61 @@
+/**
+ * Add a default reviewer to a repository.
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
+import type { GlobalOptions } from '../../types/config.js';
+
+export interface AddDefaultReviewerOptions extends GlobalOptions {
+  username: string;
+}
+
+export class AddDefaultReviewerCommand extends BaseCommand<
+  AddDefaultReviewerOptions,
+  void
+> {
+  public readonly name = 'default-reviewers.add';
+  public readonly description = 'Add a default reviewer to a repository';
+
+  constructor(
+    private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: AddDefaultReviewerOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    const entry = await this.defaultReviewerService.add(
+      repoContext,
+      options.username
+    );
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        reviewer: entry,
+      });
+      return;
+    }
+
+    this.output.success(
+      `Added ${entry.displayName ?? options.username} as a default reviewer for ${repoContext.workspace}/${repoContext.repoSlug}`
+    );
+  }
+}

--- a/src/commands/repo/default-reviewers.add.command.ts
+++ b/src/commands/repo/default-reviewers.add.command.ts
@@ -8,6 +8,7 @@ import type {
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
+import type { UsersApi } from '../../generated/api.js';
 import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
 
@@ -24,6 +25,7 @@ export class AddDefaultReviewerCommand extends BaseCommand<
 
   constructor(
     private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly usersApi: UsersApi,
     private readonly contextService: IContextService,
     output: IOutputService
   ) {
@@ -39,9 +41,18 @@ export class AddDefaultReviewerCommand extends BaseCommand<
       ...options,
     });
 
+    // Bitbucket's default-reviewers PUT accepts account_id or {uuid} in the
+    // URL path, but not the nickname. Resolve via the users API first so
+    // users can pass whatever handle they know.
+    const userResponse = await this.usersApi.usersSelectedUserGet({
+      selectedUser: options.username,
+    });
+    const user = userResponse.data;
+    const identifier = user.uuid ?? options.username;
+
     const entry = await this.defaultReviewerService.add(
       repoContext,
-      options.username
+      identifier
     );
 
     if (context.globalOptions.json) {
@@ -55,7 +66,7 @@ export class AddDefaultReviewerCommand extends BaseCommand<
     }
 
     this.output.success(
-      `Added ${entry.displayName ?? options.username} as a default reviewer for ${repoContext.workspace}/${repoContext.repoSlug}`
+      `Added ${entry.displayName ?? user.display_name ?? options.username} as a default reviewer for ${repoContext.workspace}/${repoContext.repoSlug}`
     );
   }
 }

--- a/src/commands/repo/default-reviewers.list.command.ts
+++ b/src/commands/repo/default-reviewers.list.command.ts
@@ -12,7 +12,7 @@ import type { DefaultReviewerService } from '../../services/default-reviewer.ser
 import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListDefaultReviewersOptions extends GlobalOptions {
-  direct?: boolean;
+  repoOnly?: boolean;
 }
 
 export class ListDefaultReviewersCommand extends BaseCommand<
@@ -39,7 +39,7 @@ export class ListDefaultReviewersCommand extends BaseCommand<
       ...options,
     });
 
-    const mode = options.direct ? 'direct' : 'effective';
+    const mode = options.repoOnly ? 'direct' : 'effective';
     const reviewers = await this.defaultReviewerService.list(repoContext, mode);
 
     if (context.globalOptions.json) {

--- a/src/commands/repo/default-reviewers.list.command.ts
+++ b/src/commands/repo/default-reviewers.list.command.ts
@@ -1,0 +1,77 @@
+/**
+ * List repository default reviewers command.
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
+import type { GlobalOptions } from '../../types/config.js';
+
+export interface ListDefaultReviewersOptions extends GlobalOptions {
+  direct?: boolean;
+}
+
+export class ListDefaultReviewersCommand extends BaseCommand<
+  ListDefaultReviewersOptions,
+  void
+> {
+  public readonly name = 'default-reviewers.list';
+  public readonly description = 'List default reviewers for a repository';
+
+  constructor(
+    private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListDefaultReviewersOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    const mode = options.direct ? 'direct' : 'effective';
+    const reviewers = await this.defaultReviewerService.list(repoContext, mode);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        mode,
+        count: reviewers.length,
+        reviewers,
+      });
+      return;
+    }
+
+    if (reviewers.length === 0) {
+      this.output.info('No default reviewers configured for this repository');
+      return;
+    }
+
+    if (mode === 'effective') {
+      this.output.table(
+        ['Display Name', 'Nickname', 'Source'],
+        reviewers.map((r) => [
+          r.displayName ?? 'Unknown',
+          r.nickname ?? '',
+          r.reviewerType ?? '',
+        ])
+      );
+    } else {
+      this.output.table(
+        ['Display Name', 'Nickname'],
+        reviewers.map((r) => [r.displayName ?? 'Unknown', r.nickname ?? ''])
+      );
+    }
+  }
+}

--- a/src/commands/repo/default-reviewers.remove.command.ts
+++ b/src/commands/repo/default-reviewers.remove.command.ts
@@ -8,6 +8,7 @@ import type {
   IContextService,
   IOutputService,
 } from '../../core/interfaces/services.js';
+import type { UsersApi } from '../../generated/api.js';
 import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
@@ -26,6 +27,7 @@ export class RemoveDefaultReviewerCommand extends BaseCommand<
 
   constructor(
     private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly usersApi: UsersApi,
     private readonly contextService: IContextService,
     output: IOutputService
   ) {
@@ -51,7 +53,13 @@ export class RemoveDefaultReviewerCommand extends BaseCommand<
       });
     }
 
-    await this.defaultReviewerService.remove(repoContext, options.username);
+    // Same as add: resolve via the users API so nicknames work.
+    const userResponse = await this.usersApi.usersSelectedUserGet({
+      selectedUser: options.username,
+    });
+    const identifier = userResponse.data.uuid ?? options.username;
+
+    await this.defaultReviewerService.remove(repoContext, identifier);
 
     if (context.globalOptions.json) {
       this.output.json({

--- a/src/commands/repo/default-reviewers.remove.command.ts
+++ b/src/commands/repo/default-reviewers.remove.command.ts
@@ -1,0 +1,70 @@
+/**
+ * Remove a default reviewer from a repository.
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface RemoveDefaultReviewerOptions extends GlobalOptions {
+  username: string;
+  yes?: boolean;
+}
+
+export class RemoveDefaultReviewerCommand extends BaseCommand<
+  RemoveDefaultReviewerOptions,
+  void
+> {
+  public readonly name = 'default-reviewers.remove';
+  public readonly description = 'Remove a default reviewer from a repository';
+
+  constructor(
+    private readonly defaultReviewerService: DefaultReviewerService,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: RemoveDefaultReviewerOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    if (!options.yes) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          `This will remove ${options.username} from the default reviewers of ` +
+          `${repoContext.workspace}/${repoContext.repoSlug}.\n` +
+          'Use --yes to confirm.',
+      });
+    }
+
+    await this.defaultReviewerService.remove(repoContext, options.username);
+
+    if (context.globalOptions.json) {
+      this.output.json({
+        success: true,
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        username: options.username,
+      });
+      return;
+    }
+
+    this.output.success(
+      `Removed ${options.username} from default reviewers of ${repoContext.workspace}/${repoContext.repoSlug}`
+    );
+  }
+}

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -150,6 +150,12 @@ export const ServiceTokens = {
   ListReposCommand: 'ListReposCommand',
   ViewRepoCommand: 'ViewRepoCommand',
   DeleteRepoCommand: 'DeleteRepoCommand',
+  ListDefaultReviewersCommand: 'ListDefaultReviewersCommand',
+  AddDefaultReviewerCommand: 'AddDefaultReviewerCommand',
+  RemoveDefaultReviewerCommand: 'RemoveDefaultReviewerCommand',
+
+  // Services - Default Reviewers
+  DefaultReviewerService: 'DefaultReviewerService',
 
   // Commands - PR
   CreatePRCommand: 'CreatePRCommand',

--- a/src/services/default-reviewer.service.ts
+++ b/src/services/default-reviewer.service.ts
@@ -1,0 +1,135 @@
+/**
+ * Default reviewer service.
+ *
+ * Wraps the Bitbucket repository default-reviewer endpoints and hides
+ * pagination + response-shape differences between the `default-reviewers`
+ * (plain) and `effective-default-reviewers` endpoints.
+ */
+
+import type {
+  Account,
+  DefaultReviewerAndType,
+  PaginatedAccounts,
+  PaginatedDefaultReviewerAndType,
+  PullrequestsApi,
+  User,
+} from '../generated/api.js';
+import type { RepoContext } from '../types/config.js';
+import { collectPages } from './pagination.js';
+
+export type DefaultReviewerMode = 'direct' | 'effective';
+
+export interface DefaultReviewerEntry {
+  uuid: string;
+  accountId?: string;
+  displayName?: string;
+  nickname?: string;
+  /** 'repository' | 'project' — only populated in `effective` mode. */
+  reviewerType?: string;
+}
+
+// Upper bound; the repo/project default reviewer list is small in practice
+// but we still want to walk pagination defensively.
+const LIST_LIMIT = 500;
+
+export class DefaultReviewerService {
+  constructor(private readonly pullrequestsApi: PullrequestsApi) {}
+
+  public async list(
+    repo: RepoContext,
+    mode: DefaultReviewerMode = 'effective'
+  ): Promise<DefaultReviewerEntry[]> {
+    if (mode === 'effective') {
+      return this.listEffective(repo);
+    }
+
+    return this.listDirect(repo);
+  }
+
+  public async add(
+    repo: RepoContext,
+    username: string
+  ): Promise<DefaultReviewerEntry> {
+    const response =
+      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(
+        {
+          workspace: repo.workspace,
+          repoSlug: repo.repoSlug,
+          targetUsername: username,
+        }
+      );
+
+    return accountToEntry(response.data);
+  }
+
+  public async remove(repo: RepoContext, username: string): Promise<void> {
+    await this.pullrequestsApi.repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(
+      {
+        workspace: repo.workspace,
+        repoSlug: repo.repoSlug,
+        targetUsername: username,
+      }
+    );
+  }
+
+  private async listDirect(repo: RepoContext): Promise<DefaultReviewerEntry[]> {
+    const accounts = await collectPages<Account>({
+      limit: LIST_LIMIT,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugDefaultReviewersGet(
+            {
+              workspace: repo.workspace,
+              repoSlug: repo.repoSlug,
+            },
+            { params: { page, pagelen } }
+          );
+        return response.data as PaginatedAccounts;
+      },
+    });
+
+    return accounts.map((account) => accountToEntry(account));
+  }
+
+  private async listEffective(
+    repo: RepoContext
+  ): Promise<DefaultReviewerEntry[]> {
+    const entries = await collectPages<DefaultReviewerAndType>({
+      limit: LIST_LIMIT,
+      fetchPage: async (page, pagelen) => {
+        const response =
+          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugEffectiveDefaultReviewersGet(
+            {
+              workspace: repo.workspace,
+              repoSlug: repo.repoSlug,
+            },
+            { params: { page, pagelen } }
+          );
+        return response.data as PaginatedDefaultReviewerAndType;
+      },
+    });
+
+    const mapped: DefaultReviewerEntry[] = [];
+    for (const entry of entries) {
+      const user = entry.user;
+      if (!user?.uuid) {
+        continue;
+      }
+      mapped.push({
+        ...accountToEntry(user),
+        reviewerType: entry.reviewer_type,
+      });
+    }
+    return mapped;
+  }
+}
+
+function accountToEntry(account: Account | User): DefaultReviewerEntry {
+  const asUser = account as User;
+  return {
+    uuid: account.uuid ?? '',
+    accountId: asUser.account_id,
+    displayName: account.display_name,
+    nickname: asUser.nickname,
+  };
+}

--- a/src/services/default-reviewer.service.ts
+++ b/src/services/default-reviewer.service.ts
@@ -50,13 +50,17 @@ export class DefaultReviewerService {
     repo: RepoContext,
     username: string
   ): Promise<DefaultReviewerEntry> {
+    // Bitbucket returns 400 if Content-Type: application/json is sent with an
+    // empty body (the global axios default). Send `{}` so the server sees a
+    // valid empty JSON document.
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(
         {
           workspace: repo.workspace,
           repoSlug: repo.repoSlug,
           targetUsername: username,
-        }
+        },
+        { data: {} }
       );
 
     return accountToEntry(response.data);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -16,3 +16,8 @@ export {
   buildReviewersUpdateBody,
   updatePullRequestReviewers,
 } from './reviewer.service.js';
+export { DefaultReviewerService } from './default-reviewer.service.js';
+export type {
+  DefaultReviewerEntry,
+  DefaultReviewerMode,
+} from './default-reviewer.service.js';

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -19,6 +19,7 @@ export interface BBConfig {
   lastVersionCheck?: string;
   skipVersionCheck?: boolean;
   versionCheckInterval?: number;
+  prCreateIncludeDefaultReviewers?: boolean;
 }
 
 export interface AuthCredentials {
@@ -59,6 +60,7 @@ export const CONFIG_KEYS = [
   'lastVersionCheck',
   'skipVersionCheck',
   'versionCheckInterval',
+  'prCreateIncludeDefaultReviewers',
 ] as const;
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
 
@@ -66,6 +68,7 @@ export const SETTABLE_CONFIG_KEYS = [
   'defaultWorkspace',
   'skipVersionCheck',
   'versionCheckInterval',
+  'prCreateIncludeDefaultReviewers',
 ] as const;
 export type SettableConfigKey = (typeof SETTABLE_CONFIG_KEYS)[number];
 
@@ -74,6 +77,7 @@ export const READABLE_CONFIG_KEYS = [
   'defaultWorkspace',
   'skipVersionCheck',
   'versionCheckInterval',
+  'prCreateIncludeDefaultReviewers',
 ] as const;
 export type ReadableConfigKey = (typeof READABLE_CONFIG_KEYS)[number];
 
@@ -147,12 +151,22 @@ export function parseSettableConfigValue<K extends SettableConfigKey>(
       }
       return parsed as BBConfig[K];
     }
+    case 'prCreateIncludeDefaultReviewers': {
+      const parsed = parseBooleanLiteral(value);
+      if (parsed === undefined) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message:
+            "Invalid value for 'prCreateIncludeDefaultReviewers'. Expected 'true' or 'false'.",
+          context: { key, value },
+        });
+      }
+      return parsed as BBConfig[K];
+    }
   }
 }
 
-export function coerceSkipVersionCheckValue(
-  value: unknown
-): boolean | undefined {
+export function coerceBooleanConfigValue(value: unknown): boolean | undefined {
   if (typeof value === 'boolean') {
     return value;
   }
@@ -163,6 +177,8 @@ export function coerceSkipVersionCheckValue(
 
   return undefined;
 }
+
+export const coerceSkipVersionCheckValue = coerceBooleanConfigValue;
 
 export function coerceVersionCheckIntervalValue(
   value: unknown
@@ -192,7 +208,8 @@ export function normalizeReadableConfigValue(
 
   switch (key) {
     case 'skipVersionCheck':
-      return coerceSkipVersionCheckValue(value);
+    case 'prCreateIncludeDefaultReviewers':
+      return coerceBooleanConfigValue(value);
     case 'versionCheckInterval':
       return coerceVersionCheckIntervalValue(value);
     case 'username':

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -110,7 +110,7 @@ describe('GetConfigCommand', () => {
     ).rejects.toBeDefined();
 
     expect(output.logs).toContain(
-      'jsonError:{"name":"BBError","code":4003,"message":"Unknown config key \'invalidKey\'. Valid keys: username, defaultWorkspace, skipVersionCheck, versionCheckInterval","context":{"key":"invalidKey"}}'
+      'jsonError:{"name":"BBError","code":4003,"message":"Unknown config key \'invalidKey\'. Valid keys: username, defaultWorkspace, skipVersionCheck, versionCheckInterval, prCreateIncludeDefaultReviewers","context":{"key":"invalidKey"}}'
     );
   });
 });

--- a/tests/commands/default-reviewers.test.ts
+++ b/tests/commands/default-reviewers.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Repo default-reviewers command tests.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListDefaultReviewersCommand } from '../../src/commands/repo/default-reviewers.list.command.js';
+import { AddDefaultReviewerCommand } from '../../src/commands/repo/default-reviewers.add.command.js';
+import { RemoveDefaultReviewerCommand } from '../../src/commands/repo/default-reviewers.remove.command.js';
+import type {
+  DefaultReviewerEntry,
+  DefaultReviewerService,
+} from '../../src/services/default-reviewer.service.js';
+import type { IContextService } from '../../src/core/interfaces/services.js';
+import { createMockOutputService } from '../setup.js';
+
+function createMockService(
+  overrides: Partial<DefaultReviewerService> & {
+    entries?: DefaultReviewerEntry[];
+    addResult?: DefaultReviewerEntry;
+    removeCalls?: string[];
+    addCalls?: string[];
+  } = {}
+): DefaultReviewerService {
+  const addCalls = overrides.addCalls ?? [];
+  const removeCalls = overrides.removeCalls ?? [];
+
+  const svc = {
+    async list() {
+      return overrides.entries ?? [];
+    },
+    async add(_repo: unknown, username: string) {
+      addCalls.push(username);
+      return (
+        overrides.addResult ?? {
+          uuid: `{${username}-uuid}`,
+          displayName: `Display ${username}`,
+        }
+      );
+    },
+    async remove(_repo: unknown, username: string) {
+      removeCalls.push(username);
+    },
+  };
+
+  return svc as unknown as DefaultReviewerService;
+}
+
+function createContextService(): IContextService {
+  return {
+    parseRemoteUrl() {
+      return null;
+    },
+    async getRepoContextFromGit() {
+      return null;
+    },
+    async getRepoContext() {
+      return { workspace: 'ws', repoSlug: 'repo' };
+    },
+    async requireRepoContext() {
+      return { workspace: 'ws', repoSlug: 'repo' };
+    },
+  };
+}
+
+describe('ListDefaultReviewersCommand', () => {
+  it('prints an info message when empty', async () => {
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({ entries: [] }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({}, { globalOptions: {} });
+
+    expect(output.logs.some((l) => l.startsWith('info:'))).toBe(true);
+  });
+
+  it('renders a table with a Source column for effective mode', async () => {
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({
+        entries: [
+          {
+            uuid: '{a}',
+            displayName: 'Alice',
+            nickname: 'alice',
+            reviewerType: 'repository',
+          },
+        ],
+      }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((l) => l === 'table:Display Name,Nickname,Source')
+    ).toBe(true);
+  });
+
+  it('renders a table without Source column for --direct', async () => {
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({
+        entries: [{ uuid: '{a}', displayName: 'Alice', nickname: 'alice' }],
+      }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({ direct: true }, { globalOptions: {} });
+
+    expect(output.logs.some((l) => l === 'table:Display Name,Nickname')).toBe(
+      true
+    );
+  });
+
+  it('outputs JSON when requested', async () => {
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({
+        entries: [{ uuid: '{a}', displayName: 'Alice' }],
+      }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({}, { globalOptions: { json: true } });
+
+    expect(output.logs.some((l) => l.startsWith('json:'))).toBe(true);
+  });
+});
+
+describe('AddDefaultReviewerCommand', () => {
+  it('adds the user via the service and reports success', async () => {
+    const addCalls: string[] = [];
+    const output = createMockOutputService();
+    const cmd = new AddDefaultReviewerCommand(
+      createMockService({ addCalls }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({ username: 'jdoe' }, { globalOptions: {} });
+
+    expect(addCalls).toEqual(['jdoe']);
+    expect(
+      output.logs.some((l) => l.startsWith('success:') && l.includes('jdoe'))
+    ).toBe(true);
+  });
+});
+
+describe('RemoveDefaultReviewerCommand', () => {
+  it('refuses without --yes', async () => {
+    const removeCalls: string[] = [];
+    const output = createMockOutputService();
+    const cmd = new RemoveDefaultReviewerCommand(
+      createMockService({ removeCalls }),
+      createContextService(),
+      output
+    );
+
+    await expect(
+      cmd.execute({ username: 'jdoe' }, { globalOptions: {} })
+    ).rejects.toThrow(/--yes/);
+    expect(removeCalls).toEqual([]);
+  });
+
+  it('removes when --yes is passed', async () => {
+    const removeCalls: string[] = [];
+    const output = createMockOutputService();
+    const cmd = new RemoveDefaultReviewerCommand(
+      createMockService({ removeCalls }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({ username: 'jdoe', yes: true }, { globalOptions: {} });
+
+    expect(removeCalls).toEqual(['jdoe']);
+    expect(output.logs.some((l) => l.startsWith('success:'))).toBe(true);
+  });
+});

--- a/tests/commands/default-reviewers.test.ts
+++ b/tests/commands/default-reviewers.test.ts
@@ -129,7 +129,7 @@ describe('ListDefaultReviewersCommand', () => {
     ).toBe(true);
   });
 
-  it('renders a table without Source column for --direct', async () => {
+  it('renders a table without Source column for --repo-only', async () => {
     const output = createMockOutputService();
     const cmd = new ListDefaultReviewersCommand(
       createMockService({
@@ -139,7 +139,7 @@ describe('ListDefaultReviewersCommand', () => {
       output
     );
 
-    await cmd.execute({ direct: true }, { globalOptions: {} });
+    await cmd.execute({ repoOnly: true }, { globalOptions: {} });
 
     expect(output.logs.some((l) => l === 'table:Display Name,Nickname')).toBe(
       true

--- a/tests/commands/default-reviewers.test.ts
+++ b/tests/commands/default-reviewers.test.ts
@@ -11,7 +11,36 @@ import type {
   DefaultReviewerService,
 } from '../../src/services/default-reviewer.service.js';
 import type { IContextService } from '../../src/core/interfaces/services.js';
-import { createMockOutputService } from '../setup.js';
+import type { UsersApi } from '../../src/generated/api.js';
+import { createMockOutputService, mockUser } from '../setup.js';
+
+function createMockUsersApi(): UsersApi {
+  const api = {
+    async userGet() {
+      return {
+        data: mockUser,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+    },
+    async usersSelectedUserGet(params: { selectedUser: string }) {
+      return {
+        data: {
+          ...mockUser,
+          uuid: `{${params.selectedUser}-uuid}`,
+          display_name: `Display ${params.selectedUser}`,
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+    },
+  };
+  return api as unknown as UsersApi;
+}
 
 function createMockService(
   overrides: Partial<DefaultReviewerService> & {
@@ -139,13 +168,14 @@ describe('AddDefaultReviewerCommand', () => {
     const output = createMockOutputService();
     const cmd = new AddDefaultReviewerCommand(
       createMockService({ addCalls }),
+      createMockUsersApi(),
       createContextService(),
       output
     );
 
     await cmd.execute({ username: 'jdoe' }, { globalOptions: {} });
 
-    expect(addCalls).toEqual(['jdoe']);
+    expect(addCalls).toEqual(['{jdoe-uuid}']);
     expect(
       output.logs.some((l) => l.startsWith('success:') && l.includes('jdoe'))
     ).toBe(true);
@@ -158,6 +188,7 @@ describe('RemoveDefaultReviewerCommand', () => {
     const output = createMockOutputService();
     const cmd = new RemoveDefaultReviewerCommand(
       createMockService({ removeCalls }),
+      createMockUsersApi(),
       createContextService(),
       output
     );
@@ -173,13 +204,14 @@ describe('RemoveDefaultReviewerCommand', () => {
     const output = createMockOutputService();
     const cmd = new RemoveDefaultReviewerCommand(
       createMockService({ removeCalls }),
+      createMockUsersApi(),
       createContextService(),
       output
     );
 
     await cmd.execute({ username: 'jdoe', yes: true }, { globalOptions: {} });
 
-    expect(removeCalls).toEqual(['jdoe']);
+    expect(removeCalls).toEqual(['{jdoe-uuid}']);
     expect(output.logs.some((l) => l.startsWith('success:'))).toBe(true);
   });
 });

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1173,24 +1173,134 @@ describe('ChecksPRCommand', () => {
   });
 });
 
+import type { DefaultReviewerEntry } from '../../src/services/default-reviewer.service.js';
+import type { DefaultReviewerService } from '../../src/services/default-reviewer.service.js';
+import type { IConfigService } from '../../src/core/interfaces/services.js';
+import { createMockConfigService } from '../setup.js';
+
+function createMockDefaultReviewerService(
+  entries: DefaultReviewerEntry[] = [],
+  throwOnList = false
+): DefaultReviewerService {
+  const svc = {
+    async list() {
+      if (throwOnList) {
+        throw new Error('effective reviewers fetch failed');
+      }
+      return entries;
+    },
+    async add() {
+      return entries[0] ?? { uuid: '{}' };
+    },
+    async remove() {
+      // not used
+    },
+  };
+  return svc as unknown as DefaultReviewerService;
+}
+
+interface CreatePRHarnessOptions {
+  currentBranch?: string;
+  defaultReviewers?: DefaultReviewerEntry[];
+  defaultReviewersThrow?: boolean;
+  authorUuid?: string;
+  config?: Parameters<typeof createMockConfigService>[0];
+  capturedBodyRef?: { body?: import('../../src/generated/api.js').Pullrequest };
+}
+
+function buildCreatePRCommand(options: CreatePRHarnessOptions = {}): {
+  command: CreatePRCommand;
+  output: ReturnType<typeof createMockOutputService>;
+  captured: { body?: import('../../src/generated/api.js').Pullrequest };
+} {
+  const captured: {
+    body?: import('../../src/generated/api.js').Pullrequest;
+  } = options.capturedBodyRef ?? {};
+
+  const basePullrequestsApi = createMockPullrequestsApi();
+  // Wrap POST so we can inspect the body on assertions.
+  const originalPost =
+    basePullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPost.bind(
+      basePullrequestsApi
+    );
+  const pullrequestsApi = basePullrequestsApi as typeof basePullrequestsApi & {
+    repositoriesWorkspaceRepoSlugPullrequestsPost: (params: {
+      workspace: string;
+      repoSlug: string;
+      body: import('../../src/generated/api.js').Pullrequest;
+    }) => Promise<
+      AxiosResponse<import('../../src/generated/api.js').Pullrequest>
+    >;
+  };
+  pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPost = async (
+    params
+  ) => {
+    captured.body = params.body;
+    return originalPost(params);
+  };
+
+  const authorUuid = options.authorUuid ?? '{author-uuid}';
+  const usersApi = {
+    async userGet() {
+      return {
+        data: { ...mockUser, uuid: authorUuid },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+    },
+    async usersSelectedUserGet(params: { selectedUser: string }) {
+      return {
+        data: {
+          ...mockUser,
+          uuid: `{${params.selectedUser}-uuid}`,
+          display_name: `Display ${params.selectedUser}`,
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+    },
+  } as unknown as UsersApi;
+
+  const contextService = createMockContextService({
+    workspace: 'workspace',
+    repoSlug: 'repo',
+  });
+
+  const gitService = createMockGitService({
+    currentBranch: options.currentBranch ?? 'feature-branch',
+  });
+
+  const defaultReviewerService = createMockDefaultReviewerService(
+    options.defaultReviewers,
+    options.defaultReviewersThrow
+  );
+
+  const configService: IConfigService = createMockConfigService(
+    options.config ?? {}
+  );
+
+  const output = createMockOutputService();
+
+  const command = new CreatePRCommand(
+    pullrequestsApi,
+    usersApi,
+    contextService,
+    gitService,
+    defaultReviewerService,
+    configService,
+    output
+  );
+
+  return { command, output, captured };
+}
+
 describe('CreatePRCommand', () => {
   it('should create pull request with title', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
-    });
-    const gitService = createMockGitService({
-      currentBranch: 'feature-branch',
-    });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
+    const { command, output } = buildCreatePRCommand();
     await command.execute({ title: 'My PR' }, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
@@ -1200,157 +1310,169 @@ describe('CreatePRCommand', () => {
   });
 
   it('should fail when title not provided', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
-    });
-    const gitService = createMockGitService();
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
-
+    const { command, output } = buildCreatePRCommand();
     await expect(command.run({}, { globalOptions: {} })).rejects.toThrow();
     expect(output.logs.some((log) => log.includes('title'))).toBe(true);
   });
 
   it('should use current branch as source', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
+    const { command, output } = buildCreatePRCommand({
+      currentBranch: 'my-feature',
     });
-    const gitService = createMockGitService({ currentBranch: 'my-feature' });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
     await command.execute({ title: 'My PR' }, { globalOptions: {} });
-
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 
   it('should use explicit source branch', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
-    });
-    const gitService = createMockGitService();
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
+    const { command, output } = buildCreatePRCommand();
     await command.execute(
       { title: 'My PR', source: 'explicit-branch' },
       { globalOptions: {} }
     );
-
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 
   it('should use main as default destination', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
+    const { command, output } = buildCreatePRCommand({
+      currentBranch: 'feature',
     });
-    const gitService = createMockGitService({ currentBranch: 'feature' });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
     await command.execute({ title: 'My PR' }, { globalOptions: {} });
-
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 
   it('should use explicit destination branch', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
+    const { command, output } = buildCreatePRCommand({
+      currentBranch: 'feature',
     });
-    const gitService = createMockGitService({ currentBranch: 'feature' });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
     await command.execute(
       { title: 'My PR', destination: 'develop' },
       { globalOptions: {} }
     );
-
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 
   it('should create draft pull request when flag is set', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
+    const { command, output } = buildCreatePRCommand({
+      currentBranch: 'feature',
     });
-    const gitService = createMockGitService({ currentBranch: 'feature' });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
     await command.execute(
       { title: 'Draft PR', draft: true },
       { globalOptions: {} }
     );
-
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 
   it('should output json when requested', async () => {
-    const pullrequestsApi = createMockPullrequestsApi();
-    const contextService = createMockContextService({
-      workspace: 'workspace',
-      repoSlug: 'repo',
-    });
-    const gitService = createMockGitService({
-      currentBranch: 'feature-branch',
-    });
-    const output = createMockOutputService();
-
-    const command = new CreatePRCommand(
-      pullrequestsApi,
-      contextService,
-      gitService,
-      output
-    );
+    const { command, output } = buildCreatePRCommand();
     await command.execute(
       { title: 'My PR' },
       { globalOptions: { json: true } }
     );
-
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
+  });
+
+  it('should not include reviewers by default', async () => {
+    const { command, captured } = buildCreatePRCommand({
+      defaultReviewers: [
+        { uuid: '{r1}', displayName: 'R One' },
+        { uuid: '{r2}', displayName: 'R Two' },
+      ],
+    });
+    await command.execute({ title: 'My PR' }, { globalOptions: {} });
+    expect(captured.body?.reviewers).toBeUndefined();
+  });
+
+  it('should include default reviewers when --default-reviewers is set', async () => {
+    const { command, captured, output } = buildCreatePRCommand({
+      defaultReviewers: [
+        { uuid: '{r1}', displayName: 'R One' },
+        { uuid: '{r2}', displayName: 'R Two' },
+      ],
+      authorUuid: '{author-uuid}',
+    });
+    await command.execute(
+      { title: 'My PR', defaultReviewers: true },
+      { globalOptions: {} }
+    );
+    const uuids = Array.from(captured.body?.reviewers ?? []).map((r) => r.uuid);
+    expect(uuids).toEqual(['{r1}', '{r2}']);
+    expect(output.logs.some((log) => log.includes('Reviewers:'))).toBe(true);
+  });
+
+  it('should include explicit --reviewer values and dedupe with defaults', async () => {
+    const { command, captured } = buildCreatePRCommand({
+      defaultReviewers: [{ uuid: '{r1}', displayName: 'R One' }],
+      authorUuid: '{author-uuid}',
+    });
+    await command.execute(
+      {
+        title: 'My PR',
+        defaultReviewers: true,
+        reviewer: ['r1', 'r3'],
+      },
+      { globalOptions: {} }
+    );
+    const uuids = Array.from(captured.body?.reviewers ?? []).map((r) => r.uuid);
+    // Default {r1} + explicit {r1-uuid} + explicit {r3-uuid}, de-duped
+    expect(uuids).toContain('{r1}');
+    expect(uuids).toContain('{r1-uuid}');
+    expect(uuids).toContain('{r3-uuid}');
+  });
+
+  it('should filter out the author from the reviewer list', async () => {
+    const { command, captured } = buildCreatePRCommand({
+      defaultReviewers: [
+        { uuid: '{author-uuid}', displayName: 'Me' },
+        { uuid: '{r1}', displayName: 'R One' },
+      ],
+      authorUuid: '{author-uuid}',
+    });
+    await command.execute(
+      { title: 'My PR', defaultReviewers: true },
+      { globalOptions: {} }
+    );
+    const uuids = Array.from(captured.body?.reviewers ?? []).map((r) => r.uuid);
+    expect(uuids).toEqual(['{r1}']);
+  });
+
+  it('should respect --no-default-reviewers even when config enables it', async () => {
+    const { command, captured } = buildCreatePRCommand({
+      defaultReviewers: [{ uuid: '{r1}', displayName: 'R One' }],
+      config: { prCreateIncludeDefaultReviewers: true },
+    });
+    await command.execute(
+      { title: 'My PR', defaultReviewers: false },
+      { globalOptions: {} }
+    );
+    expect(captured.body?.reviewers).toBeUndefined();
+  });
+
+  it('should include defaults when config enables it and no flag is passed', async () => {
+    const { command, captured } = buildCreatePRCommand({
+      defaultReviewers: [{ uuid: '{r1}', displayName: 'R One' }],
+      config: { prCreateIncludeDefaultReviewers: true },
+      authorUuid: '{author-uuid}',
+    });
+    await command.execute({ title: 'My PR' }, { globalOptions: {} });
+    const uuids = Array.from(captured.body?.reviewers ?? []).map((r) => r.uuid);
+    expect(uuids).toEqual(['{r1}']);
+  });
+
+  it('should warn and continue when the default-reviewer fetch fails', async () => {
+    const { command, captured, output } = buildCreatePRCommand({
+      defaultReviewersThrow: true,
+    });
+    await command.execute(
+      { title: 'My PR', defaultReviewers: true },
+      { globalOptions: {} }
+    );
+    expect(captured.body?.reviewers).toBeUndefined();
+    expect(
+      output.logs.some(
+        (log) => log.startsWith('warning:') && log.includes('default reviewers')
+      )
+    ).toBe(true);
+    expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
 });
 

--- a/tests/services/default-reviewer.service.test.ts
+++ b/tests/services/default-reviewer.service.test.ts
@@ -1,0 +1,234 @@
+/**
+ * DefaultReviewerService tests.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { AxiosResponse } from 'axios';
+import { DefaultReviewerService } from '../../src/services/default-reviewer.service.js';
+import type {
+  Account,
+  DefaultReviewerAndType,
+  PaginatedAccounts,
+  PaginatedDefaultReviewerAndType,
+  PullrequestsApi,
+} from '../../src/generated/api.js';
+
+function axiosOk<T>(data: T): AxiosResponse<T> {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  };
+}
+
+interface MockOptions {
+  effectivePages?: DefaultReviewerAndType[][];
+  directPages?: Account[][];
+  throwOnPut?: boolean;
+  throwOnDelete?: boolean;
+  onPut?: (username: string) => void;
+  onDelete?: (username: string) => void;
+}
+
+function createMockApi(options: MockOptions = {}): PullrequestsApi {
+  const paginate = <T>(
+    pages: T[][] | undefined,
+    page: number
+  ): { values: Set<T>; next?: string; page: number } => {
+    const values = new Set<T>(pages?.[page - 1] ?? []);
+    const hasNext = !!pages && page < pages.length;
+    return {
+      values,
+      next: hasNext ? `page=${page + 1}` : undefined,
+      page,
+    };
+  };
+
+  const api = {
+    async repositoriesWorkspaceRepoSlugEffectiveDefaultReviewersGet(
+      _params: { workspace: string; repoSlug: string },
+      axiosOpts?: { params?: { page?: number; pagelen?: number } }
+    ) {
+      const page = axiosOpts?.params?.page ?? 1;
+      const paginated = paginate(options.effectivePages, page);
+      return axiosOk({
+        size: (options.effectivePages ?? []).flat().length,
+        page: paginated.page,
+        pagelen: axiosOpts?.params?.pagelen ?? 25,
+        next: paginated.next,
+        values: paginated.values,
+      } as PaginatedDefaultReviewerAndType);
+    },
+    async repositoriesWorkspaceRepoSlugDefaultReviewersGet(
+      _params: { workspace: string; repoSlug: string },
+      axiosOpts?: { params?: { page?: number; pagelen?: number } }
+    ) {
+      const page = axiosOpts?.params?.page ?? 1;
+      const paginated = paginate(options.directPages, page);
+      return axiosOk({
+        size: (options.directPages ?? []).flat().length,
+        page: paginated.page,
+        pagelen: axiosOpts?.params?.pagelen ?? 25,
+        next: paginated.next,
+        values: paginated.values,
+      } as PaginatedAccounts);
+    },
+    async repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(params: {
+      workspace: string;
+      repoSlug: string;
+      targetUsername: string;
+    }) {
+      if (options.throwOnPut) {
+        throw new Error('forbidden');
+      }
+      options.onPut?.(params.targetUsername);
+      return axiosOk<Account>({
+        type: 'user',
+        uuid: `{${params.targetUsername}-uuid}`,
+        display_name: `Display ${params.targetUsername}`,
+      });
+    },
+    async repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(params: {
+      workspace: string;
+      repoSlug: string;
+      targetUsername: string;
+    }) {
+      if (options.throwOnDelete) {
+        throw new Error('forbidden');
+      }
+      options.onDelete?.(params.targetUsername);
+      return axiosOk(undefined);
+    },
+  };
+
+  return api as unknown as PullrequestsApi;
+}
+
+const repo = { workspace: 'ws', repoSlug: 'repo' };
+
+describe('DefaultReviewerService', () => {
+  describe('list (effective)', () => {
+    it('returns entries with reviewer_type and walks pagination', async () => {
+      const api = createMockApi({
+        effectivePages: [
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'repository',
+              user: {
+                type: 'user',
+                uuid: '{a-uuid}',
+                display_name: 'Alice',
+                account_id: 'alice-id',
+                nickname: 'alice',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'project',
+              user: {
+                type: 'user',
+                uuid: '{b-uuid}',
+                display_name: 'Bob',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+        ],
+      });
+
+      const service = new DefaultReviewerService(api);
+      const result = await service.list(repo, 'effective');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        uuid: '{a-uuid}',
+        accountId: 'alice-id',
+        displayName: 'Alice',
+        nickname: 'alice',
+        reviewerType: 'repository',
+      });
+      expect(result[1]?.reviewerType).toBe('project');
+    });
+
+    it('returns an empty array when the list is empty', async () => {
+      const api = createMockApi({ effectivePages: [[]] });
+      const service = new DefaultReviewerService(api);
+      const result = await service.list(repo, 'effective');
+      expect(result).toEqual([]);
+    });
+
+    it('skips entries without a user uuid', async () => {
+      const api = createMockApi({
+        effectivePages: [
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'repository',
+              user: { type: 'user' } as DefaultReviewerAndType['user'],
+            },
+          ],
+        ],
+      });
+      const service = new DefaultReviewerService(api);
+      const result = await service.list(repo, 'effective');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('list (direct)', () => {
+    it('returns accounts from the direct endpoint', async () => {
+      const api = createMockApi({
+        directPages: [
+          [
+            {
+              type: 'user',
+              uuid: '{c-uuid}',
+              display_name: 'Carol',
+            } as Account,
+          ],
+        ],
+      });
+
+      const service = new DefaultReviewerService(api);
+      const result = await service.list(repo, 'direct');
+
+      expect(result).toEqual([
+        {
+          uuid: '{c-uuid}',
+          accountId: undefined,
+          displayName: 'Carol',
+          nickname: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe('add', () => {
+    it('calls PUT and maps the returned account', async () => {
+      let seen = '';
+      const api = createMockApi({ onPut: (u) => (seen = u) });
+      const service = new DefaultReviewerService(api);
+
+      const entry = await service.add(repo, 'alice');
+
+      expect(seen).toBe('alice');
+      expect(entry.uuid).toBe('{alice-uuid}');
+      expect(entry.displayName).toBe('Display alice');
+    });
+  });
+
+  describe('remove', () => {
+    it('calls DELETE with the username', async () => {
+      let seen = '';
+      const api = createMockApi({ onDelete: (u) => (seen = u) });
+      const service = new DefaultReviewerService(api);
+
+      await service.remove(repo, 'alice');
+      expect(seen).toBe('alice');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for Bitbucket Default Reviewers, covering both asks from #139:

- **Inspect & manage** defaults via `bb repo default-reviewers list|add|remove`.
- **Opt-in auto-add** on `bb pr create` via `--default-reviewers` (per-invocation) or config key `prCreateIncludeDefaultReviewers` (persistent). Explicit `--reviewer <username>` (repeatable) works independently. `--no-default-reviewers` opts out when the config key enables defaults.

### Design notes

- **Opt-in**, not on by default. `bb pr create` currently sends no reviewers; silently auto-adding them on upgrade would trigger notifications for anyone set as a default reviewer across all repos. Opt-in aligns with the project's recent conservative posture (`--yes` gates, token redaction) and can be promoted to default-on later based on feedback.
- **Uses the effective endpoint** (`/repositories/{ws}/{repo}/effective-default-reviewers`) so `list` and `--default-reviewers` match what the Bitbucket web UI auto-populates (repo-level + project-inherited reviewers). `list --direct` exposes the plain `/default-reviewers` endpoint for repo-only entries.
- **Author is filtered out** automatically (Bitbucket rejects PRs where the author is also a reviewer).
- **Failure of the default-reviewer fetch** during `pr create` logs a warning and continues — a transient API error should not block PR creation. Explicit `--reviewer` lookups still fail-fast.
- **Pagination** handled via the existing `collectPages` helper.
- **Project-level default reviewers** are out of scope for this PR; the same service can back a future `bb workspace default-reviewers` group.

### Files

- New service: `src/services/default-reviewer.service.ts` (+ tests)
- New commands: `src/commands/repo/default-reviewers.{list,add,remove}.command.ts` (+ tests)
- `bb pr create` gains `--reviewer`/`--default-reviewers`/`--no-default-reviewers`
- New config key `prCreateIncludeDefaultReviewers` (boolean, default `false`)
- Docs: `repo.mdx`, `pr/create-and-edit.mdx`, `config.mdx`
- Changeset: minor

## Test plan

- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun test` — 595/595 pass, including 20+ new tests covering pagination, empty states, default/explicit merge + de-dupe, author exclusion, `--no-default-reviewers`, config-driven opt-in, and graceful fetch-failure behavior
- [x] `bun run dev repo default-reviewers --help` and `bun run dev pr create --help` show the new commands/flags correctly
- [x] Smoke test end-to-end against a real Bitbucket repo (pending workspace access)

Closes #139