### PR TITLE
docs: fill reference documentation gaps

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -104,6 +104,7 @@ export default defineConfig({
             { label: "JSON Output", slug: "reference/json-output" },
             { label: "Error Codes", slug: "reference/error-codes" },
             { label: "Configuration File", slug: "reference/configuration" },
+            { label: "Token Scopes", slug: "reference/token-scopes" },
           ],
         },
         {

--- a/docs/src/content/docs/getting-started/authentication.mdx
+++ b/docs/src/content/docs/getting-started/authentication.mdx
@@ -60,6 +60,9 @@ Use API tokens when a browser is not available (SSH sessions, Docker containers,
       - `admin:repository:bitbucket` — delete repositories (optional)
       - `read:pullrequest:bitbucket` — list and view pull requests
       - `write:pullrequest:bitbucket` — create, edit, merge, approve, decline pull requests
+
+      See [Token Scopes](/reference/token-scopes/) for a per-command breakdown
+      if you want to mint a token with the minimum scope set for your workflow.
    7. Click **Create**
    8. **Copy the generated token** - you won't be able to see it again!
 

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -92,12 +92,28 @@ bb pr list --json | jq '.pullRequests | group_by(.author.nickname // .author.dis
 
 ## Exit Codes
 
-The CLI uses standard exit codes:
+The CLI uses a deliberately small exit-code surface:
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Error (authentication, API, validation, etc.) |
+| 1 | Any failure (authentication, API, validation, network, jq, …) |
+
+There is **no `2`/`3`/etc. mapping** — every failure exits with `1`. To branch
+on the specific failure mode in a script, parse the JSON error written to
+stderr and read its `code` field, which corresponds to one of the
+[error codes](/reference/error-codes/).
+
+```bash
+if ! bb pr view 999 --json > out.json 2> err.json; then
+  code=$(jq -r '.code' err.json)
+  case "$code" in
+    1001|1002|1003) echo "auth problem";;
+    2002)            echo "PR not found";;
+    *)               echo "other failure ($code)";;
+  esac
+fi
+```
 
 ### Checking Exit Codes
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -110,11 +110,40 @@ bb config set skipVersionCheck true
 bb config set versionCheckInterval 7
 ```
 
+#### Settable Keys
+
+`bb config set` only accepts these four keys (the full list lives in
+`SETTABLE_CONFIG_KEYS` in `src/types/config.ts`). Everything else is either
+managed by the auth flow or written automatically by the CLI.
+
+| Key | Type | Example |
+|-----|------|---------|
+| `defaultWorkspace` | string | `bb config set defaultWorkspace myworkspace` |
+| `skipVersionCheck` | boolean | `bb config set skipVersionCheck true` |
+| `versionCheckInterval` | integer (days, ≥ 1) | `bb config set versionCheckInterval 7` |
+| `prCreateIncludeDefaultReviewers` | boolean | `bb config set prCreateIncludeDefaultReviewers true` |
+
 Typed key validation:
 
 - `skipVersionCheck` accepts only `true` or `false`
 - `versionCheckInterval` accepts only positive integers (`>= 1`)
 - `prCreateIncludeDefaultReviewers` accepts only `true` or `false`
+
+#### `prCreateIncludeDefaultReviewers` and the `--default-reviewers` flag
+
+The config key sets the default behavior for `bb pr create`. The per-command
+flag — `--default-reviewers` or `--no-default-reviewers` — always wins when
+present, so you can opt in or out for a single PR without changing the config.
+
+| Config | Flag | Result |
+|--------|------|--------|
+| unset / `false` | (none) | Default reviewers are **not** added |
+| `true` | (none) | Default reviewers are added |
+| unset / `false` | `--default-reviewers` | Default reviewers are added |
+| `true` | `--no-default-reviewers` | Default reviewers are **not** added |
+
+In short: the flag is an explicit override; the config is only consulted when
+neither `--default-reviewers` nor `--no-default-reviewers` is passed.
 
 Values are stored as native JSON types, so `bb config get <key> --json` returns booleans/numbers for these keys.
 

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -17,6 +17,18 @@ Environment variables allow you to configure the CLI without storing credentials
 | `FORCE_COLOR` | Force-enable color output globally | `1` |
 | `DEBUG` | Enable HTTP debug logging (logs request method, URL, status, and response body for every API call) | `true` |
 
+### Internal / System Variables
+
+These variables are read by the CLI but are normally set by the runtime, your
+shell, or your operating system rather than by you. They are documented here
+so they aren't surprising during troubleshooting.
+
+| Variable | Set By | Description |
+|----------|--------|-------------|
+| `NODE_ENV` | Test runners | When set to `test`, the CLI suppresses `process.exitCode = 1` on errors so a single failing test cannot cascade into later tests. Don't set this in production. |
+| `COMP_LINE` | tabtab / your shell | Set automatically while shell completion is being computed (`bb completion`). Its presence triggers the completion path; you should not set it manually. |
+| `APPDATA` | Windows | Used to locate the config file at `%APPDATA%\bb\config.json` on Windows. The CLI falls back to `%USERPROFILE%\AppData\Roaming\bb\config.json` if it isn't set. |
+
 ## Configuration Priority
 
 Repository context is resolved in this order (highest priority first):

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -94,10 +94,8 @@ bb auth login
 
 **Solution:**
 1. Check your API token scopes at [Bitbucket API Tokens](https://bitbucket.org/account/settings/api-tokens/)
-2. Required scopes depend on the operation:
-   - **Read operations:** `account:read`, `repository:read`, `pullrequest:read`
-   - **Write operations:** `repository:write`, `pullrequest:write`
-   - **Delete operations:** `repository:admin`
+2. See [Token Scopes](/reference/token-scopes/) for the exact scope each `bb` command requires.
+3. If a scope is missing, mint a new token (you can't add scopes to an existing one) and re-authenticate with `bb auth login`.
 
 ### 2004 - API_RATE_LIMITED
 
@@ -341,6 +339,16 @@ DEBUG=true bb <your-command> 2>&1
 ```
 
 ---
+
+## Exit Codes and Error Codes
+
+The process exit code is intentionally minimal — `0` for success and `1` for
+any failure. The numeric error code on this page lives in the JSON error
+payload's `code` field, not in the exit status. To branch on a specific
+failure mode in a script, parse stderr JSON and read `.code`.
+
+See [Exit Codes in the scripting guide](/guides/scripting/#exit-codes) for a
+full example.
 
 ## Handling Errors in Scripts
 

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -247,7 +247,38 @@ Some action commands include the full resource in the response:
 
 Used by: `pr diff` (with `--stat`, `--web`, `--name-only`, or default diff mode)
 
-Returns context metadata plus mode-specific data:
+Returns context metadata plus mode-specific data. Every mode includes the same
+context envelope (`workspace`, `repoSlug`, `pullRequestId`, `mode`); the
+remaining fields depend on the mode.
+
+| Mode | Trigger | Mode-specific fields |
+|------|---------|----------------------|
+| `diff` | (default) | `diff` (string — the raw unified diff text) |
+| `stat` | `--stat` | `filesChanged`, `totalAdditions`, `totalDeletions`, `files[]` |
+| `name-only` | `--name-only` | `files[]` (string array of paths) |
+| `web` | `--web` | `url` |
+
+#### `bb pr diff 42 --json` (default mode)
+
+The default mode returns the raw unified diff as a single string under `diff`.
+Newlines are preserved, so the value is suitable for piping to `git apply` or
+writing to a `.patch` file.
+
+```json
+{
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "pullRequestId": 42,
+  "mode": "diff",
+  "diff": "diff --git a/src/index.ts b/src/index.ts\nindex abc123..def456 100644\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,3 +1,4 @@\n import { foo } from './foo';\n+import { bar } from './bar';\n \n export const main = () => {\n"
+}
+```
+
+Extract just the diff text in scripts:
+
+```bash
+bb pr diff 42 --json --jq '.diff' > pr-42.patch
+```
 
 #### `bb pr diff 42 --stat --json`
 
@@ -399,9 +430,41 @@ Error JSON fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Error class name (always `BBError`) |
+| `name` | string | Error class name (usually `BBError`; can also be `APIError`, `AuthError`, `GitError`, `ValidationError`) |
 | `code` | number | Numeric [error code](/reference/error-codes/) |
 | `message` | string | Human-readable message |
-| `context` | object | Optional structured metadata |
+| `context` | object | Optional structured metadata. Shape depends on `code` — see the table below |
+
+The Bitbucket API response body is **not** nested inside the error JSON.
+`APIError` keeps the upstream HTTP status and response body as instance
+properties for the in-process error path, but only `name`, `code`, `message`,
+and `context` are serialized to stderr. Likewise, `cause` (the underlying
+`Error`) and stack traces are never exposed in `--json` mode.
+
+#### `context` fields by error code
+
+The `context` object is omitted when there's nothing useful to attach. When
+present, the shape is:
+
+| Code | Typical `context` keys |
+|------|------------------------|
+| `1001` AUTH_REQUIRED | _(none)_ |
+| `1002` AUTH_INVALID | `status` (HTTP status, OAuth verification failures only) |
+| `1003` AUTH_EXPIRED | `status` (HTTP status from the token endpoint) |
+| `2001`–`2005` API_* | _(none — the upstream HTTP status code is in `APIError.statusCode` in-process but is not serialized)_ |
+| `3001` GIT_NOT_REPOSITORY | _(none)_ |
+| `3002` GIT_COMMAND_FAILED | `command`, `exitCode` |
+| `3003` GIT_REMOTE_NOT_FOUND | `remote` |
+| `4001` CONFIG_READ_FAILED | _(none)_ |
+| `4002` CONFIG_WRITE_FAILED | _(none)_ |
+| `4003` CONFIG_INVALID_KEY | `key` |
+| `5001` VALIDATION_REQUIRED | `field` (when thrown by `ValidationError`) |
+| `5002` VALIDATION_INVALID | varies — usually `{ key, value }`, the offending option name, or the rejected ID |
+| `6001` CONTEXT_REPO_NOT_FOUND | _(none)_ |
+| `6002` CONTEXT_WORKSPACE_NOT_FOUND | _(none)_ |
+| `7001` NETWORK_ERROR | _(usually none; OAuth revoke failures include `status`, `body`)_ |
+| `8001` JQ_FAILED | `expression`, optional `exitCode` |
+| `8002` JSON_FORMAT_INVALID | _(none)_ |
+| `9999` UNKNOWN | _(none)_ |
 
 In automation, always check the process exit code before parsing stdout JSON.

--- a/docs/src/content/docs/reference/token-scopes.mdx
+++ b/docs/src/content/docs/reference/token-scopes.mdx
@@ -1,0 +1,153 @@
+---
+title: Token Scopes
+description: Required Bitbucket API token scopes for each bb command
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+When you authenticate with an [API token](/getting-started/authentication/#api-token-for-cicd-and-headless-environments),
+you choose which scopes the token grants. This page maps every `bb` command to
+the minimum scope required to run it, so you can mint a token with exactly the
+permissions a workflow needs and nothing more.
+
+<Aside type="tip">
+OAuth logins (`bb auth login` without `-u`/`-p`) request a fixed scope set up
+front and don't need this table. Use this reference when generating an API
+token at [Bitbucket API tokens](https://bitbucket.org/account/settings/api-tokens/).
+</Aside>
+
+## Scope Reference
+
+Bitbucket Cloud API token scopes follow the format `<action>:<resource>:bitbucket`.
+The CLI uses these scopes:
+
+| Scope | Grants |
+|-------|--------|
+| `read:user:bitbucket` | Read your own user profile (required by `bb auth status`, used to verify any login) |
+| `read:repository:bitbucket` | List and view repositories, list default reviewers |
+| `write:repository:bitbucket` | Create repositories, manage default reviewers |
+| `admin:repository:bitbucket` | Delete repositories |
+| `read:pullrequest:bitbucket` | List, view, and diff pull requests; read comments, activity, checks, and reviewers |
+| `write:pullrequest:bitbucket` | Create, edit, approve, decline, merge, and mark PRs ready; add/edit/delete comments; add/remove reviewers |
+| `read:snippet:bitbucket` | List and view snippets |
+| `write:snippet:bitbucket` | Create, edit, and delete snippets |
+
+## Command → Scope Map
+
+### Auth (`bb auth …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb auth login` | `read:user:bitbucket` (verifies the credentials) |
+| `bb auth logout` | _(none — local-only for API tokens; OAuth revoke uses the existing token)_ |
+| `bb auth status` | `read:user:bitbucket` |
+| `bb auth token` | _(none — prints the locally-stored token)_ |
+
+### Repositories (`bb repo …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb repo list` | `read:repository:bitbucket` |
+| `bb repo view` | `read:repository:bitbucket` |
+| `bb repo clone` | `read:repository:bitbucket` (plus your normal git auth) |
+| `bb repo create` | `write:repository:bitbucket` |
+| `bb repo delete` | `admin:repository:bitbucket` |
+| `bb repo default-reviewers list` | `read:repository:bitbucket` |
+| `bb repo default-reviewers add` | `write:repository:bitbucket` |
+| `bb repo default-reviewers remove` | `write:repository:bitbucket` |
+
+### Pull Requests (`bb pr …`)
+
+Read-only PR commands — `list`, `view`, `diff`, `checkout`, `activity`,
+`checks`, `comments list`, `reviewers list` — only need
+`read:pullrequest:bitbucket` (plus `read:repository:bitbucket` for repository
+context).
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb pr list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr view` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr diff` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr checkout` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr activity` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr checks` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr comments list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr reviewers list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr create` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr edit` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr ready` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr approve` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr decline` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr merge` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr comments add` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr comments edit` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr comments delete` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr reviewers add` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+| `bb pr reviewers remove` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+
+### Snippets (`bb snippet …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb snippet list` | `read:snippet:bitbucket` |
+| `bb snippet view` | `read:snippet:bitbucket` |
+| `bb snippet create` | `write:snippet:bitbucket` |
+| `bb snippet edit` | `write:snippet:bitbucket` |
+| `bb snippet delete` | `write:snippet:bitbucket` |
+
+### Local-only commands
+
+These don't hit the API and don't need any scope:
+
+- `bb config` (all subcommands)
+- `bb completion`
+- `bb` (root, including the version-check)
+
+## Common Profiles
+
+Pick the profile that matches your workflow and grant only those scopes when
+creating the token.
+
+### Read-only automation (status checks, dashboards)
+
+```
+read:user:bitbucket
+read:repository:bitbucket
+read:pullrequest:bitbucket
+```
+
+### Bot account that creates and merges PRs
+
+```
+read:user:bitbucket
+read:repository:bitbucket
+read:pullrequest:bitbucket
+write:pullrequest:bitbucket
+```
+
+### Repo provisioning automation
+
+```
+read:user:bitbucket
+read:repository:bitbucket
+write:repository:bitbucket
+admin:repository:bitbucket
+```
+
+<Aside type="caution" title="Principle of least privilege">
+Don't grant `write:` or `admin:` scopes to a token unless the script that uses
+it actually needs them. A leaked read-only token is far less damaging than a
+leaked admin token.
+</Aside>
+
+## Troubleshooting
+
+If a command exits with [`2003` API_FORBIDDEN](/reference/error-codes/#2003---api_forbidden),
+your token is missing the scope listed in the table above. Mint a new token
+with the required scope (you can't add scopes to an existing token) and
+re-authenticate:
+
+```bash
+bb auth logout
+bb auth login -u your-username -p new-token
+```


### PR DESCRIPTION
## Summary

Closes #185.

Fills the reference-documentation gaps called out in the issue. Pure docs change — no code or behavior touched.

- **`reference/environment-variables.mdx`** — adds an "Internal / system variables" section covering `NODE_ENV`, `COMP_LINE`, and `APPDATA` so they aren't surprising during troubleshooting.
- **`reference/configuration.mdx`** — adds a dedicated **Settable Keys** subsection enumerating the four keys from `SETTABLE_CONFIG_KEYS`, plus a precedence table for `prCreateIncludeDefaultReviewers` × `--default-reviewers` / `--no-default-reviewers`.
- **`guides/scripting.mdx` + `reference/error-codes.mdx`** — makes the `0` = success / `1` = any failure contract explicit, notes there is no `2`/`3`/etc. mapping, and points scripts at the JSON `code` field for branching. Cross-linked both directions.
- **`reference/json-output.mdx`** —
  - documents the default `bb pr diff <id> --json` shape (`mode: "diff"`, `diff: <string>`) with a sample.
  - adds a per-error-code table mapping `ErrorCode` → expected `context` keys.
  - clarifies what is *not* serialized in error JSON: `APIError.statusCode`, the upstream response body, `cause`, and stack traces.
- **New `reference/token-scopes.mdx`** — full command → required-token-scope map for every `bb` command (auth / repo / pr / snippet / local-only), plus three common scope profiles. Wired into the sidebar; cross-linked from `error-codes #2003 API_FORBIDDEN` and the auth getting-started page.

The `lastVersionCheck` gap mentioned at the bottom of the issue is intentionally left out — it's tracked separately in #181.

## Test plan

- [x] `bun run format:check` — passes
- [x] `cd docs && bun run build` — 28 pages built, no broken-link warnings
- [ ] Spot-check rendered pages on the deployed docs once merged