### PR TITLE
fix(security): harden config-file integrity

### DIFF
--- a/.changeset/harden-config-file-integrity.md
+++ b/.changeset/harden-config-file-integrity.md
@@ -1,0 +1,16 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+security: harden config-file integrity
+
+- Write the config via a unique tmp file with `O_EXCL` (`flag: 'wx'`) and an
+  atomic `rename`, so a hostile pre-existing symlink at `config.json` is no
+  longer silently followed and a crash mid-write cannot leave a partially
+  written config behind.
+- On read, refuse to open `config.json` (or its containing directory) with
+  group/world-accessible permissions — the co-tenant scenario where another
+  user pre-creates the file with `0o644` before the first login is now
+  surfaced as a clear error with the exact `chmod` command to fix it.
+- Create the config directory with mode `0o700` and the config file with
+  mode `0o600`.

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -4,6 +4,7 @@
 
 import { posix, win32 } from 'node:path';
 import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 import type {
   IConfigService,
   ICredentialStore,
@@ -22,15 +23,23 @@ interface ConfigServicePathOptions {
   homeDir?: string;
 }
 
+const CONFIG_FILE_MODE = 0o600;
+const CONFIG_DIR_MODE = 0o700;
+// Bits that must NOT be set on the config file or directory; any group/other
+// access is treated as a hostile pre-existing path on a shared host.
+const INSECURE_MODE_MASK = 0o077;
+
 export class ConfigService implements IConfigService, ICredentialStore {
   private readonly configDir: string;
   private readonly configFile: string;
+  private readonly platform: NodeJS.Platform;
   private configCache: BBConfig | null = null;
 
   constructor(configDir?: string, options: ConfigServicePathOptions = {}) {
     const platform = options.platform ?? process.platform;
     const joinPath = platform === 'win32' ? win32.join : posix.join;
 
+    this.platform = platform;
     this.configDir =
       configDir ?? this.resolveDefaultConfigDir({ ...options, platform });
     this.configFile = joinPath(this.configDir, 'config.json');
@@ -61,12 +70,47 @@ export class ConfigService implements IConfigService, ICredentialStore {
   private async ensureConfigDir(): Promise<void> {
     try {
       const fs = await import('node:fs/promises');
-      await fs.mkdir(this.configDir, { recursive: true });
+      await fs.mkdir(this.configDir, {
+        recursive: true,
+        mode: CONFIG_DIR_MODE,
+      });
     } catch (error) {
       throw new BBError({
         code: ErrorCode.CONFIG_WRITE_FAILED,
         message: `Failed to create config directory: ${this.configDir}`,
         cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
+  // POSIX permission bits are meaningless on Windows; skip the check there to
+  // avoid spurious failures while still hardening the Linux/macOS hosts the
+  // co-tenant scenario actually targets.
+  private async verifyPermissions(
+    path: string,
+    expectedMode: number,
+    kind: 'file' | 'directory'
+  ): Promise<void> {
+    if (this.platform === 'win32') return;
+
+    const fs = await import('node:fs/promises');
+    let stats;
+    try {
+      stats = await fs.stat(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    }
+
+    const mode = stats.mode & 0o777;
+    if (mode & INSECURE_MODE_MASK) {
+      const actual = mode.toString(8).padStart(3, '0');
+      const expected = expectedMode.toString(8).padStart(3, '0');
+      throw new BBError({
+        code: ErrorCode.CONFIG_READ_FAILED,
+        message:
+          `Config ${kind} has insecure permissions (${actual}); ` +
+          `expected ${expected}. Run: chmod ${expected} ${path}`,
       });
     }
   }
@@ -78,6 +122,13 @@ export class ConfigService implements IConfigService, ICredentialStore {
 
     try {
       const fs = await import('node:fs/promises');
+      await this.verifyPermissions(
+        this.configDir,
+        CONFIG_DIR_MODE,
+        'directory'
+      );
+      await this.verifyPermissions(this.configFile, CONFIG_FILE_MODE, 'file');
+
       const data = await fs.readFile(this.configFile, 'utf-8');
       this.configCache = JSON.parse(data) as BBConfig;
       return this.configCache;
@@ -86,6 +137,11 @@ export class ConfigService implements IConfigService, ICredentialStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         this.configCache = {};
         return this.configCache;
+      }
+
+      // Permission errors already carry a precise message; don't wrap them.
+      if (error instanceof BBError) {
+        throw error;
       }
 
       throw new BBError({
@@ -99,13 +155,30 @@ export class ConfigService implements IConfigService, ICredentialStore {
   public async setConfig(config: BBConfig): Promise<void> {
     await this.ensureConfigDir();
 
+    const fs = await import('node:fs/promises');
+    const body = JSON.stringify(config, null, 2);
+    // Unique suffix avoids EEXIST against a stale tmp from a prior crash while
+    // still letting `flag: 'wx'` (O_EXCL) refuse to follow a hostile symlink
+    // an attacker may have planted at this exact path.
+    const tmpFile = `${this.configFile}.${randomUUID()}.tmp`;
+
     try {
-      const fs = await import('node:fs/promises');
-      await fs.writeFile(this.configFile, JSON.stringify(config, null, 2), {
-        mode: 0o600, // Secure permissions
+      await fs.writeFile(tmpFile, body, {
+        mode: CONFIG_FILE_MODE,
+        flag: 'wx',
       });
+      // rename() is atomic on the same filesystem, so a crash mid-write cannot
+      // leave a partially-written config behind. It also replaces a symlink
+      // sitting at configFile with the real file, rather than following it.
+      await fs.rename(tmpFile, this.configFile);
       this.configCache = config;
     } catch (error) {
+      try {
+        await fs.unlink(tmpFile);
+      } catch {
+        // Best-effort cleanup; surface the original write error below.
+      }
+
       throw new BBError({
         code: ErrorCode.CONFIG_WRITE_FAILED,
         message: `Failed to write config file: ${this.configFile}`,

--- a/tests/services/config.service.test.ts
+++ b/tests/services/config.service.test.ts
@@ -9,7 +9,15 @@ import type {
   ICredentialStore,
 } from '../../src/core/interfaces/services.js';
 import { ErrorCode } from '../../src/types/errors.js';
-import { mkdir, rm, readFile, writeFile } from 'fs/promises';
+import {
+  mkdir,
+  rm,
+  readFile,
+  writeFile,
+  stat,
+  symlink,
+  chmod,
+} from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -37,10 +45,11 @@ describe('ConfigService', () => {
     });
 
     it('should return config from file', async () => {
-      await mkdir(testConfigDir, { recursive: true });
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
       await writeFile(
         join(testConfigDir, 'config.json'),
-        JSON.stringify({ username: 'testuser', defaultWorkspace: 'workspace' })
+        JSON.stringify({ username: 'testuser', defaultWorkspace: 'workspace' }),
+        { mode: 0o600 }
       );
 
       configService.clearCache();
@@ -51,10 +60,11 @@ describe('ConfigService', () => {
     });
 
     it('should cache config after first read', async () => {
-      await mkdir(testConfigDir, { recursive: true });
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
       await writeFile(
         join(testConfigDir, 'config.json'),
-        JSON.stringify({ username: 'original' })
+        JSON.stringify({ username: 'original' }),
+        { mode: 0o600 }
       );
 
       // First read
@@ -63,7 +73,8 @@ describe('ConfigService', () => {
       // Modify file directly
       await writeFile(
         join(testConfigDir, 'config.json'),
-        JSON.stringify({ username: 'modified' })
+        JSON.stringify({ username: 'modified' }),
+        { mode: 0o600 }
       );
 
       // Second read should return cached value
@@ -73,13 +84,47 @@ describe('ConfigService', () => {
     });
 
     it('should throw error for invalid JSON', async () => {
-      await mkdir(testConfigDir, { recursive: true });
-      await writeFile(join(testConfigDir, 'config.json'), 'invalid json {');
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
+      await writeFile(join(testConfigDir, 'config.json'), 'invalid json {', {
+        mode: 0o600,
+      });
 
       configService.clearCache();
 
       await expect(configService.getConfig()).rejects.toMatchObject({
         code: ErrorCode.CONFIG_READ_FAILED,
+      });
+    });
+
+    it('should refuse to read a config file with world/group-readable permissions', async () => {
+      if (process.platform === 'win32') return;
+
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
+      const file = join(testConfigDir, 'config.json');
+      await writeFile(file, JSON.stringify({ username: 'u' }), { mode: 0o600 });
+      await chmod(file, 0o644);
+
+      configService.clearCache();
+
+      await expect(configService.getConfig()).rejects.toMatchObject({
+        code: ErrorCode.CONFIG_READ_FAILED,
+        message: expect.stringContaining('insecure permissions'),
+      });
+    });
+
+    it('should refuse to read when the config directory is world-traversable', async () => {
+      if (process.platform === 'win32') return;
+
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
+      const file = join(testConfigDir, 'config.json');
+      await writeFile(file, JSON.stringify({ username: 'u' }), { mode: 0o600 });
+      await chmod(testConfigDir, 0o755);
+
+      configService.clearCache();
+
+      await expect(configService.getConfig()).rejects.toMatchObject({
+        code: ErrorCode.CONFIG_READ_FAILED,
+        message: expect.stringContaining('insecure permissions'),
       });
     });
   });
@@ -566,7 +611,8 @@ describe('ConfigService', () => {
       // Modify file directly
       await writeFile(
         join(testConfigDir, 'config.json'),
-        JSON.stringify({ username: 'modified' })
+        JSON.stringify({ username: 'modified' }),
+        { mode: 0o600 }
       );
 
       // Still cached
@@ -579,6 +625,63 @@ describe('ConfigService', () => {
       // Now reads from file
       config = await configService.getConfig();
       expect(config.username).toBe('modified');
+    });
+  });
+
+  describe('setConfig (security hardening)', () => {
+    it('should write the config file with mode 0600', async () => {
+      if (process.platform === 'win32') return;
+
+      await configService.setConfig({ username: 'u', apiToken: 't' });
+
+      const stats = await stat(join(testConfigDir, 'config.json'));
+      expect(stats.mode & 0o777).toBe(0o600);
+    });
+
+    it('should create the config directory with mode 0700', async () => {
+      if (process.platform === 'win32') return;
+
+      await configService.setConfig({ username: 'u' });
+
+      const stats = await stat(testConfigDir);
+      expect(stats.mode & 0o777).toBe(0o700);
+    });
+
+    it('should not follow a hostile symlink planted at config.json', async () => {
+      if (process.platform === 'win32') return;
+
+      await mkdir(testConfigDir, { recursive: true, mode: 0o700 });
+      const decoyDir = join(tmpdir(), `bb-test-decoy-${Date.now()}`);
+      await mkdir(decoyDir, { recursive: true, mode: 0o700 });
+      const decoyTarget = join(decoyDir, 'attacker-target');
+      await writeFile(decoyTarget, 'untouched', { mode: 0o600 });
+
+      try {
+        await symlink(decoyTarget, join(testConfigDir, 'config.json'));
+
+        // setConfig writes to a tmp file under configDir and renames it over
+        // the symlink. The rename replaces the link itself, so the attacker's
+        // target file must remain untouched.
+        await configService.setConfig({ username: 'u', apiToken: 't' });
+
+        const decoyContent = await readFile(decoyTarget, 'utf-8');
+        expect(decoyContent).toBe('untouched');
+
+        const finalStat = await stat(join(testConfigDir, 'config.json'));
+        expect(finalStat.isSymbolicLink()).toBe(false);
+        expect(finalStat.mode & 0o777).toBe(0o600);
+      } finally {
+        await rm(decoyDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should not leave a tmp file behind on success', async () => {
+      await configService.setConfig({ username: 'u' });
+
+      const fs = await import('node:fs/promises');
+      const entries = await fs.readdir(testConfigDir);
+      const tmpFiles = entries.filter((name) => name.endsWith('.tmp'));
+      expect(tmpFiles).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #196.

- **Atomic, symlink-safe write**: `setConfig` now writes to a unique tmp file with `O_EXCL` (`flag: 'wx'`) and atomically `rename`s it over `config.json`. A hostile symlink planted at `config.json` is no longer followed (its target is left untouched), and a crash between truncate and write can no longer leave a partially-written config behind.
- **Permission verification on read**: `getConfig` now `stat`s the directory and the file before reading. If either has any group/world bits set (`mode & 0o077 !== 0`), the read fails with a clear `CONFIG_READ_FAILED` message and the exact `chmod` command. This blocks the co-tenant scenario where another user pre-creates `~/.config/bb/config.json` with `0o644` before the first login.
- **Stricter creation modes**: the config directory is now created with `0o700` and the file with `0o600`. The check is skipped on Windows where POSIX mode bits don't apply.

## Test plan

- [x] `bun test` — 863 tests pass (54 in `config.service.test.ts`, including new cases for hostile-symlink rejection, dir/file mode enforcement, refusal on `0o644`/`0o755`, and tmp cleanup).
- [x] `bun run lint` (tsc --noEmit) — clean.
- [x] `bun run format:check` — clean.