### PR TITLE
docs(cli): standardize --help text coverage across all commands

### DIFF
--- a/.changeset/standardize-help-text-coverage.md
+++ b/.changeset/standardize-help-text-coverage.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+docs(cli): standardize `--help` text coverage across all commands. PR `approve`/`decline`/`ready`/`checkout`, PR `comments edit`/`delete`, PR `reviewers add`/`remove`, snippet `watch`/`unwatch`/`comments delete`/`comments edit`, `auth logout`, and `completion install`/`uninstall` now include multiple realistic examples and (where applicable) `validValues` blocks. `pr merge --strategy` documents the API default. `bb snippet comments add` now also accepts `<message>` as a positional argument for parity with `bb pr comments add`, and its help marks the message as required. A new test guarantees every leaf command exposes an Examples block.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -362,7 +362,12 @@ authCmd
 authCmd
   .command('logout')
   .description('Log out of Bitbucket')
-  .addHelpText('after', buildHelpText({ examples: ['bb auth logout'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb auth logout', 'bb auth logout --json'],
+    })
+  )
   .action(async () => {
     await runCommand(ServiceTokens.LogoutCommand, undefined, cli);
   });
@@ -814,6 +819,10 @@ prCmd
           'rebase_merge',
         ],
       },
+      defaults: {
+        strategy:
+          "the repository's configured merge strategy (typically merge_commit)",
+      },
     })
   )
   .action(async (id, options) => {
@@ -829,7 +838,16 @@ prCmd
 prCmd
   .command('approve <id>')
   .description('Approve a pull request')
-  .addHelpText('after', buildHelpText({ examples: ['bb pr approve 42'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pr approve 42',
+        'bb pr approve 42 --json',
+        'bb pr approve 42 -w my-workspace -r my-repo',
+      ],
+    })
+  )
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(
@@ -843,7 +861,16 @@ prCmd
 prCmd
   .command('decline <id>')
   .description('Decline a pull request')
-  .addHelpText('after', buildHelpText({ examples: ['bb pr decline 42'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pr decline 42',
+        'bb pr decline 42 --json',
+        'bb pr decline 42 -w my-workspace -r my-repo',
+      ],
+    })
+  )
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(
@@ -857,7 +884,16 @@ prCmd
 prCmd
   .command('ready <id>')
   .description('Mark a draft pull request as ready for review')
-  .addHelpText('after', buildHelpText({ examples: ['bb pr ready 42'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pr ready 42',
+        'bb pr ready 42 --json',
+        'bb pr ready 42 -w my-workspace -r my-repo',
+      ],
+    })
+  )
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(
@@ -871,7 +907,15 @@ prCmd
 prCmd
   .command('checkout <id>')
   .description('Checkout a pull request locally')
-  .addHelpText('after', buildHelpText({ examples: ['bb pr checkout 42'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pr checkout 42',
+        'bb pr checkout 42 -w my-workspace -r my-repo',
+      ],
+    })
+  )
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(
@@ -976,7 +1020,10 @@ prCommentsCmd
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb pr comments edit 42 12345 "Updated comment"'],
+      examples: [
+        'bb pr comments edit 42 12345 "Updated comment"',
+        'bb pr comments edit 42 12345 "Updated comment" --json',
+      ],
     })
   )
   .action(async (prId, commentId, message, options) => {
@@ -996,7 +1043,10 @@ prCommentsCmd
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb pr comments delete 42 12345 --yes'],
+      examples: [
+        'bb pr comments delete 42 12345',
+        'bb pr comments delete 42 12345 --yes',
+      ],
     })
   )
   .action(async (prId, commentId, options) => {
@@ -1037,7 +1087,12 @@ prReviewersCmd
   .description('Add a reviewer to a pull request')
   .addHelpText(
     'after',
-    buildHelpText({ examples: ['bb pr reviewers add 42 jdoe'] })
+    buildHelpText({
+      examples: [
+        'bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"',
+        'bb pr reviewers add 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"',
+      ],
+    })
   )
   .action(async (id, username, options) => {
     const context = createContext(cli);
@@ -1054,7 +1109,12 @@ prReviewersCmd
   .description('Remove a reviewer from a pull request')
   .addHelpText(
     'after',
-    buildHelpText({ examples: ['bb pr reviewers remove 42 jdoe'] })
+    buildHelpText({
+      examples: [
+        'bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"',
+        'bb pr reviewers remove 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"',
+      ],
+    })
   )
   .action(async (id, username, options) => {
     const context = createContext(cli);
@@ -1211,7 +1271,12 @@ snippetCmd
 snippetCmd
   .command('watch <id>')
   .description('Watch a snippet')
-  .addHelpText('after', buildHelpText({ examples: ['bb snippet watch kypj'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb snippet watch kypj', 'bb snippet watch kypj -w my-team'],
+    })
+  )
   .action(async (id, options) => {
     const context = createContext(cli);
     await runCommand(
@@ -1227,7 +1292,12 @@ snippetCmd
   .description('Stop watching a snippet')
   .addHelpText(
     'after',
-    buildHelpText({ examples: ['bb snippet unwatch kypj'] })
+    buildHelpText({
+      examples: [
+        'bb snippet unwatch kypj',
+        'bb snippet unwatch kypj -w my-team',
+      ],
+    })
   )
   .action(async (id, options) => {
     const context = createContext(cli);
@@ -1268,20 +1338,28 @@ snippetCommentsCmd
   });
 
 snippetCommentsCmd
-  .command('add <id>')
-  .description('Add a comment to a snippet')
-  .option('-m, --message <text>', 'Comment message')
+  .command('add <id> [message]')
+  .description('Add a comment to a snippet (message is required)')
+  .option(
+    '-m, --message <text>',
+    'Comment message (alternative to the positional [message] argument; one of the two is required)'
+  )
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb snippet comments add kypj -m "Great snippet!"'],
+      examples: [
+        'bb snippet comments add kypj "Great snippet!"',
+        'bb snippet comments add kypj -m "Great snippet!"',
+        'bb snippet comments add kypj "Great snippet!" --json',
+      ],
     })
   )
-  .action(async (id, options) => {
+  .action(async (id, message, options) => {
     const context = createContext(cli);
+    const resolvedMessage = message ?? options.message;
     await runCommand(
       ServiceTokens.AddSnippetCommentCommand,
-      withGlobalOptions({ id, ...options }, context),
+      withGlobalOptions({ id, ...options, message: resolvedMessage }, context),
       cli,
       context
     );
@@ -1293,7 +1371,10 @@ snippetCommentsCmd
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb snippet comments edit kypj 123 "Updated comment"'],
+      examples: [
+        'bb snippet comments edit kypj 123 "Updated comment"',
+        'bb snippet comments edit kypj 123 "Updated comment" --json',
+      ],
     })
   )
   .action(async (snippetId, commentId, message, options) => {
@@ -1313,7 +1394,10 @@ snippetCommentsCmd
   .addHelpText(
     'after',
     buildHelpText({
-      examples: ['bb snippet comments delete kypj 123 --yes'],
+      examples: [
+        'bb snippet comments delete kypj 123',
+        'bb snippet comments delete kypj 123 --yes',
+      ],
     })
   )
   .action(async (snippetId, commentId, options) => {
@@ -1400,7 +1484,15 @@ const completionCmd = new Command('completion').description(
 completionCmd
   .command('install')
   .description('Install shell completions for bash, zsh, or fish')
-  .addHelpText('after', buildHelpText({ examples: ['bb completion install'] }))
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb completion install', 'bb completion install --json'],
+      validValues: {
+        'Supported shells': ['bash', 'zsh', 'fish'],
+      },
+    })
+  )
   .action(async () => {
     await runCommand(ServiceTokens.InstallCompletionCommand, undefined, cli);
   });
@@ -1410,7 +1502,12 @@ completionCmd
   .description('Uninstall shell completions')
   .addHelpText(
     'after',
-    buildHelpText({ examples: ['bb completion uninstall'] })
+    buildHelpText({
+      examples: ['bb completion uninstall', 'bb completion uninstall --json'],
+      validValues: {
+        'Supported shells': ['bash', 'zsh', 'fish'],
+      },
+    })
   )
   .action(async () => {
     await runCommand(ServiceTokens.UninstallCompletionCommand, undefined, cli);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -499,6 +499,26 @@ describe('CLI command registration', () => {
     // Sanity check: we covered a reasonable number of leaves.
     expect(leaves.length).toBeGreaterThanOrEqual(40);
   });
+
+  it('should attach addHelpText("after") with at least one example to every leaf command', () => {
+    // Commander implements `addHelpText('after', ...)` by registering a
+    // listener for the `afterHelp` event. We assert each leaf command has at
+    // least one such listener and renders an "Examples:" section, so help
+    // coverage cannot silently regress on new commands. See issue #187.
+    const leaves = collectLeafCommands(cli);
+    const missing: string[] = [];
+    for (const leaf of leaves) {
+      if (leaf.listenerCount('afterHelp') < 1) {
+        missing.push(leaf.name());
+        continue;
+      }
+      const help = captureHelp(leaf);
+      if (!help.includes('Examples:') || !help.includes('$ bb ')) {
+        missing.push(leaf.name());
+      }
+    }
+    expect(missing).toEqual([]);
+  });
 });
 
 describe('CLI leaf command options', () => {


### PR DESCRIPTION
## Summary

- Walked every leaf command in `src/cli.ts` and applied a consistent `addHelpText` checklist: at least two realistic examples, defaults declared, enum values listed in `validValues`, and env-var blocks where they apply.
- `bb snippet comments add` now also accepts `<message>` as a positional argument for parity with `bb pr comments add`. `-m, --message` is preserved as an alternative; help marks the message as required.
- `bb pr merge --help` now documents that omitting `--strategy` uses the repository's configured merge strategy (the API default).
- Added a regression test in `tests/cli.test.ts` that fails if any leaf command lacks an `addHelpText('after', …)` listener or doesn't render an `Examples:` section.

Closes #187.

## Test plan

- [x] `bun test` (864 pass)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Spot-checked rendered output for `bb pr approve --help`, `bb pr merge --help`, and `bb snippet comments add --help`