### PR TITLE
fix(security): anchor remote URL regex; redact query strings in DEBUG logs

### DIFF
--- a/.changeset/anchor-remote-url-redact-debug.md
+++ b/.changeset/anchor-remote-url-redact-debug.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+security: anchor `parseRemoteUrl` regex to reject crafted Bitbucket URLs like `git@bitbucket.org:foo/bar.git.attacker.com/x/y`, and redact query strings from request URL DEBUG logs.

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -78,6 +78,21 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function redactRequestUrl(
+  requestUrl: string | undefined,
+  baseUrl: string | undefined
+): string {
+  const raw = requestUrl ?? '';
+  try {
+    const parsed = new URL(raw, baseUrl);
+    const query = parsed.search ? '?[redacted]' : '';
+    return `${parsed.origin}${parsed.pathname}${query}`;
+  } catch {
+    const queryIdx = raw.indexOf('?');
+    return queryIdx === -1 ? raw : `${raw.slice(0, queryIdx)}?[redacted]`;
+  }
+}
+
 export function createApiClient(
   credentialStore: ICredentialStore,
   oauthService?: OAuthService
@@ -94,7 +109,9 @@ export function createApiClient(
   instance.interceptors.request.use(
     async (config) => {
       if (process.env.DEBUG === 'true') {
-        console.debug(`[HTTP] ${config.method?.toUpperCase()} ${config.url}`);
+        console.debug(
+          `[HTTP] ${config.method?.toUpperCase()} ${redactRequestUrl(config.url, config.baseURL)}`
+        );
       }
 
       const authMethod = await credentialStore.getAuthMethod();

--- a/src/services/context.service.ts
+++ b/src/services/context.service.ts
@@ -22,7 +22,8 @@ export class ContextService implements IContextService {
    */
   public parseRemoteUrl(url: string): RepoContext | null {
     // SSH format: git@bitbucket.org:workspace/repo.git
-    const sshMatch = /git@bitbucket\.org:([^/]+)\/([^.]+)(?:\.git)?/.exec(url);
+    const sshMatch =
+      /^git@bitbucket\.org:([^/\s]+)\/([^/\s.]+)(?:\.git)?$/.exec(url);
     if (sshMatch) {
       return {
         workspace: sshMatch[1]!,
@@ -33,7 +34,7 @@ export class ContextService implements IContextService {
     // HTTPS format: https://bitbucket.org/workspace/repo.git
     // or: https://username@bitbucket.org/workspace/repo.git
     const httpsMatch =
-      /https?:\/\/(?:[^@]+@)?bitbucket\.org\/([^/]+)\/([^/.]+)(?:\.git)?/.exec(
+      /^https?:\/\/(?:[^@\s]+@)?bitbucket\.org\/([^/\s]+)\/([^/\s.]+)(?:\.git)?$/.exec(
         url
       );
     if (httpsMatch) {

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -616,6 +616,22 @@ describe('createApiClient - DEBUG response logging redaction', () => {
     expect(output).toContain('[HTTP] GET');
     expect(output).toContain('/some/resource');
   });
+
+  it('redacts query strings from request URL DEBUG logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
+    client = createApiClient(mockConfigService());
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/some/resource?token=abc&other=xyz');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] GET');
+    expect(output).toContain('/some/resource');
+    expect(output).not.toContain('token=abc');
+    expect(output).not.toContain('other=xyz');
+    expect(output).toContain('[redacted]');
+  });
 });
 
 describe('createApiClient - authentication header', () => {

--- a/tests/services/context.service.test.ts
+++ b/tests/services/context.service.test.ts
@@ -85,6 +85,41 @@ describe('ContextService', () => {
       expect(service.parseRemoteUrl('not-a-url')).toBeNull();
       expect(service.parseRemoteUrl('')).toBeNull();
     });
+
+    it('should reject SSH URLs with attacker-controlled trailing path', () => {
+      const gitService = createMockGitService();
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      expect(
+        service.parseRemoteUrl('git@bitbucket.org:foo/bar.git.attacker.com/x/y')
+      ).toBeNull();
+    });
+
+    it('should reject HTTPS URLs with attacker-controlled trailing path', () => {
+      const gitService = createMockGitService();
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      expect(
+        service.parseRemoteUrl(
+          'https://bitbucket.org/foo/bar.git.attacker.com/x/y'
+        )
+      ).toBeNull();
+    });
+
+    it('should reject URLs with crafted prefixes', () => {
+      const gitService = createMockGitService();
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      expect(
+        service.parseRemoteUrl('prefix git@bitbucket.org:foo/bar.git')
+      ).toBeNull();
+      expect(
+        service.parseRemoteUrl('xhttps://bitbucket.org/foo/bar.git')
+      ).toBeNull();
+    });
   });
 
   describe('getRepoContextFromGit', () => {


### PR DESCRIPTION
## Summary

Closes #191.

- **Anchor `parseRemoteUrl` regex** — both the SSH and HTTPS patterns in `src/services/context.service.ts` now use `^…$` and exclude whitespace, so a freshly-cloned hostile repo with a remote like `git@bitbucket.org:foo/bar.git.attacker.com/x/y` returns `null` instead of silently mis-parsing the workspace/repo and sending API calls to the wrong place.
- **Redact query strings in DEBUG logs** — the request-URL DEBUG line in `src/services/api-client.service.ts` now logs only `origin + pathname + ?[redacted]` (when a query is present). Bitbucket's API doesn't put secrets in query strings today, but DEBUG output regularly ends up in pasted bug reports and CI logs — defense-in-depth.

## Test plan

- [x] `bun test` — 841/841 pass
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] Added regression tests:
  - `parseRemoteUrl` rejects attacker-trailing-path SSH and HTTPS URLs and crafted prefixes.
  - DEBUG request log for `/some/resource?token=abc&other=xyz` does not contain `token=abc` or `other=xyz`, includes `[redacted]`.