### PR TITLE
refactor(cli): extract PR_STATES and collapse completion dispatch

### DIFF
--- a/.changeset/completion-state-enum.md
+++ b/.changeset/completion-state-enum.md
@@ -1,0 +1,10 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+refactor(cli): extract PR states constant and collapse completion if/else into a map
+
+Internal-only change — no user-facing behavior change.
+
+- **`PR_STATES` constant**: The literal list `['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED']` was written out three times — once in `pr/list.command.ts` as the option validator, once in `cli.ts` as the `--state` description, and once in the help text's `Valid states`. Lifted to a new `src/types/pr.ts` export so future additions only touch one place.
+- **Tabtab completion**: The `env.prev` dispatch in `cli.ts` was an eight-branch if/else chain hand-maintained next to Commander's command tree. Replaced with a single `ReadonlyMap<parent, subcommands>` table, keeping the special-case `comments` disambiguation (its parent can be `pr` or `snippet`) separate. Same completions, fewer branches to keep in sync.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,12 @@ const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> = new Map([
   ['completion', ['install', 'uninstall']],
 ]);
 
-const COMMENTS_SUBCOMMANDS: readonly string[] = ['list', 'add', 'edit', 'delete'];
+const COMMENTS_SUBCOMMANDS: readonly string[] = [
+  'list',
+  'add',
+  'edit',
+  'delete',
+];
 
 // Handle tabtab completion
 if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import type { BaseCommand } from './core/base-command.js';
 import type { CommandContext } from './core/interfaces/commands.js';
 import type { IOutputService } from './core/interfaces/services.js';
 import type { VersionService } from './services/version.service.js';
+import { PR_STATES } from './types/pr.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
@@ -45,78 +46,84 @@ export function getCompletionParent(
   return undefined;
 }
 
+/**
+ * Subcommands keyed by their direct parent. `comments` is handled
+ * specially because it appears under both `pr` and `snippet`.
+ */
+const ROOT_COMPLETIONS: readonly string[] = [
+  'auth',
+  'repo',
+  'pr',
+  'snippet',
+  'config',
+  'completion',
+  '--help',
+  '--version',
+  '--json',
+  '--no-color',
+  '--workspace',
+  '--repo',
+];
+
+const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> = new Map([
+  ['auth', ['login', 'logout', 'status', 'token']],
+  ['repo', ['clone', 'create', 'list', 'view', 'delete', 'default-reviewers']],
+  ['default-reviewers', ['list', 'add', 'remove']],
+  [
+    'pr',
+    [
+      'create',
+      'list',
+      'view',
+      'activity',
+      'checks',
+      'edit',
+      'merge',
+      'approve',
+      'decline',
+      'ready',
+      'checkout',
+      'diff',
+      'comments',
+      'reviewers',
+    ],
+  ],
+  ['reviewers', ['list', 'add', 'remove']],
+  [
+    'snippet',
+    [
+      'list',
+      'view',
+      'create',
+      'edit',
+      'delete',
+      'watch',
+      'unwatch',
+      'comments',
+    ],
+  ],
+  ['config', ['get', 'set', 'list']],
+  ['completion', ['install', 'uninstall']],
+]);
+
+const COMMENTS_SUBCOMMANDS: readonly string[] = ['list', 'add', 'edit', 'delete'];
+
 // Handle tabtab completion
 if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
   const env = tabtab.parseEnv(process.env);
   if (env.complete) {
-    const completions = [
-      'auth',
-      'repo',
-      'pr',
-      'snippet',
-      'config',
-      'completion',
-      '--help',
-      '--version',
-      '--json',
-      '--no-color',
-      '--workspace',
-      '--repo',
-    ];
+    const completions = [...ROOT_COMPLETIONS];
 
-    // Add subcommands based on current command
-    if (env.prev === 'auth') {
-      completions.push('login', 'logout', 'status', 'token');
-    } else if (env.prev === 'repo') {
-      completions.push(
-        'clone',
-        'create',
-        'list',
-        'view',
-        'delete',
-        'default-reviewers'
-      );
-    } else if (env.prev === 'default-reviewers') {
-      completions.push('list', 'add', 'remove');
-    } else if (env.prev === 'pr') {
-      completions.push(
-        'create',
-        'list',
-        'view',
-        'activity',
-        'checks',
-        'edit',
-        'merge',
-        'approve',
-        'decline',
-        'ready',
-        'checkout',
-        'diff',
-        'comments',
-        'reviewers'
-      );
-    } else if (env.prev === 'reviewers') {
-      completions.push('list', 'add', 'remove');
-    } else if (env.prev === 'snippet') {
-      completions.push(
-        'list',
-        'view',
-        'create',
-        'edit',
-        'delete',
-        'watch',
-        'unwatch',
-        'comments'
-      );
-    } else if (env.prev === 'comments') {
+    if (env.prev === 'comments') {
       const parent = getCompletionParent(env.line, 'comments');
       if (parent === 'snippet' || parent === 'pr') {
-        completions.push('list', 'add', 'edit', 'delete');
+        completions.push(...COMMENTS_SUBCOMMANDS);
       }
-    } else if (env.prev === 'config') {
-      completions.push('get', 'set', 'list');
-    } else if (env.prev === 'completion') {
-      completions.push('install', 'uninstall');
+    } else {
+      const subcommands = SUBCOMMAND_COMPLETIONS.get(env.prev);
+      if (subcommands) {
+        completions.push(...subcommands);
+      }
     }
 
     tabtab.log(completions);
@@ -603,7 +610,7 @@ prCmd
   .description('List pull requests')
   .option(
     '-s, --state <state>',
-    'Filter by state (OPEN, MERGED, DECLINED, SUPERSEDED)',
+    `Filter by state (${PR_STATES.join(', ')})`,
     'OPEN'
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
@@ -618,7 +625,7 @@ prCmd
         'bb pr list --json',
       ],
       validValues: {
-        'Valid states': ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'],
+        'Valid states': [...PR_STATES],
       },
       defaults: { state: 'OPEN', limit: '25' },
     })

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../generated/api.js';
 import { collectPages, parseLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { PR_STATES } from '../../types/pr.js';
 
 export interface ListPRsOptions extends GlobalOptions {
   state?: string;
@@ -44,14 +45,8 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       ...options,
     });
 
-    const ALLOWED_STATES = [
-      'OPEN',
-      'MERGED',
-      'DECLINED',
-      'SUPERSEDED',
-    ] as const;
     const state = options.state
-      ? this.parseEnumOption(options.state, 'state', ALLOWED_STATES)
+      ? this.parseEnumOption(options.state, 'state', PR_STATES)
       : 'OPEN';
     const limit = parseLimit(options.limit);
     const reviewerQuery = options.mine

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@
 
 export * from './errors.js';
 export * from './config.js';
+export * from './pr.js';

--- a/src/types/pr.ts
+++ b/src/types/pr.ts
@@ -1,0 +1,12 @@
+/**
+ * Pull request related constants and types
+ */
+
+export const PR_STATES = [
+  'OPEN',
+  'MERGED',
+  'DECLINED',
+  'SUPERSEDED',
+] as const;
+
+export type PRState = (typeof PR_STATES)[number];

--- a/src/types/pr.ts
+++ b/src/types/pr.ts
@@ -2,11 +2,6 @@
  * Pull request related constants and types
  */
 
-export const PR_STATES = [
-  'OPEN',
-  'MERGED',
-  'DECLINED',
-  'SUPERSEDED',
-] as const;
+export const PR_STATES = ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'] as const;
 
 export type PRState = (typeof PR_STATES)[number];


### PR DESCRIPTION
## Summary

Two related cleanups in the CLI layer — no user-facing behavior change.

### `PR_STATES` constant
The literal list `['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED']` was written out three times:
- In `pr/list.command.ts` as the `parseEnumOption` allowlist.
- In `cli.ts` as the `--state` option description string.
- In `cli.ts` as the help text's `Valid states`.

Lifted to a new `src/types/pr.ts` export. Adding or renaming a state now touches one place.

### Tabtab completion dispatch
The `env.prev` branch in `cli.ts` was an eight-arm if/else chain hand-maintained next to Commander's command tree. Replaced with a single `ReadonlyMap<parent, subcommands>` table. The `comments` case stays special because its parent can be either `pr` or `snippet` (disambiguated by `getCompletionParent`, which is unchanged).

Same completions, fewer branches to keep in sync with Commander.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 806 pass, 0 fail
- [x] `getCompletionParent` tests unchanged and still pass