### PR TITLE
fix(oauth): don't leak token endpoint response body via BBError.context

### DIFF
--- a/.changeset/oauth-error-body-leak.md
+++ b/.changeset/oauth-error-body-leak.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+security: stop persisting the OAuth token-endpoint response body in `BBError.context`. The raw body could include attacker-influenced data when a custom OAuth provider was configured via `--client-id`/`--client-secret`, and surfaced through `--json` error output. The error now exposes only `{ status }` in `context`; if the response is a JSON body with `error_description`, a sanitized, length-capped excerpt is folded into the user-facing `message`.

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -48,6 +48,42 @@ function generateState(): string {
   return randomBytes(16).toString('hex');
 }
 
+const OAUTH_ERROR_DESCRIPTION_MAX_LENGTH = 200;
+
+/**
+ * Extract a sanitized `error_description` from an OAuth token-endpoint error
+ * body. Returns undefined if the body isn't a JSON object with a string
+ * `error_description`. The result is trimmed to a single line and capped in
+ * length so attacker-influenced responses can't bloat the user-facing message.
+ */
+function extractOAuthErrorDescription(body: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('error_description' in parsed)
+  ) {
+    return undefined;
+  }
+  const description = (parsed as { error_description: unknown })
+    .error_description;
+  if (typeof description !== 'string') {
+    return undefined;
+  }
+  const sanitized = description.replace(/\s+/g, ' ').trim();
+  if (sanitized.length === 0) {
+    return undefined;
+  }
+  return sanitized.length > OAUTH_ERROR_DESCRIPTION_MAX_LENGTH
+    ? `${sanitized.slice(0, OAUTH_ERROR_DESCRIPTION_MAX_LENGTH)}…`
+    : sanitized;
+}
+
 export class OAuthService {
   constructor(
     private readonly configService: IConfigService,
@@ -125,10 +161,12 @@ export class OAuthService {
 
     if (!response.ok) {
       const errorBody = await response.text();
+      const description = extractOAuthErrorDescription(errorBody);
+      const baseMessage = `Failed to refresh OAuth token. Run 'bb auth login' to re-authenticate.`;
       throw new BBError({
         code: ErrorCode.AUTH_EXPIRED,
-        message: `Failed to refresh OAuth token. Run 'bb auth login' to re-authenticate.`,
-        context: { status: response.status, body: errorBody },
+        message: description ? `${baseMessage} (${description})` : baseMessage,
+        context: { status: response.status },
       });
     }
 
@@ -331,10 +369,12 @@ export class OAuthService {
 
     if (!response.ok) {
       const errorBody = await response.text();
+      const description = extractOAuthErrorDescription(errorBody);
+      const baseMessage = `Failed to exchange authorization code. Please try again.`;
       throw new BBError({
         code: ErrorCode.AUTH_INVALID,
-        message: `Failed to exchange authorization code. Please try again.`,
-        context: { status: response.status, body: errorBody },
+        message: description ? `${baseMessage} (${description})` : baseMessage,
+        context: { status: response.status },
       });
     }
 

--- a/tests/services/oauth.service.test.ts
+++ b/tests/services/oauth.service.test.ts
@@ -260,6 +260,100 @@ describe('OAuthService', () => {
       }
     });
 
+    it('should not leak the refresh token endpoint body into BBError.context (#195)', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'bad-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
+      });
+      const service = new OAuthService(configService, configService);
+
+      // A hostile token endpoint can return any string here — verify it
+      // doesn't get persisted into the structured --json error contract.
+      const hostileBody = 'attacker-controlled-string';
+      mockFetch([
+        {
+          ok: false,
+          status: 401,
+          text: async () => hostileBody,
+        },
+      ]);
+
+      try {
+        await service.refreshAccessToken();
+        expect(true).toBe(false);
+      } catch (err: any) {
+        expect(err.code).toBe(ErrorCode.AUTH_EXPIRED);
+        expect(err.context).toEqual({ status: 401 });
+        expect(err.context).not.toHaveProperty('body');
+        expect(JSON.stringify(err.toJSON())).not.toContain(hostileBody);
+      }
+    });
+
+    it('should fold a sanitized error_description into the refresh error message', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'bad-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
+      });
+      const service = new OAuthService(configService, configService);
+
+      mockFetch([
+        {
+          ok: false,
+          status: 401,
+          text: async () =>
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Refresh token is invalid',
+            }),
+        },
+      ]);
+
+      try {
+        await service.refreshAccessToken();
+        expect(true).toBe(false);
+      } catch (err: any) {
+        expect(err.message).toContain('Refresh token is invalid');
+        expect(err.context).toEqual({ status: 401 });
+      }
+    });
+
+    it('should cap the sanitized error_description length', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'bad-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
+      });
+      const service = new OAuthService(configService, configService);
+
+      const longDescription = 'X'.repeat(1000);
+      mockFetch([
+        {
+          ok: false,
+          status: 401,
+          text: async () =>
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: longDescription,
+            }),
+        },
+      ]);
+
+      try {
+        await service.refreshAccessToken();
+        expect(true).toBe(false);
+      } catch (err: any) {
+        // Cap is 200 chars + ellipsis; total message should be much shorter
+        // than the raw description.
+        expect(err.message.length).toBeLessThan(longDescription.length);
+        expect(err.message).toContain('…');
+      }
+    });
+
     it('should use custom client credentials when stored', async () => {
       const configService = createMockConfigService({
         authMethod: 'oauth',
@@ -646,7 +740,46 @@ describe('OAuthService', () => {
       };
       expect(err.code).toBe(ErrorCode.AUTH_INVALID);
       expect(err.message).toContain('Failed to exchange authorization code');
-      expect(err.context).toEqual({ status: 400, body: 'invalid_grant' });
+      // Body must NOT be persisted into context — see #195. The token-endpoint
+      // response body can be attacker-influenced when --client-id points at a
+      // hostile OAuth provider.
+      expect(err.context).toEqual({ status: 400 });
+      expect(err.context).not.toHaveProperty('body');
+    });
+
+    it('should not leak token endpoint body into context, even with JSON error_description', async () => {
+      const configService = createMockConfigService({});
+      const service = new OAuthService(configService, configService);
+
+      mockFetch([
+        {
+          ok: false,
+          status: 400,
+          text: async () =>
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Authorization code is invalid or expired',
+            }),
+        },
+      ]);
+
+      const authorizeOutcome = outcome(service.authorize());
+      const authUrl = await waitForBrowserOpen();
+      const state = extractState(authUrl);
+
+      await originalFetch(`${CALLBACK_URL}?code=c&state=${state}`);
+
+      const result = await authorizeOutcome;
+      const err = result.error as {
+        code: number;
+        message: string;
+        context: Record<string, unknown>;
+      };
+      expect(err.code).toBe(ErrorCode.AUTH_INVALID);
+      expect(err.context).toEqual({ status: 400 });
+      expect(err.context).not.toHaveProperty('body');
+      // Sanitized excerpt may be folded into the message.
+      expect(err.message).toContain('Authorization code is invalid or expired');
     });
 
     it('should reject with AUTH_INVALID when user info fetch fails', async () => {


### PR DESCRIPTION
## Summary

- Stops persisting the raw OAuth token-endpoint response body into `BBError.context`. With `--client-id`/`--client-secret` pointing at an attacker-controlled provider, that body is attacker-influenced data smuggled into the CLI's structured `--json` error output.
- `context` now exposes only `{ status }`. If the body is JSON with an `error_description`, a sanitized, length-capped (200 char) excerpt is folded into the user-facing `message` instead.
- Applies to both `refreshAccessToken` and `exchangeCode`.

## Test plan

- [x] `bun test` — 841 pass, 0 fail
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] New tests assert `BBError.context` for OAuth errors does not contain `body`, the hostile body string is absent from `toJSON()`, and that a JSON `error_description` is sanitized + capped before being added to `message`.
- [x] Updated the existing token-exchange-failure test that previously asserted `body` was present in `context`.

Closes #195