### PR TITLE
docs: surface `--json <fields>` and `--jq` throughout docs and CLI help

### DIFF
--- a/.changeset/surface-json-fields-and-jq.md
+++ b/.changeset/surface-json-fields-and-jq.md
@@ -1,0 +1,15 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+docs: surface `--json <fields>` projection and `--jq` filter throughout README, quickstart, per-command pages, and CLI help
+
+Adds the `--jq` flag to the README global options, a scripting callout in the
+quickstart, and `--json fields` / `--jq` examples to the highest-traffic command
+pages (`pr list`, `pr view`, `pr create`, `repo list`, `snippet list`). The
+`--jq` description in `bb --help` now includes an inline example, and the
+`reference/json-output.mdx` page gains a before/after shape comparison and three
+additional combined projection + jq patterns.
+
+No CLI behavior changes — `--json [fields]` and `--jq <expression>` already
+existed; this PR is purely about discoverability.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,21 @@ bb pr approve 42
 bb config set defaultWorkspace myworkspace
 ```
 
-**Global options:** `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`
+**Global options:** `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`
+
+### Scripting with `--json` and `--jq`
+
+`--json` accepts an optional comma-separated field list to project the output, and `--jq` filters the JSON in-process (no external `jq` binary required):
+
+```bash
+# Project to specific fields
+bb pr list --json id,title,state
+
+# Filter through built-in jq
+bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
+```
+
+See [JSON Output](https://bitbucket-cli.paulvanderlei.com/reference/json-output/) and the [Scripting guide](https://bitbucket-cli.paulvanderlei.com/guides/scripting/) for more.
 
 ---
 

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 Create and inspect pull requests.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
 
 ## `bb pr create`
 
@@ -60,6 +60,12 @@ bb pr create -t "Add new feature" \
 # Combine defaults + explicit additions (duplicates are de-duped)
 bb pr create -t "Add new feature" --default-reviewers \
   --reviewer "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
+
+# Capture the new PR's URL from JSON output for scripting
+bb pr create -t "Add new feature" --json --jq '.links.html.href'
+
+# Project the response to just the fields you need
+bb pr create -t "Add new feature" --json id,title,links.html.href
 ```
 
 ### Reviewers
@@ -172,6 +178,12 @@ bb pr list -w myworkspace -r myrepo
 # List with JSON output for scripting
 bb pr list --json
 
+# Project to specific fields (returns a flat array)
+bb pr list --json id,title,author.display_name
+
+# Filter with built-in --jq (no external jq binary needed)
+bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
+
 # List more results
 bb pr list --limit 50
 
@@ -226,4 +238,10 @@ bb pr view 42 -w myworkspace -r myrepo
 
 # Get PR details as JSON
 bb pr view 42 --json
+
+# Project to specific fields
+bb pr view 42 --json id,title,state,author.display_name
+
+# Extract just the web URL with built-in --jq
+bb pr view 42 --json --jq '.links.html.href'
 ```

--- a/docs/src/content/docs/commands/pr/index.mdx
+++ b/docs/src/content/docs/commands/pr/index.mdx
@@ -14,7 +14,9 @@ import {
 
 Manage pull requests in Bitbucket repositories.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+`--json` accepts an optional comma-separated field list to project the output, and `--jq` filters the JSON in-process — see [JSON Output](/reference/json-output/) for the full reference.
 
 ## Choose a Workflow <Badge text="Task-based" variant="note" />
 
@@ -70,15 +72,21 @@ Global options available on all PR commands: `--json`, `--no-color`, `-w, --work
 
 ## JSON for Automation
 
-Use `--json` when scripting:
+Use `--json` when scripting. The optional field list (`--json id,title,state`) projects to just those fields, and `--jq` filters in-process — no external `jq` binary required:
 
 ```bash
-# List open PR titles
-bb pr list --json | jq -r '.pullRequests[].title'
+# Project to specific fields (returns a flat array)
+bb pr list --json id,title,author.display_name
+
+# Filter with built-in --jq
+bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
+
+# Combine projection + filter (jq runs after projection)
+bb pr list --json id,title,state --jq '.[] | select(.state == "OPEN") | .title'
 
 # Grab a PR URL from view output
-bb pr view 42 --json | jq -r '.links.html.href'
+bb pr view 42 --json --jq '.links.html.href'
 
 # Capture diffstat totals
-bb pr diff 42 --stat --json | jq '{filesChanged, totalAdditions, totalDeletions}'
+bb pr diff 42 --stat --json --jq '{filesChanged, totalAdditions, totalDeletions}'
 ```

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -5,7 +5,7 @@ description: Complete reference for Bitbucket CLI repository commands. Learn to 
 
 Manage Bitbucket repositories.
 
-Global options available on all repo commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all repo commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
 
 ## `bb repo clone`
 
@@ -110,6 +110,12 @@ bb repo list -w myworkspace --limit 50
 
 # List with JSON output for scripting
 bb repo list -w myworkspace --json
+
+# Project to specific fields (returns a flat array)
+bb repo list -w myworkspace --json full_name,is_private,language
+
+# Filter with built-in --jq — print just public repo names
+bb repo list -w myworkspace --json --jq '.repositories[] | select(.is_private == false) | .full_name'
 ```
 
 ### Notes

--- a/docs/src/content/docs/commands/snippet.mdx
+++ b/docs/src/content/docs/commands/snippet.mdx
@@ -9,7 +9,7 @@ Snippet commands operate at **workspace** scope (no repo context required). Use
 `-w, --workspace <workspace>` or set a default with
 `bb config set defaultWorkspace <workspace>`.
 
-Global options available on all snippet commands: `--json`, `--no-color`, `-w, --workspace`.
+Global options available on all snippet commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
 
 ---
 
@@ -36,6 +36,12 @@ bb snippet list [options]
 bb snippet list
 bb snippet list --role owner
 bb snippet list --limit 50 --json
+
+# Project to specific fields (returns a flat array)
+bb snippet list --json id,title,is_private
+
+# Filter with built-in --jq — public snippets only
+bb snippet list --json --jq '.snippets[] | select(.is_private == false) | .title'
 ```
 
 ### Notes

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -140,6 +140,24 @@ bb pr create -<Tab>  # Shows available flags
 
 ---
 
+## Scripting with JSON
+
+Every command accepts `--json` for machine-readable output. You can project to a comma-separated field list and filter results through a built-in `jq` engine — no external `jq` binary required:
+
+```bash
+# Project to specific fields
+bb pr list --json id,title,state
+
+# Filter through built-in jq
+bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
+```
+
+<Aside type="tip">
+See [JSON Output](/reference/json-output/) for the full shape reference and the [Scripting guide](/guides/scripting/) for end-to-end automation patterns.
+</Aside>
+
+---
+
 ## Next Steps
 
 You're all set! Here's where to go next:
@@ -147,4 +165,5 @@ You're all set! Here's where to go next:
 - **[Command Reference](/commands/auth/)** - Full documentation for all commands
 - **[Repository Context](/guides/repository-context/)** - How the CLI detects your workspace/repo
 - **[Scripting & Automation](/guides/scripting/)** - Use bb in scripts and CI/CD
+- **[JSON Output Reference](/reference/json-output/)** - Field projection, `--jq` filtering, output shapes
 - **[Troubleshooting](/help/troubleshooting/)** - Common issues and solutions

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -63,6 +63,40 @@ bb pr list --json id,title,author.display_name
 ]
 ```
 
+#### Before / after: shape change after projection
+
+`bb pr list --json` returns the full envelope with metadata and a named array:
+
+```json
+{
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "state": "OPEN",
+  "count": 2,
+  "pullRequests": [
+    {
+      "id": 42,
+      "title": "Add feature",
+      "state": "OPEN",
+      "author": { "display_name": "Alice", "nickname": "alice" },
+      "links": { "html": { "href": "..." } }
+    },
+    { "id": 41, "title": "Fix bug", "state": "OPEN", "author": {...}, "links": {...} }
+  ]
+}
+```
+
+The same command with `--json id,title,state` drops the envelope and projects each item to a flat array of just those fields:
+
+```json
+[
+  { "id": 42, "title": "Add feature", "state": "OPEN" },
+  { "id": 41, "title": "Fix bug",     "state": "OPEN" }
+]
+```
+
+This is why `--jq` filters use `.[]` after projection (`.[] | select(...)`) but `.pullRequests[]` against the full envelope.
+
 ## Built-in jq (`--jq`)
 
 The `--jq <expression>` flag pipes the JSON output through an embedded jq
@@ -78,6 +112,18 @@ bb pr list --json id,title,state --jq '.[] | select(.state == "OPEN") | .title'
 
 # Aggregate
 bb pr list --json --jq '.count'
+
+# Project + format with jq string interpolation
+bb pr list --json id,title,author.display_name \
+  --jq '.[] | "\(.id)\t\(.["author.display_name"])\t\(.title)"'
+
+# Project a nested URL out of a single resource
+bb pr view 42 --json links.html.href --jq '.["links.html.href"]'
+
+# Top open PRs by author with built-in jq (no projection — full shape)
+bb pr list --json --jq '.pullRequests | group_by(.author.display_name)
+  | map({ author: .[0].author.display_name, count: length })
+  | sort_by(-.count)'
 ```
 
 **Rules:**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -273,7 +273,7 @@ cli
   )
   .option(
     '--jq <expression>',
-    'Filter the JSON output through a jq expression (requires --json)'
+    'Filter the JSON output through a jq expression — runs in-process via embedded jq, requires --json (e.g. \'.pullRequests[] | select(.state == "OPEN") | .title\')'
   )
   .option('--no-color', 'Disable color output')
   .option('-w, --workspace <workspace>', 'Specify workspace')


### PR DESCRIPTION
## Summary

Closes #180. The `--json [fields]` projection and `--jq <expression>` filter (shipped in v1.14.0) work well but are under-discovered — they live deep in `reference/json-output.mdx` and `guides/scripting.mdx` and are barely surfaced where users look first. This PR is a documentation-only pass to fix that.

- **README** (`README.md`) — `--jq` added to the global options list, plus a short "Scripting with --json and --jq" section with field-projection and built-in-jq examples linking to the docs.
- **Quickstart** (`docs/src/content/docs/getting-started/quickstart.mdx`) — new "Scripting with JSON" section after step-by-step setup with field projection / `--jq` examples and a tip callout pointing to `/reference/json-output/` and `/guides/scripting/`. Added a JSON Output Reference link to the Next Steps list.
- **CLI `--help`** (`src/cli.ts:276`) — expanded the `--jq` description with an inline example: `'.pullRequests[] | select(.state == "OPEN") | .title'`.
- **Per-command pages** — `--json fields` / `--jq` examples added to the highest-traffic pages: `pr list`, `pr view`, `pr create`, `repo list`, `snippet list`. Each page header now lists the global options as `--json [fields]`, `--jq <expression>` instead of bare `--json`. The PR index page's "JSON for Automation" section now leads with projection and built-in `--jq`.
- **Reference page** (`docs/src/content/docs/reference/json-output.mdx`) — added a before/after shape comparison showing how the wrapper envelope drops away after projection (and explaining why `.pullRequests[]` becomes `.[]`), plus three more combined patterns: jq string interpolation over a projected list, a single-resource dotted-path extraction, and a group-by aggregate.

No CLI behavior changes — `--json [fields]` and `--jq <expression>` already existed; this PR is purely about discoverability. Includes a patch changeset.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `bun test` — 863 passing, 0 failing
- [ ] Visually skim rendered docs site (Astro) once deployed