### PR TITLE
chore(tsconfig): tighten type-checking for typescript 6

### DIFF
--- a/.changeset/tsconfig-enhancements.md
+++ b/.changeset/tsconfig-enhancements.md
@@ -1,0 +1,11 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+chore(tsconfig): tighten type-checking for TypeScript 6
+
+- Enable `verbatimModuleSyntax`, `isolatedModules`, and `noUncheckedIndexedAccess` for stricter, Bun-aligned type-checking.
+- Replace legacy `bun-types` entry with `bun` (matches the `@types/bun` dependency).
+- Drop `declaration`, `outDir`, and `rootDir` — no-ops under `noEmit: true`, since builds go through `bun build`.
+
+No runtime behavior change. A handful of internal `string | undefined` sites from regex captures and guaranteed-index array access were narrowed with non-null assertions.

--- a/src/commands/repo/clone.command.ts
+++ b/src/commands/repo/clone.command.ts
@@ -67,10 +67,10 @@ export class CloneCommand extends BaseCommand<
 
     if (parts.length === 1) {
       workspace = await resolveWorkspace(this.configService);
-      repoSlug = parts[0];
+      repoSlug = parts[0]!;
     } else if (parts.length === 2) {
-      workspace = parts[0];
-      repoSlug = parts[1];
+      workspace = parts[0]!;
+      repoSlug = parts[1]!;
     } else {
       throw new BBError({
         code: ErrorCode.VALIDATION_INVALID,

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -96,7 +96,7 @@ export class ViewSnippetCommand extends BaseCommand<
       for (const name of fileNames) {
         this.output.text('');
         this.output.text(this.output.bold(`── ${name} ──`));
-        this.output.text(contents[name]);
+        this.output.text(contents[name] ?? '');
       }
       return;
     }

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -3,8 +3,8 @@
  */
 
 import axios, {
-  AxiosInstance,
-  AxiosError,
+  type AxiosInstance,
+  type AxiosError,
   type InternalAxiosRequestConfig,
 } from 'axios';
 import type { IConfigService } from '../core/interfaces/services.js';

--- a/src/services/context.service.ts
+++ b/src/services/context.service.ts
@@ -27,8 +27,8 @@ export class ContextService implements IContextService {
     ).exec(url);
     if (sshMatch) {
       return {
-        workspace: sshMatch[1],
-        repoSlug: sshMatch[2],
+        workspace: sshMatch[1]!,
+        repoSlug: sshMatch[2]!,
       };
     }
 
@@ -39,8 +39,8 @@ export class ContextService implements IContextService {
     ).exec(url);
     if (httpsMatch) {
       return {
-        workspace: httpsMatch[1],
-        repoSlug: httpsMatch[2],
+        workspace: httpsMatch[1]!,
+        repoSlug: httpsMatch[2]!,
       };
     }
 

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -35,7 +35,7 @@ export class OutputService implements IOutputService {
 
     // Print header
     const headerRow = headers
-      .map((header, index) => header.padEnd(widths[index]))
+      .map((header, index) => header.padEnd(widths[index]!))
       .join('  ');
 
     console.log(this.format(headerRow, chalk.bold));
@@ -46,7 +46,7 @@ export class OutputService implements IOutputService {
     // Print rows
     for (const row of rows) {
       const formattedRow = row
-        .map((cell, index) => (cell || '').padEnd(widths[index]))
+        .map((cell, index) => (cell || '').padEnd(widths[index]!))
         .join('  ');
       console.log(formattedRow);
     }

--- a/src/services/version.service.ts
+++ b/src/services/version.service.ts
@@ -161,7 +161,7 @@ export class VersionService {
       const cleanVersion = version.replace(/^v/, '');
       return cleanVersion.split('.').map((part) => {
         // Handle pre-release versions like "1.0.0-beta.1"
-        const numPart = part.split('-')[0];
+        const numPart = part.split('-')[0]!;
         return Number.parseInt(numPart, 10) || 0;
       });
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,13 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "declaration": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["bun-types"],
+    "types": ["bun"],
     "lib": ["ESNext"],
     "allowImportingTsExtensions": true,
-    "noEmit": true
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "docs"]


### PR DESCRIPTION
## Summary

Follow-up to the TypeScript 6 upgrade. Tightens `tsconfig.json` to better match Bun's runtime semantics and catch more errors at type-check time.

### Changes
- **Enable `isolatedModules`** — Bun transpiles file-by-file; this ensures the type system agrees.
- **Enable `verbatimModuleSyntax`** — TS 6's modern replacement for the removed `importsNotUsedAsValues`/`preserveValueImports` flags. Enforces the `import type` consistency AGENTS.md already mandates.
- **Enable `noUncheckedIndexedAccess`** — adds `| undefined` to indexed access, surfacing real edge cases.
- Replace legacy `"bun-types"` entry with `"bun"` (matches the `@types/bun` dev dependency; `bun-types` was only present transitively).
- Drop `declaration`, `outDir`, `rootDir` — all no-ops under `noEmit: true` (builds go through `bun build`, not `tsc`).

### Code fallout
Twelve sites across six files needed narrowing. All are either regex capture groups after a truthy-match branch or guaranteed-index array access (length-checked or from a just-built array), so non-null assertions are safe and minimal.

- `src/services/api-client.service.ts` — `AxiosInstance`/`AxiosError` changed to type-only imports
- `src/commands/repo/clone.command.ts` — `parts[0]`/`parts[1]` after length check
- `src/services/context.service.ts` — regex capture groups
- `src/services/output.service.ts` — `widths[index]` inside same-array `map`
- `src/commands/snippet/view.command.ts` — `contents[name]` with `?? ''` fallback
- `src/services/version.service.ts` — `split('-')[0]` always exists

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` — 788/788 pass
- [x] `bun run build` succeeds
- [ ] CI green