### PR TITLE
docs(ai-agents): fix wrong merge strategy values in skill snippet

### DIFF
--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -49,7 +49,7 @@ Pick your editor and paste the command:
 
     - Auto-detects workspace/repo from git remotes; override with `-w` / `-r`
     - All commands support `--json` for structured output
-    - Merge strategies: `merge-commit`, `squash`, `fast-forward`
+    - Merge strategies: `merge_commit`, `squash`, `fast_forward`, `squash_fast_forward`, `rebase_fast_forward`, `rebase_merge`
     SKILL
 
     echo "✓ Skill installed. Restart Claude Code to activate."


### PR DESCRIPTION
## Summary

- Fixes hyphenated merge strategy values in the Claude Code skill snippet of `docs/src/content/docs/guides/ai-agents.mdx`. The CLI rejects `merge-commit` / `fast-forward` via `parseEnumOption`, so any agent copying the snippet hits validation errors.
- Replaces the line with the actual underscored values accepted by `bb pr merge --strategy` (per `src/cli.ts:807-815` and `VALID_STRATEGIES` in `src/commands/pr/merge.command.ts`), and lists all six options for completeness.
- Spot-checked the other code blocks (lines ~132 and ~162); they only reference `--strategy squash`, which is valid in either form.

Closes #179

## Test plan

- [x] `bun run format:check` passes
- [x] Visual inspection of the rendered MDX section
- [ ] Verify a sample command like `bb pr merge 42 --strategy merge_commit` is accepted by the CLI's enum validation