### PR TITLE
fix(pagination): reject --limit 0 and add dedicated tests

### DIFF
--- a/.changeset/parse-limit-rejects-zero.md
+++ b/.changeset/parse-limit-rejects-zero.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+fix(pagination): reject `--limit 0` and other non-positive values instead of silently returning no results
+
+`parseLimit` previously fell back to the default limit when given `0`, a negative number, or a non-numeric string — except for `collectPages`, which honored `0` by returning an empty array. A user passing `--limit 0` got zero results with no feedback. `parseLimit` now throws a `VALIDATION_INVALID` `BBError` (`--limit must be a positive integer`) for any explicit non-positive or non-finite value. A missing option still returns the fallback. Adds a dedicated `tests/services/pagination.test.ts` covering `parseLimit` and `collectPages`. Resolves #145.

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -2,6 +2,8 @@
  * Pagination helpers for Bitbucket paginated endpoints.
  */
 
+import { BBError, ErrorCode } from '../types/errors.js';
+
 export interface PaginatedCollection<T> {
   values?: Iterable<T>;
   next?: string;
@@ -21,13 +23,16 @@ export function parseLimit(
   limit?: string,
   fallback: number = DEFAULT_LIMIT
 ): number {
-  if (!limit) {
+  if (limit === undefined || limit === '') {
     return fallback;
   }
 
   const parsed = Number.parseInt(limit, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    return fallback;
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new BBError({
+      code: ErrorCode.VALIDATION_INVALID,
+      message: '--limit must be a positive integer',
+    });
   }
 
   return parsed;

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Pagination helper tests
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  collectPages,
+  DEFAULT_LIMIT,
+  parseLimit,
+  type PaginatedCollection,
+} from '../../src/services/pagination.js';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
+
+describe('parseLimit', () => {
+  it('parses a valid positive integer', () => {
+    expect(parseLimit('10')).toBe(10);
+  });
+
+  it('returns the default when the option is missing', () => {
+    expect(parseLimit()).toBe(DEFAULT_LIMIT);
+  });
+
+  it('returns the provided fallback when the option is missing', () => {
+    expect(parseLimit(undefined, 7)).toBe(7);
+  });
+
+  it('returns the default when the option is an empty string', () => {
+    expect(parseLimit('')).toBe(DEFAULT_LIMIT);
+  });
+
+  it('throws for zero', () => {
+    expect(() => parseLimit('0')).toThrow(BBError);
+    try {
+      parseLimit('0');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BBError);
+      expect((error as BBError).code).toBe(ErrorCode.VALIDATION_INVALID);
+      expect((error as BBError).message).toBe(
+        '--limit must be a positive integer'
+      );
+    }
+  });
+
+  it('throws for negative integers', () => {
+    expect(() => parseLimit('-5')).toThrow(BBError);
+  });
+
+  it('throws for non-numeric strings', () => {
+    expect(() => parseLimit('abc')).toThrow(BBError);
+  });
+
+  it('truncates decimals via parseInt and accepts the integer part', () => {
+    expect(parseLimit('10.9')).toBe(10);
+  });
+});
+
+describe('collectPages', () => {
+  it('returns items from a single page', async () => {
+    const result = await collectPages<number>({
+      limit: 10,
+      fetchPage: async () => ({ values: [1, 2, 3] }),
+    });
+
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('truncates multi-page results to the configured limit', async () => {
+    const pages: Array<PaginatedCollection<number>> = [
+      { values: [1, 2, 3], next: 'page2' },
+      { values: [4, 5, 6], next: 'page3' },
+      { values: [7, 8, 9] },
+    ];
+    const calls: number[] = [];
+
+    const result = await collectPages<number>({
+      limit: 5,
+      pageSize: 3,
+      fetchPage: async (page) => {
+        calls.push(page);
+        return pages[page - 1] ?? { values: [] };
+      },
+    });
+
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+    expect(calls).toEqual([1, 2]);
+  });
+
+  it('returns an empty array when the first page is empty', async () => {
+    const result = await collectPages<number>({
+      limit: 10,
+      fetchPage: async () => ({ values: [] }),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('stops when next is a malformed URL without crashing', async () => {
+    const pages: Array<PaginatedCollection<number>> = [
+      { values: [1, 2], next: 'not-a-valid-url://???' },
+      { values: [3, 4] },
+    ];
+    const calls: number[] = [];
+
+    const result = await collectPages<number>({
+      limit: 10,
+      pageSize: 2,
+      fetchPage: async (page) => {
+        calls.push(page);
+        return pages[page - 1] ?? { values: [] };
+      },
+    });
+
+    expect(result).toEqual([1, 2, 3, 4]);
+    expect(calls).toEqual([1, 2]);
+  });
+
+  it('propagates errors thrown by fetchPage', async () => {
+    const failure = new Error('boom');
+
+    await expect(
+      collectPages<number>({
+        limit: 10,
+        fetchPage: async () => {
+          throw failure;
+        },
+      })
+    ).rejects.toBe(failure);
+  });
+
+  it('filters items using shouldInclude', async () => {
+    const result = await collectPages<number>({
+      limit: 10,
+      fetchPage: async () => ({ values: [1, 2, 3, 4] }),
+      shouldInclude: (value) => value % 2 === 0,
+    });
+
+    expect(result).toEqual([2, 4]);
+  });
+});


### PR DESCRIPTION
## Summary

- `parseLimit` now throws `BBError(VALIDATION_INVALID)` with message `--limit must be a positive integer` when the user explicitly passes `0`, a negative number, or a non-numeric/non-finite string. Previously these silently fell back to the default limit, and `collectPages` separately honored `0` by returning an empty array — a user passing `--limit 0` got zero results with no feedback.
- A missing `--limit` still returns the fallback (default `25`), so existing command defaults are unchanged.
- Adds `tests/services/pagination.test.ts` — `parseLimit` and `collectPages` were previously only exercised indirectly through command tests.

## Test plan

- [x] `bun test tests/services/pagination.test.ts` (14 new tests pass)
- [x] `bun test` (full suite: 802 pass, 0 fail)
- [x] `bun run lint`
- [x] `bun run format:check`

Resolves #145