### PR TITLE
refactor(context): drop pointless new RegExp wrapping

### DIFF
--- a/.changeset/context-regex-cleanup.md
+++ b/.changeset/context-regex-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+refactor(context): drop pointless `new RegExp(/literal/)` wrapping in remote URL parser
+
+Internal-only change — no behavior change. `ContextService.parseRemoteUrl` constructed its SSH and HTTPS regexes as `new RegExp(/.../).exec(url)`, which wraps an already-compiled regex literal in a second `RegExp` constructor call. Replaced with direct `/regex/.exec(url)` calls.

--- a/src/services/context.service.ts
+++ b/src/services/context.service.ts
@@ -22,9 +22,7 @@ export class ContextService implements IContextService {
    */
   public parseRemoteUrl(url: string): RepoContext | null {
     // SSH format: git@bitbucket.org:workspace/repo.git
-    const sshMatch = new RegExp(
-      /git@bitbucket\.org:([^/]+)\/([^.]+)(?:\.git)?/
-    ).exec(url);
+    const sshMatch = /git@bitbucket\.org:([^/]+)\/([^.]+)(?:\.git)?/.exec(url);
     if (sshMatch) {
       return {
         workspace: sshMatch[1]!,
@@ -34,9 +32,10 @@ export class ContextService implements IContextService {
 
     // HTTPS format: https://bitbucket.org/workspace/repo.git
     // or: https://username@bitbucket.org/workspace/repo.git
-    const httpsMatch = new RegExp(
-      /https?:\/\/(?:[^@]+@)?bitbucket\.org\/([^/]+)\/([^/.]+)(?:\.git)?/
-    ).exec(url);
+    const httpsMatch =
+      /https?:\/\/(?:[^@]+@)?bitbucket\.org\/([^/]+)\/([^/.]+)(?:\.git)?/.exec(
+        url
+      );
     if (httpsMatch) {
       return {
         workspace: httpsMatch[1]!,


### PR DESCRIPTION
## Summary

`ContextService.parseRemoteUrl` constructed its SSH and HTTPS regexes as `new RegExp(/.../).exec(url)` — wrapping an already-compiled regex literal in a redundant `RegExp` constructor call.

Replaced with the direct `/regex/.exec(url)` form.

No behavior change, fewer moving parts.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test tests/services/context.service*.test.ts` — 36 pass, 0 fail