### PR TITLE
fix(pr): use open package in pr diff --web instead of shell exec

### DIFF
--- a/.changeset/fix-pr-diff-web-shell-exec.md
+++ b/.changeset/fix-pr-diff-web-shell-exec.md
@@ -1,0 +1,11 @@
+---
+'bitbucket-cli': patch
+---
+
+fix(security): use `open` package in `pr diff --web` instead of shell-string `exec`
+
+Replaces the platform-specific shell command (`open "${url}"`, `start "" "${url}"`,
+`xdg-open "${url}"`) in `pr diff --web` with the already-bundled `open` package, so the
+URL is no longer interpreted by `/bin/sh` or `cmd.exe`. URLs containing shell
+metacharacters (`&`, `` ` ``, `$`, `"`, `|`, `>`) are now passed verbatim to the
+browser instead of being parsed as shell syntax.

--- a/.prettierignore
+++ b/.prettierignore
@@ -39,3 +39,6 @@ docs/
 
 # Git
 .git/
+
+# Conductor workspace metadata (gitignored)
+.context/

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -2,8 +2,6 @@
  * PR diff command implementation
  */
 
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { BaseCommand } from '../../core/base-command.js';
 import type { CommandContext } from '../../core/interfaces/commands.js';
 import type {
@@ -20,8 +18,6 @@ import {
 } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { BBError, ErrorCode } from '../../types/errors.js';
-
-const execAsync = promisify(exec);
 
 export interface DiffPROptions extends GlobalOptions {
   id?: string;
@@ -183,19 +179,8 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
 
   private async openInBrowser(url: string): Promise<void> {
     this.output.info(`Opening ${url} in your browser...`);
-
-    const platform = process.platform;
-    let command: string;
-
-    if (platform === 'darwin') {
-      command = `open "${url}"`;
-    } else if (platform === 'win32') {
-      command = `start "" "${url}"`;
-    } else {
-      command = `xdg-open "${url}"`;
-    }
-
-    await execAsync(command);
+    const open = (await import('open')).default;
+    await open(url);
   }
 
   private async getWebDiffUrl(

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -2,7 +2,7 @@
  * PR command tests
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, mock } from 'bun:test';
 import { ListPRsCommand } from '../../src/commands/pr/list.command.js';
 import { ViewPRCommand } from '../../src/commands/pr/view.command.js';
 import { CreatePRCommand } from '../../src/commands/pr/create.command.js';
@@ -2199,6 +2199,42 @@ describe('DiffPRCommand', () => {
     const summary = output.logs.find((log) => log.includes('file changed'));
     expect(summary).toBeDefined();
     expect(summary).toContain('1 file changed');
+  });
+
+  it('should pass the URL verbatim to open() without shell interpolation when --web is set', async () => {
+    const openCalls: string[] = [];
+    mock.module('open', () => ({
+      default: async (url: string) => {
+        openCalls.push(url);
+      },
+    }));
+
+    const maliciousUrl =
+      'https://bitbucket.org/workspace/repo/pull-requests/1/?x=" & echo pwned `id`';
+    const prs = [
+      {
+        ...mockPullRequest,
+        links: { html: { href: maliciousUrl } },
+      } as unknown as Pullrequest,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const gitService = createMockGitService();
+    const output = createMockOutputService();
+
+    const command = new DiffPRCommand(
+      pullrequestsApi,
+      contextService,
+      gitService,
+      output
+    );
+    await command.execute({ id: '1', web: true }, { globalOptions: {} });
+
+    expect(openCalls).toHaveLength(1);
+    expect(openCalls[0]).toBe(`${maliciousUrl}/diff`);
   });
 
   it('should use the PR html link when building a --web URL', async () => {


### PR DESCRIPTION
## Summary

- Fixes #193 — replaces the shell-string `exec` in `pr diff --web` with the already-bundled `open` package, removing a local shell-injection sink for URLs returned by `pr.links.html.href`.
- Drops `node:child_process` / `promisify(exec)` from `src/commands/pr/diff.command.ts`; mirrors the pattern used in `src/services/oauth.service.ts:301`.
- Adds a regression test that constructs a URL containing `\"`, `&`, and backticks and asserts it is passed verbatim to a mocked `open()` (no shell involvement).
- Adds Conductor's gitignored `.context/` to `.prettierignore` so the pre-commit `format:check` doesn't trip on workspace metadata.

## Test plan

- [x] `bun run lint`
- [x] `bun test tests/commands/pr.test.ts` (118 pass, including the new shell-metacharacter test)
- [x] `bun run format:check`
- [ ] Manual smoke: `bb pr diff --web <id>` opens the PR's web URL on macOS / Linux / Windows

Closes #193