### PR TITLE
security: harden OAuth callback server and surface revoke failures

### DIFF
--- a/.changeset/harden-oauth-callback.md
+++ b/.changeset/harden-oauth-callback.md
@@ -1,0 +1,14 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+security: harden OAuth callback flow
+
+- Bind the local OAuth callback server to `127.0.0.1` instead of all
+  interfaces so the auth window is not reachable from the LAN.
+- Bump the OAuth `state` parameter from 128 to 256 bits.
+- Add a 10s timeout to every `fetch()` in the OAuth flow (token exchange,
+  refresh, revoke, user-info) so a hung Bitbucket endpoint cannot stall
+  the CLI indefinitely.
+- Surface token-revocation failures on logout as a warning instead of
+  silently dropping them; local credentials are still cleared.

--- a/src/commands/auth/logout.command.ts
+++ b/src/commands/auth/logout.command.ts
@@ -25,18 +25,32 @@ export class LogoutCommand extends BaseCommand<void, void> {
   public async execute(_options: void, context: CommandContext): Promise<void> {
     const authMethod = await this.credentialStore.getAuthMethod();
 
+    let revokeFailed = false;
     if (authMethod === 'oauth') {
-      await this.oauthService.revokeToken();
+      try {
+        await this.oauthService.revokeToken();
+      } catch {
+        revokeFailed = true;
+      }
       await this.credentialStore.clearOAuthCredentials();
     } else {
       await this.credentialStore.clearCredentials();
     }
 
     if (context.globalOptions.json) {
-      await this.output.json({ authenticated: false, success: true });
+      await this.output.json({
+        authenticated: false,
+        success: true,
+        revokeFailed: revokeFailed || undefined,
+      });
       return;
     }
 
+    if (revokeFailed) {
+      this.output.warning(
+        'Token revocation failed; the access token may still be valid at Bitbucket. Consider revoking it manually.'
+      );
+    }
     this.output.success('Logged out of Bitbucket');
   }
 }

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -13,10 +13,12 @@ import { BBError, ErrorCode } from '../types/errors.js';
 const BITBUCKET_AUTHORIZE_URL = 'https://bitbucket.org/site/oauth2/authorize';
 const BITBUCKET_TOKEN_URL = 'https://bitbucket.org/site/oauth2/access_token';
 
+const CALLBACK_HOST = '127.0.0.1';
 const CALLBACK_PORT = 19872;
 const CALLBACK_PATH = '/callback';
 const CALLBACK_URL = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const FETCH_TIMEOUT_MS = 10_000;
 
 // Default OAuth consumer credentials for the CLI. These ship with every copy
 // of the binary and are NOT secret — this is the standard pattern for public
@@ -45,7 +47,7 @@ interface TokenResponse {
 }
 
 function generateState(): string {
-  return randomBytes(16).toString('hex');
+  return randomBytes(32).toString('hex');
 }
 
 export class OAuthService {
@@ -121,6 +123,7 @@ export class OAuthService {
         Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -145,28 +148,36 @@ export class OAuthService {
   }
 
   /**
-   * Revoke the current OAuth token
+   * Revoke the current OAuth token. Throws on failure so callers can surface
+   * the issue to the user — a still-valid token at Bitbucket is a security
+   * concern that should not be silently dropped.
    */
   public async revokeToken(): Promise<void> {
-    try {
-      const credentials = await this.credentialStore.getOAuthCredentials();
-      const clientId = await this.getClientId();
+    const credentials = await this.credentialStore.getOAuthCredentials();
+    const clientId = await this.getClientId();
 
-      const clientSecret = await this.getClientSecret();
-      const params = new URLSearchParams({
-        token: credentials.accessToken,
-      });
+    const clientSecret = await this.getClientSecret();
+    const params = new URLSearchParams({
+      token: credentials.accessToken,
+    });
 
-      await fetch('https://bitbucket.org/site/oauth2/revoke', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
-        },
-        body: params.toString(),
+    const response = await fetch('https://bitbucket.org/site/oauth2/revoke', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      },
+      body: params.toString(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '');
+      throw new BBError({
+        code: ErrorCode.NETWORK_ERROR,
+        message: `Failed to revoke OAuth token (HTTP ${response.status}).`,
+        context: { status: response.status, body: errorBody },
       });
-    } catch {
-      // Best-effort revocation — don't fail logout if this errors
     }
   }
 
@@ -295,7 +306,7 @@ export class OAuthService {
         }
       });
 
-      server.listen(CALLBACK_PORT, async () => {
+      server.listen(CALLBACK_PORT, CALLBACK_HOST, async () => {
         // Open browser
         try {
           const open = (await import('open')).default;
@@ -327,6 +338,7 @@ export class OAuthService {
         Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -346,6 +358,7 @@ export class OAuthService {
   ): Promise<{ username: string; displayName: string; accountId: string }> {
     const response = await fetch('https://api.bitbucket.org/2.0/user', {
       headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/tests/services/oauth.service.test.ts
+++ b/tests/services/oauth.service.test.ts
@@ -352,7 +352,7 @@ describe('OAuthService', () => {
       expect(body).toContain('token=token-to-revoke');
     });
 
-    it('should not throw when revocation fails', async () => {
+    it('should throw when revocation returns non-ok status', async () => {
       const configService = createMockConfigService({
         authMethod: 'oauth',
         oauthAccessToken: 'token',
@@ -361,21 +361,24 @@ describe('OAuthService', () => {
       });
       const service = new OAuthService(configService, configService);
 
-      mockFetch([{ ok: false, status: 500 }]);
+      mockFetch([{ ok: false, status: 500, text: async () => 'oops' }]);
 
-      // Should not throw
-      await service.revokeToken();
+      const result = await outcome(service.revokeToken());
+      expect(result.error).toBeDefined();
+      const err = result.error as { code: number; message: string };
+      expect(err.code).toBe(ErrorCode.NETWORK_ERROR);
+      expect(err.message).toContain('500');
     });
 
-    it('should not throw when no credentials exist', async () => {
+    it('should throw when no credentials exist', async () => {
       const configService = createMockConfigService({});
       const service = new OAuthService(configService, configService);
 
-      // getOAuthCredentials will throw, but revokeToken catches it
-      await service.revokeToken();
+      const result = await outcome(service.revokeToken());
+      expect(result.error).toBeDefined();
     });
 
-    it('should swallow fetch network errors', async () => {
+    it('should propagate fetch network errors', async () => {
       const configService = createMockConfigService({
         authMethod: 'oauth',
         oauthAccessToken: 'token',
@@ -388,7 +391,9 @@ describe('OAuthService', () => {
         throw new Error('network down');
       }) as typeof fetch;
 
-      await service.revokeToken();
+      const result = await outcome(service.revokeToken());
+      expect(result.error).toBeDefined();
+      expect((result.error as Error).message).toContain('network down');
     });
   });
 
@@ -448,6 +453,8 @@ describe('OAuthService', () => {
       expect(authUrl).toContain('scope=');
 
       const state = extractState(authUrl);
+      // OAuth state must be at least 256 bits (64 hex chars).
+      expect(state).toMatch(/^[0-9a-f]{64}$/);
 
       const callbackResponse = await originalFetch(
         `${CALLBACK_URL}?code=the-code&state=${state}`
@@ -702,7 +709,9 @@ describe('OAuthService', () => {
 
       await new Promise<void>((resolve, reject) => {
         blocker.once('error', reject);
-        blocker.listen(CALLBACK_PORT, () => resolve());
+        // Match the loopback bind the OAuth service now uses; binding to a
+        // different interface would leave the port available on 127.0.0.1.
+        blocker.listen(CALLBACK_PORT, '127.0.0.1', () => resolve());
       });
 
       try {


### PR DESCRIPTION
## Summary

Closes #192

Addresses the four security findings in `src/services/oauth.service.ts`:

- **Loopback bind** — `server.listen(CALLBACK_PORT, '127.0.0.1', cb)`. Previously the 2nd arg was the listening callback, so Node bound `::` (dual-stacked to `0.0.0.0`), exposing the 5-minute auth window to the LAN.
- **256-bit state** — `randomBytes(32)` instead of `randomBytes(16)`, matching OAuth native-app guidance.
- **Fetch timeouts** — every `fetch()` (token exchange, refresh, revoke, user-info) now carries `signal: AbortSignal.timeout(10_000)` so a hung Bitbucket endpoint cannot stall the CLI indefinitely.
- **Surface revoke failures** — `revokeToken()` now throws on failure. `logout.command.ts` catches it and emits `output.warning(...)` so the user knows the token may still be valid at Bitbucket, while still clearing local state.

## Test plan

- [x] `bun test tests/services/oauth.service.test.ts` — 24/24 pass (added a 64-hex-char state assertion and updated the three revokeToken tests that previously asserted the swallow-all behavior; the port-in-use test now binds its blocker to `127.0.0.1` to match the new bind).
- [x] `bun test` — 837/837 pass.
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean.
- [x] Manual: `curl http://<lan-ip>:19872/callback` from another host during `bb auth login` is refused (acceptance criterion from the issue).