### PR TITLE
docs(onboarding): improve first-run experience

### DIFF
--- a/.changeset/improve-onboarding.md
+++ b/.changeset/improve-onboarding.md
@@ -1,0 +1,17 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+improve onboarding and first-run experience
+
+- README install section now leads with a Bun preflight (`bun --version`),
+  steps users through Bun + CLI install, and points out
+  `bb completion install` for tab completion.
+- README gains a short Environment Variables table covering `BB_USERNAME`,
+  `BB_API_TOKEN`, `DEBUG`, `NO_COLOR`, and `FORCE_COLOR`, with a link to the
+  full reference.
+- `bb` invoked with no subcommand now appends a one-line tip suggesting
+  `bb auth login` when no credentials are configured.
+- `bb auth login --help` now leads with the recommended method (OAuth),
+  notes the API-token path for CI, and surfaces the app-password
+  deprecation up front.

--- a/README.md
+++ b/README.md
@@ -47,15 +47,28 @@
 
 ## Install
 
-```bash
-npm install -g @pilatos/bitbucket-cli
-```
+> **Requires:** [Bun](https://bun.sh) runtime 1.0 or higher. The CLI is installed via npm but runs on the Bun runtime — Node.js is not supported.
 
-```bash
-bb --version
-```
+1. **Install Bun** (if `bun --version` fails):
 
-> **Requires:** [Bun](https://bun.sh) runtime 1.0 or higher. The CLI is installed via npm but runs on the Bun runtime — Node.js is not supported. Install Bun first: `curl -fsSL https://bun.sh/install | bash`
+   ```bash
+   curl -fsSL https://bun.sh/install | bash
+   ```
+
+2. **Install the CLI:**
+
+   ```bash
+   npm install -g @pilatos/bitbucket-cli
+   bb --version
+   ```
+
+3. **Tab completion** (optional, recommended):
+
+   ```bash
+   bb completion install
+   ```
+
+   Then restart your shell.
 
 ---
 
@@ -99,6 +112,20 @@ Full documentation: **[bitbucket-cli.paulvanderlei.com](https://bitbucket-cli.pa
 - Authenticate: `bb auth login`
 
 > **Note:** Bitbucket app passwords are [deprecated](https://bitbucket.org/blog/deprecating-app-passwords) (new ones can no longer be created). Use OAuth or API tokens instead.
+
+---
+
+## Environment Variables
+
+| Variable       | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `BB_USERNAME`  | Bitbucket username (fallback for `bb auth login`)          |
+| `BB_API_TOKEN` | Bitbucket API token (fallback for `bb auth login`; for CI) |
+| `DEBUG`        | Enable HTTP debug logging when set to `true`               |
+| `NO_COLOR`     | Disable color output when set                              |
+| `FORCE_COLOR`  | Force color output when set (and not `0`)                  |
+
+Full reference: [Environment variables](https://bitbucket-cli.paulvanderlei.com/reference/environment-variables/).
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import type { BaseCommand } from './core/base-command.js';
 import type { CommandContext } from './core/interfaces/commands.js';
 import type { IOutputService } from './core/interfaces/services.js';
 import type { VersionService } from './services/version.service.js';
+import type { IConfigService } from './core/interfaces/services.js';
 import { PR_STATES } from './types/pr.js';
 import { BBError, ErrorCode } from './types/errors.js';
 
@@ -317,6 +318,28 @@ cli
     } catch {
       // Silently ignore version check errors
     }
+
+    // Nudge unauthenticated users toward `bb auth login`. First-run users hit
+    // this path immediately after install, so it's the right moment to point
+    // at the next step.
+    try {
+      const configService = container.resolve<IConfigService>(
+        ServiceTokens.ConfigService
+      );
+      const config = await configService.getConfig();
+      const hasBasicAuth = Boolean(config.username && config.apiToken);
+      const hasOAuth = Boolean(
+        config.oauthAccessToken && config.oauthRefreshToken
+      );
+      if (!hasBasicAuth && !hasOAuth) {
+        output.text('');
+        output.text(
+          `Tip: Run '${output.highlight('bb auth login')}' to get started.`
+        );
+      }
+    } catch {
+      // Don't let an unreadable config disrupt the help screen.
+    }
   });
 
 // Auth commands
@@ -338,6 +361,12 @@ authCmd
   .option(
     '--client-secret <clientSecret>',
     'Custom OAuth consumer client secret'
+  )
+  .addHelpText(
+    'before',
+    '\nDefault: OAuth (browser-based, recommended).\n' +
+      'For CI/CD: API token via --app-password or BB_API_TOKEN env var.\n' +
+      'Note: Bitbucket app passwords are deprecated; use OAuth or an API token.\n'
   )
   .addHelpText(
     'after',


### PR DESCRIPTION
## Summary

Addresses the in-scope items from #183 — small, individually-minor onboarding frictions that compound for first-time users.

- **README — Install**: leads with a Bun preflight (`bun --version`), steps users through Bun + CLI install, and points out `bb completion install` for tab completion.
- **README — Environment Variables**: short table covering `BB_USERNAME`, `BB_API_TOKEN`, `DEBUG`, `NO_COLOR`, `FORCE_COLOR`, with a link to the full reference (CI users skim the README).
- **CLI no-args nudge**: when ` bb` is run with no subcommand and no credentials are configured, a one-line tip appears after the help/version banner suggesting \`bb auth login\`. Reads config tolerantly — any error is swallowed so help rendering is never disrupted.
- **`bb auth login --help`**: now leads with the recommended method (OAuth, browser-based), calls out the API-token path for CI (\`--app-password\` / \`BB_API_TOKEN\`), and surfaces the app-password deprecation up front.

Out of scope (left as follow-ups per the issue): \`bb doctor\` diagnostic command, \`bb init\` interactive wizard.

Closes #183

## Test plan

- [x] \`bun run lint\` (tsc --noEmit) — clean
- [x] \`bun run format:check\` — clean
- [x] \`bun test\` — 863 pass / 0 fail
- [ ] Manual: \`bb\` (no subcommand) on a fresh config shows the new \`bb auth login\` tip
- [ ] Manual: \`bb\` (no subcommand) with valid credentials does **not** show the tip
- [ ] Manual: \`bb auth login --help\` shows the new recommendation banner ahead of the existing examples