### PR TITLE
fix(snippet): drop unnecessary casts in comment commands

### DIFF
--- a/.changeset/snippet-comment-types.md
+++ b/.changeset/snippet-comment-types.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+fix(snippet): replace `as unknown as` casts in snippet comment commands with real types
+
+Internal-only change — no user-facing behavior change. The generated `SnippetComment` extends `ModelObject` which carries an `[key: string]: any` index signature, so the surrounding `as unknown as SnippetComment` / `as unknown as Record<string, unknown>` casts in `comments.add`, `comments.edit`, and `comments.list` were load-bearing only because nobody had tried the direct typing. Constructing the request bodies as `SnippetComment` directly and reading response fields without the intermediate record cast keeps the same runtime behaviour while narrowing the places TypeScript is told to look the other way.

--- a/src/commands/snippet/comments.add.command.ts
+++ b/src/commands/snippet/comments.add.command.ts
@@ -44,12 +44,12 @@ export class AddSnippetCommentCommand extends BaseCommand<
       'Comment message is required. Use --message option.'
     );
 
-    const body = {
+    const body: SnippetComment = {
       type: 'snippet_comment',
       content: {
         raw: message,
       },
-    } as unknown as SnippetComment;
+    };
 
     const response =
       await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsPost({
@@ -59,7 +59,7 @@ export class AddSnippetCommentCommand extends BaseCommand<
       });
 
     const comment = response.data;
-    const commentId = (comment as unknown as Record<string, unknown>).id;
+    const commentId = comment.id;
 
     if (context.globalOptions.json) {
       this.output.json({

--- a/src/commands/snippet/comments.edit.command.ts
+++ b/src/commands/snippet/comments.edit.command.ts
@@ -47,12 +47,12 @@ export class EditSnippetCommentCommand extends BaseCommand<
 
     const commentId = this.parseIntOption(options.commentId, 'comment-id');
 
-    const body = {
+    const body: SnippetComment = {
       type: 'snippet_comment',
       content: {
         raw: options.message,
       },
-    } as unknown as SnippetComment;
+    };
 
     const response =
       await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsCommentIdPut({

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -77,13 +77,12 @@ export class ListSnippetCommentsCommand extends BaseCommand<
       return;
     }
 
-    const record = comments as unknown as Record<string, unknown>[];
-    const rows = record.map((comment) => {
+    const rows = comments.map((comment) => {
       const content = getRawContent(comment.content) ?? '';
       return [
-        String((comment.id as number) ?? ''),
+        String(comment.id ?? ''),
         getUserDisplayName(comment.user) ?? 'Unknown',
-        this.output.formatDate((comment.created_on as string) ?? ''),
+        this.output.formatDate(comment.created_on ?? ''),
         content.slice(0, 60) + (content.length > 60 ? '...' : ''),
       ];
     });


### PR DESCRIPTION
## Summary

The generated `SnippetComment` type extends `ModelObject`, which carries a `[key: string]: any` index signature. That means fields like `content`, `id`, `created_on`, and `user` are already addressable without a cast — the surrounding `as unknown as SnippetComment` / `as unknown as Record<string, unknown>` wrappers in the comment commands were load-bearing only because nobody had tried the direct typing.

- `comments.add`: request body typed as `SnippetComment` directly; response `comment.id` read without the intermediate record cast.
- `comments.edit`: same body-typing fix.
- `comments.list`: dropped the `as unknown as Record<string, unknown>[]` over the whole page and read fields straight off `SnippetComment`.

No behavior change — just narrower type holes.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 806 pass, 0 fail