### PR TITLE
refactor(services): drop duplicate types and unnecessary casts

### DIFF
--- a/.changeset/dead-code-cleanup.md
+++ b/.changeset/dead-code-cleanup.md
@@ -1,0 +1,11 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+refactor(services): drop duplicate types and unnecessary casts
+
+Internal-only change — no user-facing behavior change. Three small cleanups in `src/services/`:
+
+- `reviewer.service.ts` redefined its own `RepoContext` interface identical to the canonical one in `src/types/config.ts`. Removed the duplicate and imported the shared type.
+- `extractReviewerUuids` and `buildReviewersUpdateBody` were re-exported from `src/services/index.ts` but only consumed inside `reviewer.service.ts` itself (and the colocated tests, which already import from the module directly). Narrowed the barrel to just `updatePullRequestReviewers`.
+- `coerceVersionCheckIntervalValue(intervalDays as unknown)` in `version.service.ts` cast the argument to `unknown` unnecessarily — the coerce function accepts `unknown` already, and `IConfigService.getValue` returns a typed value.

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,11 +10,7 @@ export { VersionService } from './version.service.js';
 export { createApiClient } from './api-client.service.js';
 export { OAuthService } from './oauth.service.js';
 export { SnippetFilesService } from './snippet-files.service.js';
-export {
-  extractReviewerUuids,
-  buildReviewersUpdateBody,
-  updatePullRequestReviewers,
-} from './reviewer.service.js';
+export { updatePullRequestReviewers } from './reviewer.service.js';
 export { DefaultReviewerService } from './default-reviewer.service.js';
 export type {
   DefaultReviewerEntry,

--- a/src/services/reviewer.service.ts
+++ b/src/services/reviewer.service.ts
@@ -7,11 +7,7 @@ import type {
   Pullrequest,
   PullrequestsApi,
 } from '../generated/api.js';
-
-export interface RepoContext {
-  workspace: string;
-  repoSlug: string;
-}
+import type { RepoContext } from '../types/config.js';
 
 /**
  * Extract UUIDs from a reviewer collection in a type-safe way.

--- a/src/services/version.service.ts
+++ b/src/services/version.service.ts
@@ -92,7 +92,7 @@ export class VersionService {
     const intervalDays = await this.configService.getValue(
       'versionCheckInterval'
     );
-    const days = coerceVersionCheckIntervalValue(intervalDays as unknown) ?? 1;
+    const days = coerceVersionCheckIntervalValue(intervalDays) ?? 1;
 
     const intervalMs = days * 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Small dead-code / duplication cleanup found during a review of earlier Codex-authored code:

- **Duplicate `RepoContext` type**: `src/services/reviewer.service.ts` defined its own `RepoContext` interface identical to the canonical one in `src/types/config.ts`. Dropped the local copy and imported the shared type.
- **Over-exported helpers**: `extractReviewerUuids` and `buildReviewersUpdateBody` were re-exported from `src/services/index.ts` but only ever consumed inside `reviewer.service.ts` itself (plus the colocated tests, which import directly from the module). Narrowed the barrel export to just `updatePullRequestReviewers`.
- **Redundant cast**: `coerceVersionCheckIntervalValue(intervalDays as unknown)` in `version.service.ts` cast to `unknown` unnecessarily — `ConfigService.getValue` already returns the value typed, and the coerce function accepts `unknown` directly.

No behavior change.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 806 pass, 0 fail