### PR TITLE
feat(errors): add distinguishable error codes

### DIFF
--- a/.changeset/distinguishable-error-codes.md
+++ b/.changeset/distinguishable-error-codes.md
@@ -1,0 +1,24 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+feat(errors): add distinguishable error codes for file-not-found and shell completion failures
+
+Adds three new error codes so JSON-output-driven scripts can branch on the
+specific failure mode instead of treating everything as `VALIDATION_INVALID`
+(5002) or `UNKNOWN` (9999):
+
+- `FILE_NOT_FOUND` (5003) — used by `bb snippet create/edit --file`,
+  `bb snippet view --file`, and `bb pr edit --body-file` when a referenced
+  file does not exist on disk or in the snippet
+- `COMPLETION_INSTALL_FAILED` (9001) — `bb completion install` failures
+- `COMPLETION_UNINSTALL_FAILED` (9002) — `bb completion uninstall` failures
+
+`APIError` now also populates `context` with the failed request method,
+URL and HTTP status, giving scripts structured fields to key on for 404s
+and other API errors.
+
+The error-code reference docs are updated with the new codes and clarify
+the boundary between `AUTH_INVALID` (1002 — credentials rejected at
+request time) and `AUTH_EXPIRED` (1003 — OAuth token expired *and* its
+refresh failed).

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -19,6 +19,7 @@ When commands fail, the CLI returns structured errors with specific error codes.
 | 6xxx | Context | Repository/workspace detection issues |
 | 7xxx | Network | Transport/network failures before API response |
 | 8xxx | Output formatting | `--json fields` and `--jq` evaluation issues |
+| 9xxx | Shell completion / Unknown | Completion install/uninstall failures and uncategorized errors |
 
 ---
 
@@ -39,7 +40,7 @@ bb auth login
 
 **Message:** Invalid credentials
 
-**Cause:** Your username or API token is incorrect.
+**Cause:** Your credentials were rejected by Bitbucket at request time. This is the code emitted for any 401 response that was *not* recovered by an OAuth refresh — e.g. a wrong API token, a revoked password, or basic-auth requests with bad credentials.
 
 **Solution:**
 1. Verify your Bitbucket username
@@ -52,13 +53,13 @@ bb auth login
 
 ### 1003 - AUTH_EXPIRED
 
-**Message:** Token expired
+**Message:** OAuth token expired. Run `bb auth login` to re-authenticate.
 
-**Cause:** Your API token has expired or been revoked.
+**Cause:** Specifically: an OAuth access token expired *and* the reactive refresh attempt also failed (refresh token revoked or expired). For non-OAuth flows, a stale token surfaces as `AUTH_INVALID` (1002) instead.
 
 **Solution:**
-1. Create a new API token in Bitbucket settings
-2. Re-authenticate with the new token
+1. Re-run `bb auth login` to perform a fresh OAuth flow
+2. If that also fails, create a new API token in Bitbucket settings and switch auth methods
 
 ---
 
@@ -241,6 +242,18 @@ Common required fields:
   - PR ID must be a number
   - State must be one of: OPEN, MERGED, DECLINED, SUPERSEDED
 
+### 5003 - FILE_NOT_FOUND
+
+**Message:** File not found: `<path>`
+
+**Cause:** A file referenced by an option (e.g. `--file` for `bb snippet create`/`edit`, `--body-file` for `bb pr edit`) doesn't exist on disk, or a named file isn't present inside a snippet.
+
+**Solution:**
+- Verify the path is correct relative to the current working directory
+- For `bb snippet view --file <name>`, list snippet files first to confirm the name
+
+The `context` field on this error includes the missing path under `file` (or `bodyFile`), which scripts can key on to differentiate it from a generic `VALIDATION_INVALID`.
+
 ---
 
 ## Context Errors (6xxx)
@@ -321,6 +334,31 @@ bb pr list --json | jq '<expression>'
 
 **Solution:**
 - `--jq` requires `--json`. Add `--json` (with or without a field list).
+
+---
+
+## Shell Completion Errors (9xxx)
+
+### 9001 - COMPLETION_INSTALL_FAILED
+
+**Message:** Failed to install completions: `<reason>`
+
+**Cause:** `bb completion install` couldn't write the shell completion hooks — typically because the target shell profile isn't writable, or the underlying `tabtab` install failed.
+
+**Solution:**
+- Check write permissions on your shell rc file (e.g. `~/.zshrc`, `~/.bashrc`)
+- Re-run with `DEBUG=true bb completion install` for the underlying error
+- If the issue persists, install completions manually by following your shell's documentation for `tabtab`
+
+### 9002 - COMPLETION_UNINSTALL_FAILED
+
+**Message:** Failed to uninstall completions: `<reason>`
+
+**Cause:** `bb completion uninstall` couldn't remove the completion hooks — usually because the rc file isn't writable or the entry was already removed manually.
+
+**Solution:**
+- Check write permissions on your shell rc file
+- Manually remove the `tabtab` block from your shell rc file if needed
 
 ---
 

--- a/src/commands/completion/install.command.ts
+++ b/src/commands/completion/install.command.ts
@@ -40,7 +40,7 @@ export class InstallCompletionCommand extends BaseCommand<void, void> {
       );
     } catch (error) {
       throw new BBError({
-        code: ErrorCode.UNKNOWN,
+        code: ErrorCode.COMPLETION_INSTALL_FAILED,
         message: `Failed to install completions: ${error}`,
         cause: error instanceof Error ? error : undefined,
       });

--- a/src/commands/completion/uninstall.command.ts
+++ b/src/commands/completion/uninstall.command.ts
@@ -36,7 +36,7 @@ export class UninstallCompletionCommand extends BaseCommand<void, void> {
       this.output.success('Shell completions uninstalled successfully!');
     } catch (error) {
       throw new BBError({
-        code: ErrorCode.UNKNOWN,
+        code: ErrorCode.COMPLETION_UNINSTALL_FAILED,
         message: `Failed to uninstall completions: ${error}`,
         cause: error instanceof Error ? error : undefined,
       });

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -93,8 +93,11 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
       try {
         body = fs.readFileSync(options.bodyFile, 'utf-8');
       } catch (err) {
+        const isNotFound =
+          err instanceof Error &&
+          (err as NodeJS.ErrnoException).code === 'ENOENT';
         throw new BBError({
-          code: ErrorCode.UNKNOWN,
+          code: isNotFound ? ErrorCode.FILE_NOT_FOUND : ErrorCode.UNKNOWN,
           message: `Failed to read file '${options.bodyFile}': ${err instanceof Error ? err.message : 'Unknown error'}`,
           cause: err instanceof Error ? err : undefined,
           context: { bodyFile: options.bodyFile },

--- a/src/commands/snippet/create.command.ts
+++ b/src/commands/snippet/create.command.ts
@@ -71,7 +71,7 @@ export class CreateSnippetCommand extends BaseCommand<
     for (const filePath of options.file) {
       if (!fs.existsSync(filePath)) {
         throw new BBError({
-          code: ErrorCode.VALIDATION_INVALID,
+          code: ErrorCode.FILE_NOT_FOUND,
           message: `File not found: ${filePath}`,
           context: { file: filePath },
         });

--- a/src/commands/snippet/edit.command.ts
+++ b/src/commands/snippet/edit.command.ts
@@ -72,7 +72,7 @@ export class EditSnippetCommand extends BaseCommand<
       for (const filePath of options.file!) {
         if (!fs.existsSync(filePath)) {
           throw new BBError({
-            code: ErrorCode.VALIDATION_INVALID,
+            code: ErrorCode.FILE_NOT_FOUND,
             message: `File not found: ${filePath}`,
             context: { file: filePath },
           });

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -59,7 +59,7 @@ export class ViewSnippetCommand extends BaseCommand<
     if (options.file !== undefined) {
       if (!fileNames.includes(options.file)) {
         throw new BBError({
-          code: ErrorCode.VALIDATION_INVALID,
+          code: ErrorCode.FILE_NOT_FOUND,
           message: `File not found in snippet: ${options.file}`,
           context: { file: options.file, available: fileNames },
         });

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -201,7 +201,13 @@ export function createApiClient(
       if (error.response) {
         const { status, data } = error.response;
         const message = extractErrorMessage(data) || error.message;
-        throw new APIError(message, status, data);
+        const method = error.config?.method?.toUpperCase();
+        const url = error.config?.url;
+        throw new APIError(message, status, data, {
+          status,
+          ...(method ? { method } : {}),
+          ...(url ? { url } : {}),
+        });
       } else if (error.request) {
         throw new BBError({
           code: ErrorCode.NETWORK_ERROR,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -28,6 +28,7 @@ export enum ErrorCode {
   // Validation errors (5xxx)
   VALIDATION_REQUIRED = 5001,
   VALIDATION_INVALID = 5002,
+  FILE_NOT_FOUND = 5003,
 
   // Context errors (6xxx)
   CONTEXT_REPO_NOT_FOUND = 6001,
@@ -39,6 +40,10 @@ export enum ErrorCode {
   // Output formatting errors (8xxx)
   JQ_FAILED = 8001,
   JSON_FORMAT_INVALID = 8002,
+
+  // Completion errors (9xxx, before UNKNOWN)
+  COMPLETION_INSTALL_FAILED = 9001,
+  COMPLETION_UNINSTALL_FAILED = 9002,
 
   // Unknown
   UNKNOWN = 9999,

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -7,6 +7,7 @@ import { InstallCompletionCommand } from '../../src/commands/completion/install.
 import { UninstallCompletionCommand } from '../../src/commands/completion/uninstall.command.js';
 import { createMockOutputService } from '../setup.js';
 import type { CommandContext } from '../../src/core/interfaces/commands.js';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
 
 describe('Completion Commands', () => {
   let output: ReturnType<typeof createMockOutputService>;
@@ -108,7 +109,15 @@ describe('Completion Commands', () => {
       const command = new InstallCompletionCommand(output);
       const context: CommandContext = { globalOptions: {} };
 
-      await expect(command.execute(undefined, context)).rejects.toBeDefined();
+      try {
+        await command.execute(undefined, context);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(BBError);
+        expect((error as BBError).code).toBe(
+          ErrorCode.COMPLETION_INSTALL_FAILED
+        );
+      }
     });
   });
 
@@ -185,7 +194,15 @@ describe('Completion Commands', () => {
       const command = new UninstallCompletionCommand(output);
       const context: CommandContext = { globalOptions: {} };
 
-      await expect(command.execute(undefined, context)).rejects.toBeDefined();
+      try {
+        await command.execute(undefined, context);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(BBError);
+        expect((error as BBError).code).toBe(
+          ErrorCode.COMPLETION_UNINSTALL_FAILED
+        );
+      }
     });
   });
 });

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
 import { ListSnippetsCommand } from '../../src/commands/snippet/list.command.js';
 import { ViewSnippetCommand } from '../../src/commands/snippet/view.command.js';
 import { CreateSnippetCommand } from '../../src/commands/snippet/create.command.js';
@@ -424,7 +425,7 @@ describe('ViewSnippetCommand', () => {
     expect(output.logs.some((log) => log === 'text:hello content')).toBe(true);
   });
 
-  it('should reject --file when file is not in snippet', async () => {
+  it('should reject --file when file is not in snippet with FILE_NOT_FOUND', async () => {
     const output = createMockOutputService();
     const contextService = createMockContextService({
       defaultWorkspace: 'workspace',
@@ -433,12 +434,17 @@ describe('ViewSnippetCommand', () => {
     const { service } = createMockSnippetFilesService();
     const cmd = new ViewSnippetCommand(api, service, contextService, output);
 
-    await expect(
-      cmd.run(
+    try {
+      await cmd.run(
         { id: 'kypj', workspace: 'workspace', file: 'missing.txt' },
         makeContext()
-      )
-    ).rejects.toThrow('File not found in snippet');
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BBError);
+      expect((error as BBError).code).toBe(ErrorCode.FILE_NOT_FOUND);
+      expect((error as BBError).message).toContain('File not found in snippet');
+    }
   });
 
   it('should print all files with --files', async () => {
@@ -566,7 +572,7 @@ describe('CreateSnippetCommand', () => {
     );
   });
 
-  it('should throw when file does not exist', async () => {
+  it('should throw FILE_NOT_FOUND when file does not exist', async () => {
     const output = createMockOutputService();
     const contextService = createMockContextService({
       defaultWorkspace: 'workspace',
@@ -574,12 +580,20 @@ describe('CreateSnippetCommand', () => {
     const { service } = createMockSnippetFilesService();
     const cmd = new CreateSnippetCommand(service, contextService, output);
 
-    await expect(
-      cmd.run(
+    try {
+      await cmd.run(
         { title: 'Test', file: ['nonexistent-file-xyz.txt'] },
         makeContext()
-      )
-    ).rejects.toThrow('File not found');
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BBError);
+      expect((error as BBError).code).toBe(ErrorCode.FILE_NOT_FOUND);
+      expect((error as BBError).message).toContain('File not found');
+      expect((error as BBError).context).toEqual({
+        file: 'nonexistent-file-xyz.txt',
+      });
+    }
   });
 
   it('should reject --public and --private together', async () => {
@@ -701,7 +715,7 @@ describe('EditSnippetCommand', () => {
     ).rejects.toThrow('cannot both be set');
   });
 
-  it('should reject --file pointing to missing file', async () => {
+  it('should reject --file pointing to missing file with FILE_NOT_FOUND', async () => {
     const output = createMockOutputService();
     const contextService = createMockContextService({
       defaultWorkspace: 'workspace',
@@ -709,16 +723,20 @@ describe('EditSnippetCommand', () => {
     const { service } = createMockSnippetFilesService();
     const cmd = new EditSnippetCommand(service, contextService, output);
 
-    await expect(
-      cmd.run(
+    try {
+      await cmd.run(
         {
           id: 'kypj',
           file: ['nonexistent-xyz.txt'],
           workspace: 'workspace',
         },
         makeContext()
-      )
-    ).rejects.toThrow('File not found');
+      );
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BBError);
+      expect((error as BBError).code).toBe(ErrorCode.FILE_NOT_FOUND);
+    }
   });
 });
 

--- a/tests/types/errors.test.ts
+++ b/tests/types/errors.test.ts
@@ -229,11 +229,17 @@ describe('ErrorCode', () => {
   it('should have validation errors in 5xxx range', () => {
     expect(ErrorCode.VALIDATION_REQUIRED).toBe(5001);
     expect(ErrorCode.VALIDATION_INVALID).toBe(5002);
+    expect(ErrorCode.FILE_NOT_FOUND).toBe(5003);
   });
 
   it('should have context errors in 6xxx range', () => {
     expect(ErrorCode.CONTEXT_REPO_NOT_FOUND).toBe(6001);
     expect(ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND).toBe(6002);
+  });
+
+  it('should have completion errors in 9xxx range', () => {
+    expect(ErrorCode.COMPLETION_INSTALL_FAILED).toBe(9001);
+    expect(ErrorCode.COMPLETION_UNINSTALL_FAILED).toBe(9002);
   });
 
   it('should have unknown error as 9999', () => {


### PR DESCRIPTION
## Summary
- Adds `FILE_NOT_FOUND` (5003), `COMPLETION_INSTALL_FAILED` (9001), and `COMPLETION_UNINSTALL_FAILED` (9002) error codes so JSON-driven scripts can branch on specific failure modes instead of catching generic `VALIDATION_INVALID` (5002) or `UNKNOWN` (9999).
- Updates `bb snippet create/edit --file`, `bb snippet view --file`, `bb pr edit --body-file`, and `bb completion install/uninstall` to use the new codes (file-not-found vs other I/O errors are distinguished via `ENOENT`).
- `APIError` now populates `context` with the failed `method`, `url`, and `status`, giving scripts structured fields to key on for 404s and other API errors.
- Clarifies the `AUTH_INVALID` (1002) vs `AUTH_EXPIRED` (1003) distinction in `reference/error-codes.mdx` (1002 = credentials rejected at request time; 1003 = OAuth refresh after a 401 also failed) and documents all new codes.

Closes #189

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test` (858 pass)
- [ ] Manual: `bb snippet create --title x --file does-not-exist --json` → emits `code: 5003`
- [ ] Manual: simulate completion install failure → emits `code: 9001`