### PR TITLE
security: add PKCE (S256) to OAuth authorization-code flow

### DIFF
--- a/.changeset/oauth-pkce.md
+++ b/.changeset/oauth-pkce.md
@@ -1,0 +1,5 @@
+---
+'@0pilatos0/bitbucket-cli': patch
+---
+
+security: add PKCE (S256) to the OAuth authorization-code flow. The CLI now generates a per-login `code_verifier`, sends `code_challenge` + `code_challenge_method=S256` on the authorize redirect, and supplies the verifier on token exchange. An attacker who intercepts only the authorization code can no longer redeem it.

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -3,7 +3,7 @@
  */
 
 import { createServer, type Server } from 'node:http';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import type {
   IConfigService,
   ICredentialStore,
@@ -48,6 +48,22 @@ function generateState(): string {
   return randomBytes(16).toString('hex');
 }
 
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(
+    createHash('sha256').update(verifier).digest()
+  );
+  return { verifier, challenge };
+}
+
 export class OAuthService {
   constructor(
     private readonly configService: IConfigService,
@@ -67,8 +83,9 @@ export class OAuthService {
   }> {
     const resolvedClientId = clientId ?? (await this.getClientId());
     const state = generateState();
+    const { verifier, challenge } = generatePkcePair();
 
-    const authUrl = this.buildAuthUrl(resolvedClientId, state);
+    const authUrl = this.buildAuthUrl(resolvedClientId, state, challenge);
 
     // Start local server before opening browser
     const { code } = await this.waitForCallback(authUrl, state);
@@ -77,6 +94,7 @@ export class OAuthService {
     const tokenResponse = await this.exchangeCode(
       code,
       resolvedClientId,
+      verifier,
       clientSecret
     );
 
@@ -192,13 +210,19 @@ export class OAuthService {
     return customSecret ?? DEFAULT_CLIENT_SECRET;
   }
 
-  private buildAuthUrl(clientId: string, state: string): string {
+  private buildAuthUrl(
+    clientId: string,
+    state: string,
+    codeChallenge: string
+  ): string {
     const params = new URLSearchParams({
       client_id: clientId,
       response_type: 'code',
       redirect_uri: CALLBACK_URL,
       scope: OAUTH_SCOPES,
       state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
     });
     return `${BITBUCKET_AUTHORIZE_URL}?${params.toString()}`;
   }
@@ -311,6 +335,7 @@ export class OAuthService {
   private async exchangeCode(
     code: string,
     clientId: string,
+    codeVerifier: string,
     clientSecretOverride?: string
   ): Promise<TokenResponse> {
     const clientSecret = clientSecretOverride ?? (await this.getClientSecret());
@@ -318,6 +343,7 @@ export class OAuthService {
       grant_type: 'authorization_code',
       code,
       redirect_uri: CALLBACK_URL,
+      code_verifier: codeVerifier,
     });
 
     const response = await fetch(BITBUCKET_TOKEN_URL, {

--- a/tests/services/oauth.service.test.ts
+++ b/tests/services/oauth.service.test.ts
@@ -12,6 +12,7 @@ import {
   mock,
 } from 'bun:test';
 import { createServer, type Server } from 'node:http';
+import { createHash } from 'node:crypto';
 import { OAuthService } from '../../src/services/oauth.service.js';
 import { createMockConfigService } from '../setup.js';
 import { ErrorCode } from '../../src/types/errors.js';
@@ -752,6 +753,43 @@ describe('OAuthService', () => {
           openMock.mockImplementation(async () => undefined);
         }
       }
+    });
+
+    it('should send a PKCE S256 challenge on authorize and the matching verifier on token exchange', async () => {
+      const configService = createMockConfigService({});
+      const service = new OAuthService(configService, configService);
+
+      const fetchMock = mockFetch([tokenResponse(), userResponse()]);
+
+      const authorizePromise = service.authorize();
+      const authUrl = await waitForBrowserOpen();
+
+      const url = new URL(authUrl);
+      const challenge = url.searchParams.get('code_challenge');
+      const method = url.searchParams.get('code_challenge_method');
+      expect(method).toBe('S256');
+      expect(challenge).toBeTruthy();
+      expect(challenge).not.toContain('+');
+      expect(challenge).not.toContain('/');
+      expect(challenge).not.toContain('=');
+
+      const state = extractState(authUrl);
+      await originalFetch(`${CALLBACK_URL}?code=the-code&state=${state}`);
+      await authorizePromise;
+
+      const tokenCall = fetchMock.getCalls()[0];
+      const body = tokenCall.options.body as string;
+      const params = new URLSearchParams(body);
+      const verifier = params.get('code_verifier');
+      expect(verifier).toBeTruthy();
+
+      const expectedChallenge = createHash('sha256')
+        .update(verifier as string)
+        .digest('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+      expect(expectedChallenge).toBe(challenge as string);
     });
 
     it('should forward an override client secret to the token exchange', async () => {


### PR DESCRIPTION
## Summary

- Generate a per-login `code_verifier` and SHA-256 `code_challenge` (PKCE / RFC 7636).
- Add `code_challenge` and `code_challenge_method=S256` to the authorize URL.
- Send `code_verifier` on the token-exchange POST.

The CLI ships a public client secret (correctly noted as non-sensitive for native-app OAuth), so an authorization code intercepted on the loopback redirect could previously be redeemed by anyone holding the shipped secret. PKCE binds the code to a verifier known only to this `authorize()` invocation, closing that gap.

Closes #190

## Test plan

- [x] `bun test tests/services/oauth.service.test.ts` — added a test asserting the authorize URL carries `code_challenge_method=S256` and that `sha256(code_verifier)` (base64url) equals the challenge sent on authorize.
- [x] `bun test` — all 838 tests pass.
- [x] `bun run lint` — type-check clean.
- [x] `bun run format:check` — clean (runs in pre-commit).
- [ ] Manual: run `bb auth login` against Bitbucket Cloud and confirm the flow still completes end-to-end.