### PR TITLE
refactor(config): split IConfigService into IConfigService + ICredentialStore

### DIFF
--- a/.changeset/split-config-service-interface.md
+++ b/.changeset/split-config-service-interface.md
@@ -1,0 +1,14 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+refactor(config): split `IConfigService` into `IConfigService` + `ICredentialStore`
+
+Internal-only change — no user-facing behavior or on-disk format changes. The old `IConfigService` mixed three concerns (app config, basic auth credentials, OAuth token state), forcing every consumer and test mock to depend on the full surface even when they only needed one piece.
+
+- `IConfigService` now covers app config only: `getConfig`, `getValue`, `setValue`, `getConfigPath`, `clearConfig`.
+- New `ICredentialStore` covers basic + OAuth credentials: `getAuthMethod`, `get/set/clearCredentials`, `get/set/clearOAuthCredentials`, `isOAuthTokenExpired`.
+- `ConfigService` keeps implementing both, so the same JSON file backs both interfaces. A `ServiceTokens.CredentialStore` registration is added as an alias resolving the same singleton, leaving an opening for a future alternative store (e.g. OS keychain) without touching non-auth consumers.
+- Commands and services now inject the narrower dependency they actually use. Test mocks gain `createMockConfigServiceOnly` and `createMockCredentialStoreOnly` factories for tests that only exercise one surface.
+
+Resolves #148.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -111,13 +111,13 @@ function registerApiClient<T>(
   ctor: ApiClientCtor<T>
 ): void {
   container.register(token, () => {
-    const configService = container.resolve<ConfigService>(
-      ServiceTokens.ConfigService
+    const credentialStore = container.resolve<ConfigService>(
+      ServiceTokens.CredentialStore
     );
     const oauthService = container.resolve<OAuthService>(
       ServiceTokens.OAuthService
     );
-    const axiosInstance = createApiClient(configService, oauthService);
+    const axiosInstance = createApiClient(credentialStore, oauthService);
     return new ctor(undefined, undefined, axiosInstance);
   });
 }
@@ -141,8 +141,14 @@ function registerCommand<T>(
 export function bootstrap(options: BootstrapOptions = {}): Container {
   const container = Container.getInstance();
 
-  // Core services
+  // Core services. ConfigService backs both IConfigService (app config) and
+  // ICredentialStore (basic + OAuth credentials); the CredentialStore token
+  // resolves to the same singleton so storage stays in one JSON file while
+  // consumers depend on narrower interfaces.
   container.register(ServiceTokens.ConfigService, () => new ConfigService());
+  container.register(ServiceTokens.CredentialStore, () =>
+    container.resolve<ConfigService>(ServiceTokens.ConfigService)
+  );
   container.register(ServiceTokens.GitService, () => new GitService());
   container.register(
     ServiceTokens.OutputService,
@@ -150,6 +156,7 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   );
   registerCommand(container, ServiceTokens.OAuthService, OAuthService, [
     ServiceTokens.ConfigService,
+    ServiceTokens.CredentialStore,
   ]);
   registerCommand(container, ServiceTokens.ContextService, ContextService, [
     ServiceTokens.GitService,
@@ -169,13 +176,13 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   // Snippets share one axios instance between the generated API and the
   // raw-file helper service, so they register the axios separately.
   container.register(ServiceTokens.SnippetsAxios, () => {
-    const configService = container.resolve<ConfigService>(
-      ServiceTokens.ConfigService
+    const credentialStore = container.resolve<ConfigService>(
+      ServiceTokens.CredentialStore
     );
     const oauthService = container.resolve<OAuthService>(
       ServiceTokens.OAuthService
     );
-    return createApiClient(configService, oauthService);
+    return createApiClient(credentialStore, oauthService);
   });
   container.register(ServiceTokens.SnippetsApi, () => {
     const axiosInstance = container.resolve<AxiosInstance>(
@@ -199,23 +206,24 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
 
   // Auth commands
   registerCommand(container, ServiceTokens.LoginCommand, LoginCommand, [
-    ServiceTokens.ConfigService,
+    ServiceTokens.CredentialStore,
     ServiceTokens.UsersApi,
     ServiceTokens.OAuthService,
     ServiceTokens.OutputService,
   ]);
   registerCommand(container, ServiceTokens.LogoutCommand, LogoutCommand, [
-    ServiceTokens.ConfigService,
+    ServiceTokens.CredentialStore,
     ServiceTokens.OAuthService,
     ServiceTokens.OutputService,
   ]);
   registerCommand(container, ServiceTokens.StatusCommand, StatusCommand, [
     ServiceTokens.ConfigService,
+    ServiceTokens.CredentialStore,
     ServiceTokens.UsersApi,
     ServiceTokens.OutputService,
   ]);
   registerCommand(container, ServiceTokens.TokenCommand, TokenCommand, [
-    ServiceTokens.ConfigService,
+    ServiceTokens.CredentialStore,
     ServiceTokens.OAuthService,
     ServiceTokens.OutputService,
   ]);

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -5,7 +5,7 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
-  IConfigService,
+  ICredentialStore,
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { UsersApi } from '../../generated/api.js';
@@ -25,7 +25,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
   public readonly description = 'Authenticate with Bitbucket';
 
   constructor(
-    private readonly configService: IConfigService,
+    private readonly credentialStore: ICredentialStore,
     private readonly usersApi: UsersApi,
     private readonly oauthService: OAuthService,
     output: IOutputService
@@ -79,7 +79,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
         `Logged in as ${userInfo.displayName} (${userInfo.username})`
       );
     } catch (error) {
-      await this.configService.clearOAuthCredentials();
+      await this.credentialStore.clearOAuthCredentials();
       throw error;
     }
   }
@@ -108,8 +108,8 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
     }
 
     // Clear any existing OAuth credentials first
-    await this.configService.clearOAuthCredentials();
-    await this.configService.setCredentials({ username, apiToken });
+    await this.credentialStore.clearOAuthCredentials();
+    await this.credentialStore.setCredentials({ username, apiToken });
 
     try {
       const response = await this.usersApi.userGet();
@@ -132,7 +132,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
         `Logged in as ${user.display_name} (${user.username})`
       );
     } catch (error) {
-      await this.configService.clearCredentials();
+      await this.credentialStore.clearCredentials();
       throw new BBError({
         code: ErrorCode.AUTH_INVALID,
         message: `Authentication failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/commands/auth/logout.command.ts
+++ b/src/commands/auth/logout.command.ts
@@ -5,7 +5,7 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
-  IConfigService,
+  ICredentialStore,
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { OAuthService } from '../../services/oauth.service.js';
@@ -15,7 +15,7 @@ export class LogoutCommand extends BaseCommand<void, void> {
   public readonly description = 'Log out of Bitbucket';
 
   constructor(
-    private readonly configService: IConfigService,
+    private readonly credentialStore: ICredentialStore,
     private readonly oauthService: OAuthService,
     output: IOutputService
   ) {
@@ -23,13 +23,13 @@ export class LogoutCommand extends BaseCommand<void, void> {
   }
 
   public async execute(_options: void, context: CommandContext): Promise<void> {
-    const authMethod = await this.configService.getAuthMethod();
+    const authMethod = await this.credentialStore.getAuthMethod();
 
     if (authMethod === 'oauth') {
       await this.oauthService.revokeToken();
-      await this.configService.clearOAuthCredentials();
+      await this.credentialStore.clearOAuthCredentials();
     } else {
-      await this.configService.clearCredentials();
+      await this.credentialStore.clearCredentials();
     }
 
     if (context.globalOptions.json) {

--- a/src/commands/auth/status.command.ts
+++ b/src/commands/auth/status.command.ts
@@ -6,6 +6,7 @@ import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
   IConfigService,
+  ICredentialStore,
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { UsersApi } from '../../generated/api.js';
@@ -29,6 +30,7 @@ export class StatusCommand extends BaseCommand<void, void> {
 
   constructor(
     private readonly configService: IConfigService,
+    private readonly credentialStore: ICredentialStore,
     private readonly usersApi: UsersApi,
     output: IOutputService
   ) {
@@ -37,7 +39,7 @@ export class StatusCommand extends BaseCommand<void, void> {
 
   public async execute(_options: void, context: CommandContext): Promise<void> {
     const config = await this.configService.getConfig();
-    const authMethod = await this.configService.getAuthMethod();
+    const authMethod = await this.credentialStore.getAuthMethod();
 
     // Check if any credentials exist
     const hasBasicAuth = config.username && config.apiToken;

--- a/src/commands/auth/token.command.ts
+++ b/src/commands/auth/token.command.ts
@@ -5,7 +5,7 @@
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
-  IConfigService,
+  ICredentialStore,
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { OAuthService } from '../../services/oauth.service.js';
@@ -16,7 +16,7 @@ export class TokenCommand extends BaseCommand<void, void> {
   public readonly description = 'Print the current access token';
 
   constructor(
-    private readonly configService: IConfigService,
+    private readonly credentialStore: ICredentialStore,
     private readonly oauthService: OAuthService,
     output: IOutputService
   ) {
@@ -24,7 +24,7 @@ export class TokenCommand extends BaseCommand<void, void> {
   }
 
   public async execute(_options: void, context: CommandContext): Promise<void> {
-    const authMethod = await this.configService.getAuthMethod();
+    const authMethod = await this.credentialStore.getAuthMethod();
 
     if (authMethod === 'oauth') {
       const accessToken = await this.oauthService.getValidAccessToken();
@@ -38,7 +38,7 @@ export class TokenCommand extends BaseCommand<void, void> {
       return;
     }
 
-    const credentials = await this.configService.getCredentials();
+    const credentials = await this.credentialStore.getCredentials();
 
     if (!credentials.username || !credentials.apiToken) {
       throw new BBError({

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -125,6 +125,7 @@ export class Container {
 export const ServiceTokens = {
   // Core services
   ConfigService: 'ConfigService',
+  CredentialStore: 'CredentialStore',
   GitService: 'GitService',
   ContextService: 'ContextService',
   OutputService: 'OutputService',

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -12,21 +12,34 @@ import type {
 } from '../../types/config.js';
 
 /**
- * Configuration service interface
+ * Application config interface — reading and writing general settings
+ * (default workspace, version-check preferences, OAuth client id/secret, etc.)
+ * stored in the on-disk config file. Does NOT include any credential methods;
+ * those live on `ICredentialStore`.
  */
 export interface IConfigService {
   getConfig(): Promise<BBConfig>;
-  setConfig(config: BBConfig): Promise<void>;
-  getCredentials(): Promise<AuthCredentials>;
-  setCredentials(credentials: AuthCredentials): Promise<void>;
-  clearCredentials(): Promise<void>;
   clearConfig(): Promise<void>;
   getValue<K extends keyof BBConfig>(key: K): Promise<BBConfig[K] | undefined>;
   setValue<K extends keyof BBConfig>(key: K, value: BBConfig[K]): Promise<void>;
   getConfigPath(): string;
+}
 
-  // OAuth support
+/**
+ * Credential storage interface — basic auth credentials and OAuth token state.
+ * Backed by the same on-disk config today, but isolated behind this interface
+ * so that an alternative store (e.g. OS keychain) can be introduced without
+ * touching non-auth consumers.
+ */
+export interface ICredentialStore {
   getAuthMethod(): Promise<AuthMethod>;
+
+  // Basic auth
+  getCredentials(): Promise<AuthCredentials>;
+  setCredentials(credentials: AuthCredentials): Promise<void>;
+  clearCredentials(): Promise<void>;
+
+  // OAuth
   getOAuthCredentials(): Promise<OAuthCredentials>;
   setOAuthCredentials(credentials: OAuthCredentials): Promise<void>;
   clearOAuthCredentials(): Promise<void>;

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -7,7 +7,7 @@ import axios, {
   AxiosError,
   type InternalAxiosRequestConfig,
 } from 'axios';
-import type { IConfigService } from '../core/interfaces/services.js';
+import type { ICredentialStore } from '../core/interfaces/services.js';
 import type { OAuthService } from './oauth.service.js';
 import { BBError, ErrorCode, APIError } from '../types/errors.js';
 
@@ -79,7 +79,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 export function createApiClient(
-  configService: IConfigService,
+  credentialStore: ICredentialStore,
   oauthService?: OAuthService
 ): AxiosInstance {
   const instance = axios.create({
@@ -97,14 +97,14 @@ export function createApiClient(
         console.debug(`[HTTP] ${config.method?.toUpperCase()} ${config.url}`);
       }
 
-      const authMethod = await configService.getAuthMethod();
+      const authMethod = await credentialStore.getAuthMethod();
 
       if (authMethod === 'oauth' && oauthService) {
         // Proactive refresh: get a valid token (refreshes if expired)
         const accessToken = await oauthService.getValidAccessToken();
         config.headers.Authorization = `Bearer ${accessToken}`;
       } else {
-        const credentials = await configService.getCredentials();
+        const credentials = await credentialStore.getCredentials();
         const authString = Buffer.from(
           `${credentials.username}:${credentials.apiToken}`
         ).toString('base64');
@@ -143,7 +143,7 @@ export function createApiClient(
       if (error.response?.status === 401 && oauthService) {
         const config = error.config as RetryableConfig | undefined;
         if (config && !config.__tokenRefreshed) {
-          const authMethod = await configService.getAuthMethod();
+          const authMethod = await credentialStore.getAuthMethod();
           if (authMethod === 'oauth') {
             try {
               config.__tokenRefreshed = true;

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -4,7 +4,10 @@
 
 import { join, win32 } from 'node:path';
 import { homedir } from 'node:os';
-import type { IConfigService } from '../core/interfaces/services.js';
+import type {
+  IConfigService,
+  ICredentialStore,
+} from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 import type {
   BBConfig,
@@ -19,7 +22,7 @@ interface ConfigServicePathOptions {
   homeDir?: string;
 }
 
-export class ConfigService implements IConfigService {
+export class ConfigService implements IConfigService, ICredentialStore {
   private readonly configDir: string;
   private readonly configFile: string;
   private configCache: BBConfig | null = null;

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -4,7 +4,10 @@
 
 import { createServer, type Server } from 'node:http';
 import { randomBytes } from 'node:crypto';
-import type { IConfigService } from '../core/interfaces/services.js';
+import type {
+  IConfigService,
+  ICredentialStore,
+} from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 
 const BITBUCKET_AUTHORIZE_URL = 'https://bitbucket.org/site/oauth2/authorize';
@@ -46,7 +49,10 @@ function generateState(): string {
 }
 
 export class OAuthService {
-  constructor(private readonly configService: IConfigService) {}
+  constructor(
+    private readonly configService: IConfigService,
+    private readonly credentialStore: ICredentialStore
+  ) {}
 
   /**
    * Start the OAuth authorization flow: open browser, wait for callback, exchange code for tokens
@@ -76,7 +82,7 @@ export class OAuthService {
 
     // Store tokens
     const expiresAt = Math.floor(Date.now() / 1000) + tokenResponse.expires_in;
-    await this.configService.setOAuthCredentials({
+    await this.credentialStore.setOAuthCredentials({
       accessToken: tokenResponse.access_token,
       refreshToken: tokenResponse.refresh_token,
       expiresAt,
@@ -99,7 +105,7 @@ export class OAuthService {
    * Refresh the access token using the refresh token
    */
   public async refreshAccessToken(): Promise<string> {
-    const credentials = await this.configService.getOAuthCredentials();
+    const credentials = await this.credentialStore.getOAuthCredentials();
     const clientId = await this.getClientId();
 
     const clientSecret = await this.getClientSecret();
@@ -129,7 +135,7 @@ export class OAuthService {
     const tokenResponse = (await response.json()) as TokenResponse;
     const expiresAt = Math.floor(Date.now() / 1000) + tokenResponse.expires_in;
 
-    await this.configService.setOAuthCredentials({
+    await this.credentialStore.setOAuthCredentials({
       accessToken: tokenResponse.access_token,
       refreshToken: tokenResponse.refresh_token,
       expiresAt,
@@ -143,7 +149,7 @@ export class OAuthService {
    */
   public async revokeToken(): Promise<void> {
     try {
-      const credentials = await this.configService.getOAuthCredentials();
+      const credentials = await this.credentialStore.getOAuthCredentials();
       const clientId = await this.getClientId();
 
       const clientSecret = await this.getClientSecret();
@@ -168,11 +174,11 @@ export class OAuthService {
    * Get a valid access token, refreshing if needed
    */
   public async getValidAccessToken(): Promise<string> {
-    const isExpired = await this.configService.isOAuthTokenExpired();
+    const isExpired = await this.credentialStore.isOAuthTokenExpired();
     if (isExpired) {
       return this.refreshAccessToken();
     }
-    const credentials = await this.configService.getOAuthCredentials();
+    const credentials = await this.credentialStore.getOAuthCredentials();
     return credentials.accessToken;
   }
 

--- a/tests/commands/auth.test.ts
+++ b/tests/commands/auth.test.ts
@@ -509,7 +509,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('Not logged in'))).toBe(true);
@@ -523,7 +528,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs).toContain('success:Logged in to Bitbucket');
@@ -538,7 +548,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('API Token'))).toBe(true);
@@ -552,7 +567,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: { json: true } });
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
@@ -568,7 +588,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('OAuth'))).toBe(true);
@@ -584,7 +609,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('Token expires'))).toBe(true);
@@ -600,7 +630,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: {} });
 
     expect(output.logs.some((log) => log.includes('expired'))).toBe(true);
@@ -616,7 +651,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: { json: true } });
 
     const jsonLog = output.logs.find((l) => l.startsWith('json:'));
@@ -630,7 +670,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApi();
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
     await command.execute(undefined, { globalOptions: { json: true } });
 
     const jsonLog = output.logs.find((l) => l.startsWith('json:'));
@@ -646,7 +691,12 @@ describe('StatusCommand', () => {
     const output = createMockOutputService();
     const usersApi = createMockUsersApiError('Unauthorized');
 
-    const command = new StatusCommand(configService, usersApi, output);
+    const command = new StatusCommand(
+      configService,
+      configService,
+      usersApi,
+      output
+    );
 
     await expect(
       command.execute(undefined, { globalOptions: {} })

--- a/tests/services/config.service.test.ts
+++ b/tests/services/config.service.test.ts
@@ -4,6 +4,10 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { ConfigService } from '../../src/services/config.service.js';
+import type {
+  IConfigService,
+  ICredentialStore,
+} from '../../src/core/interfaces/services.js';
 import { ErrorCode } from '../../src/types/errors.js';
 import { mkdir, rm, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -575,5 +579,92 @@ describe('ConfigService', () => {
       config = await configService.getConfig();
       expect(config.username).toBe('modified');
     });
+  });
+});
+
+describe('ConfigService split interfaces', () => {
+  // Exercises the class through each narrower interface in isolation to
+  // confirm IConfigService and ICredentialStore can round-trip their own
+  // state without touching the other surface.
+  const testConfigDir = join('/tmp', `bb-split-${Date.now()}`);
+
+  afterEach(async () => {
+    try {
+      await rm(testConfigDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('IConfigService: round-trips app config via getValue/setValue without credentials methods', async () => {
+    const configService: IConfigService = new ConfigService(testConfigDir);
+
+    await configService.setValue('defaultWorkspace', 'acme');
+    await configService.setValue('skipVersionCheck', true);
+
+    expect(await configService.getValue('defaultWorkspace')).toBe('acme');
+    expect(await configService.getValue('skipVersionCheck')).toBe(true);
+    expect((await configService.getConfig()).defaultWorkspace).toBe('acme');
+
+    await configService.clearConfig();
+    expect(await configService.getConfig()).toEqual({});
+  });
+
+  it('ICredentialStore: round-trips basic auth credentials without app-config methods', async () => {
+    const credentialStore: ICredentialStore = new ConfigService(testConfigDir);
+
+    expect(await credentialStore.getAuthMethod()).toBe('basic');
+
+    await credentialStore.setCredentials({ username: 'alice', apiToken: 't' });
+    const creds = await credentialStore.getCredentials();
+    expect(creds.username).toBe('alice');
+    expect(creds.apiToken).toBe('t');
+    expect(await credentialStore.getAuthMethod()).toBe('basic');
+
+    await credentialStore.clearCredentials();
+    await expect(credentialStore.getCredentials()).rejects.toMatchObject({
+      code: ErrorCode.AUTH_REQUIRED,
+    });
+  });
+
+  it('ICredentialStore: round-trips OAuth tokens and expiry independently', async () => {
+    const credentialStore: ICredentialStore = new ConfigService(testConfigDir);
+
+    await credentialStore.setOAuthCredentials({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    expect(await credentialStore.getAuthMethod()).toBe('oauth');
+    expect(await credentialStore.isOAuthTokenExpired()).toBe(false);
+    const oauth = await credentialStore.getOAuthCredentials();
+    expect(oauth.accessToken).toBe('access');
+
+    await credentialStore.clearOAuthCredentials();
+    await expect(credentialStore.getOAuthCredentials()).rejects.toMatchObject({
+      code: ErrorCode.AUTH_REQUIRED,
+    });
+  });
+
+  it('shared storage: writes via IConfigService are visible to ICredentialStore and vice versa', async () => {
+    // Single concrete instance exposed through both narrow interfaces — mirrors
+    // the bootstrap wiring where CredentialStore is an alias of ConfigService.
+    const instance = new ConfigService(testConfigDir);
+    const configService: IConfigService = instance;
+    const credentialStore: ICredentialStore = instance;
+
+    await configService.setValue('defaultWorkspace', 'shared');
+    await credentialStore.setCredentials({ username: 'u', apiToken: 't' });
+
+    // Each side sees its own write
+    expect(await configService.getValue('defaultWorkspace')).toBe('shared');
+    const creds = await credentialStore.getCredentials();
+    expect(creds.username).toBe('u');
+
+    // And the cross-interface read still works because storage is shared
+    const config = await configService.getConfig();
+    expect(config.username).toBe('u');
+    expect(config.defaultWorkspace).toBe('shared');
   });
 });

--- a/tests/services/oauth.service.test.ts
+++ b/tests/services/oauth.service.test.ts
@@ -122,7 +122,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'my-refresh-token',
         oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const token = await service.getValidAccessToken();
 
@@ -136,7 +136,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'my-refresh-token',
         oauthExpiresAt: Math.floor(Date.now() / 1000) - 100, // expired
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([
         {
@@ -170,7 +170,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'my-refresh-token',
         oauthExpiresAt: Math.floor(Date.now() / 1000) + 30, // 30 seconds from now (within 60s buffer)
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([
         {
@@ -200,7 +200,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'the-refresh-token',
         oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([
         {
@@ -241,7 +241,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'bad-refresh-token',
         oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([
         {
@@ -269,7 +269,7 @@ describe('OAuthService', () => {
         oauthClientId: 'custom-id',
         oauthClientSecret: 'custom-secret',
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([
         {
@@ -305,7 +305,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'rt',
         oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([
         {
@@ -339,7 +339,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'refresh',
         oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([{ ok: true, status: 200 }]);
 
@@ -359,7 +359,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'refresh',
         oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([{ ok: false, status: 500 }]);
 
@@ -369,7 +369,7 @@ describe('OAuthService', () => {
 
     it('should not throw when no credentials exist', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       // getOAuthCredentials will throw, but revokeToken catches it
       await service.revokeToken();
@@ -382,7 +382,7 @@ describe('OAuthService', () => {
         oauthRefreshToken: 'refresh',
         oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       globalThis.fetch = (async () => {
         throw new Error('network down');
@@ -435,7 +435,7 @@ describe('OAuthService', () => {
 
     it('should complete the authorization flow and store credentials', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([tokenResponse(), userResponse()]);
 
@@ -491,7 +491,7 @@ describe('OAuthService', () => {
 
     it('should persist custom client id and secret when provided', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([tokenResponse(), userResponse()]);
 
@@ -519,7 +519,7 @@ describe('OAuthService', () => {
       const configService = createMockConfigService({
         oauthClientId: 'stored-client-id',
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([tokenResponse(), userResponse()]);
 
@@ -534,7 +534,7 @@ describe('OAuthService', () => {
 
     it('should reject with AUTH_INVALID when the callback returns error=access_denied', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       // No fetch mocks needed — authorize should reject before exchangeCode
       mockFetch([]);
@@ -560,7 +560,7 @@ describe('OAuthService', () => {
 
     it('should reject with AUTH_INVALID when state does not match', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([]);
 
@@ -581,7 +581,7 @@ describe('OAuthService', () => {
 
     it('should reject when the callback has no code and no error', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([]);
 
@@ -600,7 +600,7 @@ describe('OAuthService', () => {
 
     it('should return 404 for requests to paths other than /callback', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([tokenResponse(), userResponse()]);
 
@@ -621,7 +621,7 @@ describe('OAuthService', () => {
 
     it('should reject with AUTH_INVALID when token exchange fails', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([
         {
@@ -651,7 +651,7 @@ describe('OAuthService', () => {
 
     it('should reject with AUTH_INVALID when user info fetch fails', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([
         tokenResponse(),
@@ -673,7 +673,7 @@ describe('OAuthService', () => {
 
     it('should HTML-escape the error description in the callback page', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       mockFetch([]);
 
@@ -707,7 +707,7 @@ describe('OAuthService', () => {
 
       try {
         const configService = createMockConfigService({});
-        const service = new OAuthService(configService);
+        const service = new OAuthService(configService, configService);
 
         mockFetch([]);
 
@@ -723,7 +723,7 @@ describe('OAuthService', () => {
 
     it('should continue when the browser fails to open', async () => {
       const configService = createMockConfigService({});
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       // Swap open() to throw for this test only.
       const originalImplementation = openMock.getMockImplementation();
@@ -758,7 +758,7 @@ describe('OAuthService', () => {
       const configService = createMockConfigService({
         oauthClientSecret: 'stored-secret',
       });
-      const service = new OAuthService(configService);
+      const service = new OAuthService(configService, configService);
 
       const fetchMock = mockFetch([tokenResponse(), userResponse()]);
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,7 @@ import { beforeEach, afterEach } from 'bun:test';
 import { Container } from '../src/core/container.js';
 import type {
   IConfigService,
+  ICredentialStore,
   IGitService,
   IContextService,
   IOutputService,
@@ -42,15 +43,21 @@ afterEach(() => {
  * Mock factories
  */
 
-export function createMockConfigService(config: BBConfig = {}): IConfigService {
+/**
+ * Returns an object satisfying both `IConfigService` and `ICredentialStore`
+ * with shared in-memory state, mirroring the production `ConfigService` class
+ * that backs both interfaces. Tests that only need one interface can still
+ * pass this (widening is fine); tests that want a narrower mock should reach
+ * for `createMockConfigServiceOnly` or `createMockCredentialStoreOnly`.
+ */
+export function createMockConfigService(
+  config: BBConfig = {}
+): IConfigService & ICredentialStore {
   let currentConfig = { ...config };
 
   return {
     async getConfig() {
       return currentConfig;
-    },
-    async setConfig(newConfig: BBConfig) {
-      currentConfig = newConfig;
     },
     async getCredentials(): Promise<AuthCredentials> {
       if (!currentConfig.username || !currentConfig.apiToken) {
@@ -134,6 +141,47 @@ export function createMockConfigService(config: BBConfig = {}): IConfigService {
       if (!currentConfig.oauthExpiresAt) return true;
       return Date.now() >= (currentConfig.oauthExpiresAt - 60) * 1000;
     },
+  };
+}
+
+/**
+ * Narrow factory returning only the app-config surface. Prefer this in tests
+ * that don't touch credentials — it documents the dependency more precisely
+ * and won't satisfy code that wrongly reaches for credential methods.
+ */
+export function createMockConfigServiceOnly(
+  config: BBConfig = {}
+): IConfigService {
+  const { getConfig, clearConfig, getValue, setValue, getConfigPath } =
+    createMockConfigService(config);
+  return { getConfig, clearConfig, getValue, setValue, getConfigPath };
+}
+
+/**
+ * Narrow factory returning only the credential-store surface.
+ */
+export function createMockCredentialStoreOnly(
+  config: BBConfig = {}
+): ICredentialStore {
+  const {
+    getAuthMethod,
+    getCredentials,
+    setCredentials,
+    clearCredentials,
+    getOAuthCredentials,
+    setOAuthCredentials,
+    clearOAuthCredentials,
+    isOAuthTokenExpired,
+  } = createMockConfigService(config);
+  return {
+    getAuthMethod,
+    getCredentials,
+    setCredentials,
+    clearCredentials,
+    getOAuthCredentials,
+    setOAuthCredentials,
+    clearOAuthCredentials,
+    isOAuthTokenExpired,
   };
 }
 


### PR DESCRIPTION
## Summary

Resolves #148. Splits the overloaded `IConfigService` into two narrower interfaces so consumers (and their test mocks) only depend on what they actually use. Internal-only — no on-disk format change and no user-facing behavior change.

- **`IConfigService`** now covers app config only: `getConfig`, `getValue`, `setValue`, `getConfigPath`, `clearConfig`.
- **New `ICredentialStore`** covers basic + OAuth credentials: `getAuthMethod`, `get/set/clearCredentials`, `get/set/clearOAuthCredentials`, `isOAuthTokenExpired`.
- `ConfigService` still implements both, and a new `ServiceTokens.CredentialStore` is registered as an alias resolving the same singleton — so the JSON file keeps backing both, but the door is open for an alternative store (e.g. OS keychain) without touching non-auth consumers.
- Commands and services now inject the narrower dependency they use:
  - `api-client.service`, `auth/login`, `auth/logout`, `auth/token` → `ICredentialStore` only
  - `config/*`, `pr/create`, `context.service`, `version.service`, `workspace-resolver` → `IConfigService` only (unchanged type surface, narrower now)
  - `auth/status` and `oauth.service` → both (explicitly two deps)
- Test helpers gain `createMockConfigServiceOnly` and `createMockCredentialStoreOnly` so tests that only need one surface can stop carrying the other. The existing `createMockConfigService` still returns `IConfigService & ICredentialStore` with shared state, mirroring the production class.
- Added four split-interface round-trip tests in `tests/services/config.service.test.ts` verifying `IConfigService`, `ICredentialStore` (basic + OAuth), and shared storage each work through their narrower type.

## Test plan

- [x] `bun run lint` (tsc --noEmit) — clean
- [x] `bun test` — 792 pass / 0 fail (4 new split-interface tests)
- [x] `bun run format:check` — clean
- [x] Changeset added (`.changeset/split-config-service-interface.md`, patch)