### PR TITLE
fix(output): sanitize ANSI / control chars in terminal output

### DIFF
--- a/.changeset/sanitize-control-chars.md
+++ b/.changeset/sanitize-control-chars.md
@@ -1,0 +1,13 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+security: strip ANSI / OSC / control characters from terminal output
+
+Untrusted strings from the API (PR titles, descriptions, branch names,
+snippet file names, repo descriptions, etc.) are now sanitized before
+being printed by `OutputService`. This blocks terminal-spoofing primitives
+such as OSC-8 hyperlink injection, OSC-0 terminal-title rewrites, and
+CSI cursor / screen-clear sequences. Chalk-generated SGR color codes
+composed by commands continue to render normally. JSON output is
+unchanged.

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -10,6 +10,26 @@ import type {
 import { BBError, ErrorCode } from '../types/errors.js';
 import { projectFields } from './output.project.js';
 
+// Strip dangerous terminal control sequences from text before printing so
+// attacker-controlled API data (PR titles, descriptions, branch names,
+// snippet names, etc.) can't spoof clickable hyperlinks (OSC-8), rewrite the
+// terminal title (OSC-0), clear the screen, or trigger legacy escape-handling
+// vulnerabilities. SGR sequences (CSI ending in 'm') are preserved via the
+// first capture group so chalk-generated color/style codes composed by
+// callers — e.g. `output.text(`${output.bold('#42')} ${pr.title}`)` — still
+// render. JSON output is intentionally unchanged: JSON encoding escapes
+// control characters, so machine-readable consumers see the raw bytes.
+const CONTROL_CHARS =
+  // eslint-disable-next-line no-control-regex
+  /(\x1b\[[0-9;?]*m)|\x1b\[[0-9;?]*[A-Za-ln-z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x9B\x9D]/g;
+
+function stripControl(value: string): string {
+  return value.replace(
+    CONTROL_CHARS,
+    (_match, sgr: string | undefined) => sgr ?? ''
+  );
+}
+
 // Wrapper objects produced by list-style commands have a single canonical
 // "items" key. When `--json fields` is passed, project across that array
 // instead of the wrapper. Order matters: the first match wins. Keys must
@@ -72,16 +92,21 @@ export class OutputService implements IOutputService {
       return;
     }
 
+    const sanitizedHeaders = headers.map(stripControl);
+    const sanitizedRows = rows.map((row) =>
+      row.map((cell) => stripControl(cell || ''))
+    );
+
     // Calculate column widths
-    const widths = headers.map((header, index) => {
+    const widths = sanitizedHeaders.map((header, index) => {
       const maxRowWidth = Math.max(
-        ...rows.map((row) => (row[index] || '').length)
+        ...sanitizedRows.map((row) => (row[index] || '').length)
       );
       return Math.max(header.length, maxRowWidth);
     });
 
     // Print header
-    const headerRow = headers
+    const headerRow = sanitizedHeaders
       .map((header, index) => header.padEnd(widths[index]!))
       .join('  ');
 
@@ -91,9 +116,9 @@ export class OutputService implements IOutputService {
     console.log(widths.map((width) => '-'.repeat(width)).join('  '));
 
     // Print rows
-    for (const row of rows) {
+    for (const row of sanitizedRows) {
       const formattedRow = row
-        .map((cell, index) => (cell || '').padEnd(widths[index]!))
+        .map((cell, index) => cell.padEnd(widths[index]!))
         .join('  ');
       console.log(formattedRow);
     }
@@ -101,26 +126,26 @@ export class OutputService implements IOutputService {
 
   public success(message: string): void {
     const symbol = this.format('✓', chalk.green);
-    console.log(`${symbol} ${message}`);
+    console.log(`${symbol} ${stripControl(message)}`);
   }
 
   public error(message: string): void {
     const symbol = this.format('✗', chalk.red);
-    console.error(`${symbol} ${message}`);
+    console.error(`${symbol} ${stripControl(message)}`);
   }
 
   public warning(message: string): void {
     const symbol = this.format('⚠', chalk.yellow);
-    console.warn(`${symbol} ${message}`);
+    console.warn(`${symbol} ${stripControl(message)}`);
   }
 
   public info(message: string): void {
     const symbol = this.format('ℹ', chalk.blue);
-    console.log(`${symbol} ${message}`);
+    console.log(`${symbol} ${stripControl(message)}`);
   }
 
   public text(message: string): void {
-    console.log(message);
+    console.log(stripControl(message));
   }
 
   public formatDate(date: string | Date): string {

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -532,6 +532,134 @@ describe('OutputService', () => {
     });
   });
 
+  describe('control character sanitization', () => {
+    // Untrusted strings (PR titles, descriptions, branch names, snippet
+    // names, repo descriptions) flow into `text/info/success/warning/error`
+    // and `table()` cells. Without sanitization an attacker can inject:
+    //   * OSC-8 hyperlinks (\x1b]8;;<url>\x1b\\Click\x1b]8;;\x1b\\)
+    //   * Terminal title rewrites (\x1b]0;evil\x07)
+    //   * Cursor / screen manipulation (\x1b[2J\x1b[H)
+    //   * Older OSC fontsetting sequences with a CVE history
+    // This block locks in the strip behavior for every text output method
+    // and the table renderer.
+    it.each([
+      ['text', 'log'],
+      ['info', 'log'],
+      ['success', 'log'],
+      ['warning', 'warn'],
+      ['error', 'error'],
+    ] as const)(
+      '%s strips ESC, OSC and cursor-manipulation sequences',
+      (method, channel) => {
+        const payloads = [
+          '\x1b[2Jevil',
+          '\x1b]0;Untrusted Title\x07suffix',
+          '\x1b]8;;https://evil.example.com\x1b\\Click here\x1b]8;;\x1b\\',
+          'before\x07after',
+          'tab\x08bs',
+        ];
+
+        for (const payload of payloads) {
+          consoleLogs.length = 0;
+          consoleErrors.length = 0;
+          consoleWarns.length = 0;
+
+          (output as unknown as Record<string, (m: string) => void>)[method](
+            payload
+          );
+
+          const sink =
+            channel === 'log'
+              ? consoleLogs
+              : channel === 'warn'
+                ? consoleWarns
+                : consoleErrors;
+          const printed = sink.join('');
+          // No raw ESC byte should survive sanitization.
+          expect(printed).not.toContain('\x1b');
+          // BEL and BS should also be stripped.
+          expect(printed).not.toContain('\x07');
+          expect(printed).not.toContain('\x08');
+        }
+      }
+    );
+
+    it('table() strips control chars from headers and cells', () => {
+      output.table(
+        ['NA\x1b]0;evil\x07ME', 'VAL\x1b[2JUE'],
+        [
+          ['\x1b]8;;https://evil\x1b\\foo\x1b]8;;\x1b\\', 'b\x07ar'],
+          ['baz', '\x1b[31Jqux'],
+        ]
+      );
+
+      const printed = consoleLogs.join('\n');
+      expect(printed).not.toContain('\x1b');
+      expect(printed).not.toContain('\x07');
+      // Visible characters survive stripping.
+      expect(printed).toContain('NAME');
+      expect(printed).toContain('VALUE');
+      expect(printed).toContain('foo');
+      expect(printed).toContain('bar');
+      expect(printed).toContain('baz');
+      expect(printed).toContain('qux');
+    });
+
+    it('table() column widths are computed from sanitized cell lengths', () => {
+      // If we used raw lengths, the OSC sequence would inflate the width and
+      // the visible alignment would break.
+      output.table(
+        ['A', 'B'],
+        [['\x1b]8;;https://evil\x1b\\x\x1b]8;;\x1b\\', 'y']]
+      );
+
+      const printed = consoleLogs.join('\n');
+      expect(printed).not.toContain('\x1b');
+      // Width should match 'x' (1 char), not the raw escape-laden string.
+      const dataRow = consoleLogs[2];
+      expect(dataRow).toMatch(/^x\s+y\s*$/);
+    });
+
+    it('preserves chalk SGR codes embedded by callers', () => {
+      // Callers commonly compose colored strings before handing them to
+      // text() — e.g. `output.text(`${output.bold('#42')} ${pr.title}`)`.
+      // Stripping must not destroy the SGR codes chalk produced.
+      const originalLevel = chalk.level;
+      chalk.level = 3;
+      try {
+        const colored = chalk.bold('#42');
+        const composed = `${colored} normal`;
+        output.text(composed);
+
+        expect(consoleLogs[0]).toContain('\x1b[1m');
+        expect(consoleLogs[0]).toContain('#42');
+        expect(consoleLogs[0]).toContain('normal');
+      } finally {
+        chalk.level = originalLevel;
+      }
+    });
+
+    it('strips dangerous CSI codes mixed with chalk SGR', () => {
+      // Attacker could try to splice cursor manipulation between chalk
+      // sequences. SGR survives, the rest gets stripped.
+      const originalLevel = chalk.level;
+      chalk.level = 3;
+      try {
+        const composed = `${chalk.red('safe')}\x1b[2Jevil`;
+        output.text(composed);
+
+        const printed = consoleLogs[0]!;
+        expect(printed).toContain('\x1b[31m'); // chalk red foreground
+        expect(printed).toContain('safe');
+        expect(printed).toContain('evil');
+        // Screen-clear sequence is gone.
+        expect(printed).not.toContain('\x1b[2J');
+      } finally {
+        chalk.level = originalLevel;
+      }
+    });
+  });
+
   describe('formatDate edge cases', () => {
     it('should produce a stable formatted string for a fixed date', () => {
       const result = output.formatDate('2024-06-15T10:30:00Z');


### PR DESCRIPTION
## Summary

- Closes #194 (security: ANSI / control character sanitization).
- Strip OSC, dangerous CSI, and C0/C1 control characters from text routed through `OutputService.text/info/success/warning/error` and table cells, so attacker-controlled API data (PR titles, descriptions, branch names, snippet file names, repo descriptions) can no longer:
  - inject OSC-8 clickable hyperlinks,
  - rewrite the terminal title (OSC-0),
  - clear the screen / move the cursor (`\x1b[2J`, `\x1b[H`, etc.),
  - smuggle other C0/C1 control bytes.
- Chalk-generated SGR codes composed by command call sites (e.g. `output.text(\`${output.bold('#42')} ${pr.title}\`)`) continue to render — the regex captures SGR (CSI ending in `m`) and preserves it via the replacement function.
- JSON output is intentionally unchanged: `JSON.stringify` already escapes control characters, and machine-readable consumers should see the raw bytes.

## Implementation notes

- Single helper `stripControl()` lives next to the `OutputService` class so all output methods share it.
- The regex puts the SGR-preserve alternative first, the dangerous CSI/OSC alternatives next, and the standalone C0/C1 char-class last — order matters because regex alternation is leftmost-match: this prevents the lone-`\x1b` class from eating the leading byte of a chalk sequence.
- `table()` sanitizes headers and cells *before* width calculation so OSC sequences can't inflate column widths and break alignment.

## Test plan

- [x] `bun test tests/services/output.service.test.ts` — new `control character sanitization` block covers each output method, table headers/cells, table width recomputation after sanitization, chalk SGR preservation, and dangerous CSI mixed with chalk SGR. All 67 tests pass.
- [x] `bun test` — full suite: 846 pass, 0 fail.
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean (runs on pre-commit hook).