### PR TITLE
docs: improve docs site navigation, cross-linking, and discoverability

### DIFF
--- a/.changeset/docs-navigation-and-discoverability.md
+++ b/.changeset/docs-navigation-and-discoverability.md
@@ -1,0 +1,31 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+docs: improve docs site navigation, cross-linking, and discoverability
+
+Several small surface-level fixes that together close the gap between "I had to
+search" and "I clicked the obvious link". Resolves [#186](https://github.com/0pilatos0/bitbucket-cli/issues/186).
+
+- **Changelog page in docs**: new `/help/changelog/` page with a curated
+  summary of recent releases plus a link to the full GitHub `CHANGELOG.md`.
+  Surfaced in the sidebar under Help.
+- **AI Agents guide linked from README**: the substantial `guides/ai-agents`
+  page is now mentioned under the README's Docs section so it's discoverable
+  from the npm/GitHub landing.
+- **`See also` section in `bb --help`**: extends `buildHelpText()` with a new
+  `seeAlso` config that renders a labeled list of doc URLs. Wired up on the
+  global help, `bb pr list`, `bb pr create`, `bb config get`, and
+  `bb config set` to point users at the relevant guide.
+- **`bb config list` advertises settable keys**: after the values table, the
+  command appends `Settable keys: defaultWorkspace, skipVersionCheck, ...`
+  so users discover what they can change without reading `--help` separately.
+- **Stable anchor for `bb repo default-reviewers`**: explicit `<a id="...">`
+  before the heading so the cross-link from `pr/create-and-edit` survives any
+  future Starlight slug-generator change.
+- **Quickstart documents the version-check nudge**: explains what the upgrade
+  message means and how to silence it (`bb config set skipVersionCheck true`).
+- **CLAUDE.md uses a real markdown link to AGENTS.md**: replaces the
+  Claude-specific `@AGENTS.md` syntax (which doesn't render as a link in
+  generic markdown viewers) with `[AGENTS.md](AGENTS.md)` and adds a "must
+  read" pointer list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quick Reference
 
-See @AGENTS.md for full coding conventions, DI patterns, and command architecture.
+See [AGENTS.md](AGENTS.md) for full coding conventions, DI patterns, and command architecture.
+
+**Must read sections:**
+
+- [Code Style Guidelines](AGENTS.md#code-style-guidelines) — runtime, imports, formatting, types, naming
+- [Error Handling](AGENTS.md#error-handling) — `BBError` / `ErrorCode` usage and `BaseCommand.run()` flow
+- [Command Pattern](AGENTS.md#command-pattern) — extending `BaseCommand` and `CommandContext`
+- [Output and JSON](AGENTS.md#output-and-json) — `IOutputService` and `--json` handling
+- [Dependency Injection](AGENTS.md#dependency-injection) — bootstrap registration via `ServiceTokens`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Full documentation: **[bitbucket-cli.paulvanderlei.com](https://bitbucket-cli.pa
 - [Quick Start Guide](https://bitbucket-cli.paulvanderlei.com/getting-started/quickstart/)
 - [Command Reference](https://bitbucket-cli.paulvanderlei.com/commands/auth/)
 - [Guides](https://bitbucket-cli.paulvanderlei.com/guides/scripting/) (Scripting, CI/CD)
+- AI assistant integration (Claude Code, Cursor, Windsurf): see [Guides &gt; AI Agents](https://bitbucket-cli.paulvanderlei.com/guides/ai-agents/)
+- [Changelog](https://bitbucket-cli.paulvanderlei.com/help/changelog/) — what's new in recent releases
 - [Help](https://bitbucket-cli.paulvanderlei.com/help/troubleshooting/) (Troubleshooting, FAQ)
 
 ---

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -111,6 +111,11 @@ export default defineConfig({
           items: [
             { label: "Troubleshooting", slug: "help/troubleshooting" },
             { label: "FAQ", slug: "help/faq" },
+            {
+              label: "Changelog",
+              slug: "help/changelog",
+              badge: { text: "New", variant: "tip" },
+            },
           ],
         },
       ],

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -200,6 +200,8 @@ This action is permanent and cannot be undone! All repository data, including co
 
 ---
 
+<a id="bb-repo-default-reviewers"></a>
+
 ## `bb repo default-reviewers`
 
 Inspect and manage the default reviewers configured on a repository. Default reviewers in Bitbucket Cloud are automatically suggested when someone opens a pull request through the web UI; this command group lets you see and edit that list from the CLI.

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -140,6 +140,29 @@ bb pr create -<Tab>  # Shows available flags
 
 ---
 
+## Update notifications
+
+When a newer version is available on npm, `bb` prints a one-time nudge after
+the next command finishes:
+
+```text
+⚠ A new version is available: 1.14.0 (you have 1.13.0)
+  Run 'npm install -g @pilatos/bitbucket-cli' to update
+  Or disable with 'bb config set skipVersionCheck true'
+```
+
+The check runs at most once per `versionCheckInterval` (default: 24 hours) and
+is skipped automatically in CI environments. Disable it permanently with:
+
+```bash
+bb config set skipVersionCheck true
+```
+
+See the [Configuration File reference](/reference/configuration/) for related
+settings.
+
+---
+
 ## Next Steps
 
 You're all set! Here's where to go next:
@@ -147,4 +170,6 @@ You're all set! Here's where to go next:
 - **[Command Reference](/commands/auth/)** - Full documentation for all commands
 - **[Repository Context](/guides/repository-context/)** - How the CLI detects your workspace/repo
 - **[Scripting & Automation](/guides/scripting/)** - Use bb in scripts and CI/CD
+- **[AI Agent Integration](/guides/ai-agents/)** - Wire the CLI into Claude Code, Cursor, or Windsurf
+- **[Changelog](/help/changelog/)** - What's new in recent releases
 - **[Troubleshooting](/help/troubleshooting/)** - Common issues and solutions

--- a/docs/src/content/docs/help/changelog.mdx
+++ b/docs/src/content/docs/help/changelog.mdx
@@ -1,0 +1,66 @@
+---
+title: Changelog
+description: What's new in Bitbucket CLI — curated highlights from recent releases.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A curated summary of recent releases. The full, machine-generated changelog
+lives in the [GitHub repository](https://github.com/0pilatos0/bitbucket-cli/blob/main/CHANGELOG.md)
+and is updated on every release.
+
+<Aside type="tip">
+  Hide the in-CLI update nudge with `bb config set skipVersionCheck true`.
+  See [Configuration File](/reference/configuration/) for related settings.
+</Aside>
+
+## 1.14.0 — `--json <fields>` projection and `--jq <expression>`
+
+Match the `gh` CLI's JSON formatting flags so muscle memory and scripts port
+over cleanly.
+
+- `--json [fields]` accepts an optional comma-separated field list
+  (e.g. `--json number,title,author.display_name`). Bare `--json` keeps the
+  existing full-object output for backwards compatibility.
+- `--jq <expression>` runs the JSON output through an embedded
+  [`jq-wasm`](https://www.npmjs.com/package/jq-wasm) engine. Requires `--json`.
+- Field projection drops the wrapper around list-style results
+  (e.g. `pullRequests`, `repositories`, `snippets`) and projects per-item,
+  matching `gh` semantics.
+- Dotted paths (`author.display_name`) traverse nested objects.
+- Invalid jq expressions exit non-zero with the underlying jq error.
+
+```bash
+bb pr list --json number,title,state
+bb pr list --json author --jq '.[].author.display_name'
+bb pr list --json number,title,state --jq '.[] | select(.state == "OPEN") | .title'
+```
+
+See the [Scripting & Automation guide](/guides/scripting/) for end-to-end
+examples.
+
+## 1.13.x — Stability and CI hardening
+
+- **CI runs the full test + build matrix on Ubuntu, macOS, and Windows.** Bun
+  and every GitHub Action are pinned to explicit versions/SHAs, and the release
+  pipeline no longer tags or publishes until lint, format, and tests all pass.
+- **`--limit 0` now errors** instead of silently returning no results.
+  `parseLimit` rejects any non-positive or non-finite value with a
+  `VALIDATION_INVALID` `BBError`.
+- **Generated API client refreshed** from the latest Bitbucket Cloud OpenAPI
+  spec, with a post-generation patch that dedupes duplicate enum declarations
+  and corrects `PipelineSelector.type` optionality.
+
+## 1.13.0 — Default reviewers
+
+- **`bb repo default-reviewers`** lets you inspect and manage the default
+  reviewers configured on a repository, the same list Bitbucket suggests when
+  someone opens a PR through the web UI.
+- **`bb pr create`** picks up those default reviewers automatically when the
+  `prCreateIncludeDefaultReviewers` config key is enabled. See
+  [`bb pr create`](/commands/pr/create-and-edit/) for the full flow.
+
+## Older releases
+
+For releases prior to 1.13.0 — and the complete per-PR commit log — see the
+[full CHANGELOG on GitHub](https://github.com/0pilatos0/bitbucket-cli/blob/main/CHANGELOG.md).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -288,6 +288,20 @@ cli
         FORCE_COLOR: "Force color output when set (and not '0')",
         DEBUG: "Enable HTTP debug logging when 'true'",
       },
+      seeAlso: [
+        {
+          label: 'Quick Start',
+          url: 'https://bitbucket-cli.paulvanderlei.com/getting-started/quickstart/',
+        },
+        {
+          label: 'Scripting',
+          url: 'https://bitbucket-cli.paulvanderlei.com/guides/scripting/',
+        },
+        {
+          label: 'Changelog',
+          url: 'https://bitbucket-cli.paulvanderlei.com/help/changelog/',
+        },
+      ],
     })
   )
   .action(async () => {
@@ -641,6 +655,16 @@ prCmd
         'default-reviewers':
           'false (override with --default-reviewers or config key prCreateIncludeDefaultReviewers)',
       },
+      seeAlso: [
+        {
+          label: 'Repository Context',
+          url: 'https://bitbucket-cli.paulvanderlei.com/guides/repository-context/',
+        },
+        {
+          label: 'Default reviewers',
+          url: 'https://bitbucket-cli.paulvanderlei.com/commands/repo/#bb-repo-default-reviewers',
+        },
+      ],
     })
   )
   .action(async (options) => {
@@ -676,6 +700,16 @@ prCmd
         'Valid states': [...PR_STATES],
       },
       defaults: { state: 'OPEN', limit: '25' },
+      seeAlso: [
+        {
+          label: 'Scripting & Automation',
+          url: 'https://bitbucket-cli.paulvanderlei.com/guides/scripting/',
+        },
+        {
+          label: 'JSON Output',
+          url: 'https://bitbucket-cli.paulvanderlei.com/reference/json-output/',
+        },
+      ],
     })
   )
   .action(async (options) => {
@@ -1345,6 +1379,7 @@ configCmd
           'defaultWorkspace',
           'skipVersionCheck',
           'versionCheckInterval',
+          'prCreateIncludeDefaultReviewers',
         ],
       },
     })
@@ -1369,8 +1404,15 @@ configCmd
           'defaultWorkspace (string)',
           'skipVersionCheck (true/false)',
           'versionCheckInterval (positive integer, seconds)',
+          'prCreateIncludeDefaultReviewers (true/false)',
         ],
       },
+      seeAlso: [
+        {
+          label: 'Configuration File',
+          url: 'https://bitbucket-cli.paulvanderlei.com/reference/configuration/',
+        },
+      ],
     })
   )
   .action(async (key, value) => {

--- a/src/commands/config/list.command.ts
+++ b/src/commands/config/list.command.ts
@@ -9,6 +9,7 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import {
+  SETTABLE_CONFIG_KEYS,
   coerceBooleanConfigValue,
   coerceVersionCheckIntervalValue,
 } from '../../types/config.js';
@@ -92,9 +93,15 @@ export class ListConfigCommand extends BaseCommand<void, void> {
 
     if (rows.length === 0) {
       this.output.text('No configuration set');
-      return;
+    } else {
+      this.output.table(['KEY', 'VALUE'], rows);
     }
 
-    this.output.table(['KEY', 'VALUE'], rows);
+    this.output.text('');
+    this.output.text(
+      this.output.dim(
+        `Settable keys: ${SETTABLE_CONFIG_KEYS.join(', ')}. Run 'bb config set --help' for details.`
+      )
+    );
   }
 }

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -7,11 +7,17 @@
 
 import { Chalk } from 'chalk';
 
+export interface SeeAlsoEntry {
+  label: string;
+  url: string;
+}
+
 export interface HelpTextConfig {
   examples?: string[];
   validValues?: Record<string, string[]>;
   defaults?: Record<string, string>;
   envVars?: Record<string, string>;
+  seeAlso?: SeeAlsoEntry[];
 }
 
 interface ColorFns {
@@ -61,6 +67,15 @@ export function createHelpTextBuilder(noColor: boolean) {
       );
       for (const [name, desc] of Object.entries(config.envVars)) {
         sections.push(`  ${c.bold(name.padEnd(maxLen + 2))}${c.dim(desc)}`);
+      }
+    }
+
+    if (config.seeAlso?.length) {
+      if (sections.length) sections.push('');
+      sections.push(c.bold('See also:'));
+      const maxLen = Math.max(...config.seeAlso.map((e) => e.label.length));
+      for (const { label, url } of config.seeAlso) {
+        sections.push(`  ${c.bold(label.padEnd(maxLen + 2))}${c.cyan(url)}`);
       }
     }
 


### PR DESCRIPTION
## Summary

Closes #186.

A bundle of small surface fixes that together close the gap between *"I had to search"* and *"I clicked the obvious link."*

- **Changelog page in docs** — new `/help/changelog/` page with a curated summary of recent releases and a link to the full GitHub `CHANGELOG.md`. Surfaced in the sidebar under Help and from the README.
- **AI Agents guide linked from README** — the substantial `guides/ai-agents` page is now mentioned under the README's Docs section so it's discoverable from the npm/GitHub landing page.
- **`See also` in `--help`** — extends `buildHelpText()` with a new `seeAlso` config that renders a labeled list of doc URLs. Wired up on the global help, `bb pr list`, `bb pr create`, `bb config get`, and `bb config set`.
- **`bb config list` advertises settable keys** — appends `Settable keys: defaultWorkspace, skipVersionCheck, ...` after the values table so users discover what they can change without reading `bb config set --help` separately.
- **Stable anchor for `bb repo default-reviewers`** — explicit `<a id="bb-repo-default-reviewers">` before the heading so the cross-link from `pr/create-and-edit.mdx` survives any future Starlight slug-generator change.
- **Version-check nudge documented in quickstart** — explains what the upgrade message means and how to silence it (`bb config set skipVersionCheck true`). Also lists `prCreateIncludeDefaultReviewers` as a settable key in `config get`/`config set --help`.
- **`CLAUDE.md` uses a real markdown link** — replaces the Claude-specific `@AGENTS.md` syntax (which doesn't render as a link in generic markdown viewers) with `[AGENTS.md](AGENTS.md)` plus a "must read" pointer list to the most critical AGENTS.md sections.

## Test plan

- [x] `bun run lint` (tsc --noEmit) clean
- [x] `bun run format:check` clean
- [x] `bun test` — all 863 tests pass
- [ ] Verify the docs site renders the new `/help/changelog/` page and the locked `#bb-repo-default-reviewers` anchor resolves
- [ ] Verify `bb pr list --help`, `bb pr create --help`, `bb config set --help`, and `bb --help` show the new `See also:` section
- [ ] Verify `bb config list` prints the `Settable keys:` hint after the table