### PR TITLE
docs: add Recipes / Cookbook section with common workflows

### DIFF
--- a/.changeset/docs-recipes-cookbook.md
+++ b/.changeset/docs-recipes-cookbook.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+docs: add Recipes / Cookbook section with five common workflows — auto-merge when CI is green, bulk reviewer assignment, fork synchronization, reporting & analytics jq patterns, and a retry wrapper for transient failures. Closes #184.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -98,6 +98,18 @@ export default defineConfig({
           ],
         },
         {
+          label: "Recipes",
+          badge: { text: 'New', variant: 'tip' },
+          items: [
+            { label: "Overview", slug: "recipes" },
+            { label: "Auto-merge on green CI", slug: "recipes/auto-merge-on-ci-green" },
+            { label: "Bulk reviewer assignment", slug: "recipes/bulk-reviewer-assignment" },
+            { label: "Fork synchronization", slug: "recipes/fork-synchronization" },
+            { label: "Reporting & analytics", slug: "recipes/reporting-analytics" },
+            { label: "Retry wrapper", slug: "recipes/retry-wrapper" },
+          ],
+        },
+        {
           label: "Reference",
           items: [
             { label: "Environment Variables", slug: "reference/environment-variables" },

--- a/docs/src/content/docs/guides/cicd.mdx
+++ b/docs/src/content/docs/guides/cicd.mdx
@@ -343,6 +343,10 @@ jobs:
 
 ### Merge Approved PRs Automatically
 
+:::tip[Need CI-status gating too?]
+The script below merges as soon as any reviewer has approved. To also wait for **all CI checks to pass** before merging — the more common production pattern — see the [Auto-merge on green CI recipe](/recipes/auto-merge-on-ci-green/).
+:::
+
 ```bash
 #!/bin/bash
 # auto-merge.sh - Run in CI on schedule

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -217,6 +217,10 @@ done
 
 ## Example Scripts
 
+:::tip[Looking for a recipe?]
+For ready-to-copy workflows — auto-merge on green CI, bulk reviewer assignment, fork sync, jq analytics, and retry wrappers — see the [Recipes section](/recipes/).
+:::
+
 ### Batch PR Approval
 
 Approve all open PRs from a specific author:

--- a/docs/src/content/docs/recipes/auto-merge-on-ci-green.mdx
+++ b/docs/src/content/docs/recipes/auto-merge-on-ci-green.mdx
@@ -1,0 +1,157 @@
+---
+title: Auto-merge when CI is green
+description: Poll bb pr checks until all CI checks have passed, then merge the pull request — a safe, GitOps-friendly auto-merge pattern.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The "merge approved PRs" pattern in the [CI/CD guide](/guides/cicd/#merge-approved-prs-automatically) only checks `participants[].approved` — it ignores the actual CI status. This recipe adds the missing piece: poll [`bb pr checks`](/commands/pr/activity-and-checks/#bb-pr-checks) until every status is `SUCCESSFUL`, then merge.
+
+## What "all-green" means
+
+`bb pr checks <id> --json` returns a stable envelope. The relevant shape:
+
+```json
+{
+  "pullRequestId": 42,
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "summary": {
+    "successful": 3,
+    "failed": 0,
+    "pending": 0
+  },
+  "statuses": [
+    {
+      "key": "build",
+      "name": "Build & Test",
+      "state": "SUCCESSFUL",
+      "description": "Build #1234 succeeded",
+      "url": "https://ci.example.com/build/1234",
+      "updatedOn": "2025-01-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+Possible `state` values: `SUCCESSFUL`, `FAILED`, `INPROGRESS`, `STOPPED`.
+
+A PR is considered all-green when **at least one check exists** *and* every status is `SUCCESSFUL`. Treat zero checks as "not ready" — most teams want at least one passing build before auto-merge fires.
+
+### jq filter for all-green
+
+```bash
+# Returns "true" only if ≥1 check exists and every state is SUCCESSFUL
+bb pr checks 42 --json --jq '
+  (.statuses | length) > 0
+  and (.statuses | all(.state == "SUCCESSFUL"))
+'
+```
+
+If you want to also gate on approval:
+
+```bash
+bb pr view 42 --json --jq '
+  [.participants[] | select(.approved == true)] | length > 0
+'
+```
+
+## Recipe: poll-then-merge
+
+Drop this into a scheduled CI job or run locally. It polls a single PR until checks settle, then merges.
+
+```bash
+#!/bin/bash
+# auto-merge-on-green.sh - Wait for CI to pass, then merge.
+set -euo pipefail
+
+WORKSPACE="${WORKSPACE:-myworkspace}"
+REPO="${REPO:-myrepo}"
+PR_ID="${1:?Usage: $0 <pr-id>}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}"   # 30 minutes
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+
+while true; do
+  if [ "$(date +%s)" -gt "$deadline" ]; then
+    echo "Timed out waiting for PR #$PR_ID checks" >&2
+    exit 1
+  fi
+
+  checks_json=$(bb pr checks "$PR_ID" -w "$WORKSPACE" -r "$REPO" --json)
+
+  failed=$(echo "$checks_json" | jq '.summary.failed')
+  pending=$(echo "$checks_json" | jq '.summary.pending')
+  total=$(echo "$checks_json" | jq '.statuses | length')
+
+  if [ "$failed" -gt 0 ]; then
+    echo "PR #$PR_ID has $failed failed check(s); aborting." >&2
+    exit 1
+  fi
+
+  if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+    echo "All $total checks passed for PR #$PR_ID — merging."
+    break
+  fi
+
+  echo "PR #$PR_ID: $pending pending / $total total — sleeping ${POLL_INTERVAL}s"
+  sleep "$POLL_INTERVAL"
+done
+
+bb pr merge "$PR_ID" \
+  -w "$WORKSPACE" -r "$REPO" \
+  --strategy squash --close-source-branch
+```
+
+### Usage
+
+```bash
+WORKSPACE=myworkspace REPO=myrepo ./auto-merge-on-green.sh 42
+```
+
+## Recipe: scan all open PRs
+
+Run this on a schedule (cron, GitHub Actions cron trigger, Bitbucket Pipelines schedule). It merges every approved PR whose checks are all green and skips the rest silently.
+
+```bash
+#!/bin/bash
+# auto-merge-scan.sh - Merge every approved, all-green PR.
+set -euo pipefail
+
+WORKSPACE="${WORKSPACE:-myworkspace}"
+REPO="${REPO:-myrepo}"
+
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '.pullRequests[].id')
+
+for pr_id in $open_prs; do
+  approved=$(bb pr view "$pr_id" -w "$WORKSPACE" -r "$REPO" --json --jq '
+    [.participants[] | select(.approved == true)] | length > 0
+  ')
+  [ "$approved" = "true" ] || { echo "PR #$pr_id: not approved"; continue; }
+
+  green=$(bb pr checks "$pr_id" -w "$WORKSPACE" -r "$REPO" --json --jq '
+    (.statuses | length) > 0
+    and (.statuses | all(.state == "SUCCESSFUL"))
+  ')
+  [ "$green" = "true" ] || { echo "PR #$pr_id: checks not green"; continue; }
+
+  echo "Merging PR #$pr_id"
+  if ! bb pr merge "$pr_id" -w "$WORKSPACE" -r "$REPO" \
+        --strategy squash --close-source-branch; then
+    echo "PR #$pr_id: merge failed (conflicts or branch policy)" >&2
+  fi
+
+  sleep 2   # gentle pacing across many PRs
+done
+```
+
+<Aside type="caution">
+`bb pr merge` will still fail if the destination branch has *branch restrictions* (e.g., required reviewer counts, merge checks). The script above logs that and continues. Don't treat a passing CI job and an approval as sufficient policy on their own — Bitbucket's branch restrictions are the ultimate gate.
+</Aside>
+
+## Related
+
+- [`bb pr checks`](/commands/pr/activity-and-checks/#bb-pr-checks) — the underlying command
+- [`bb pr merge`](/commands/pr/review-and-merge/) — merge strategies and flags
+- [Scripting & Automation](/guides/scripting/) — JSON output, exit codes, jq patterns

--- a/docs/src/content/docs/recipes/bulk-reviewer-assignment.mdx
+++ b/docs/src/content/docs/recipes/bulk-reviewer-assignment.mdx
@@ -1,0 +1,100 @@
+---
+title: Bulk reviewer assignment
+description: Assign a list of reviewers across many open pull requests at once — useful for team rotations, onboarding, and review coverage policies.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The [Scripting guide](/guides/scripting/#example-scripts) covers batch *approval*, but assigning reviewers across many PRs in one pass is a separate workflow. This recipe handles team rotations, onboarding new reviewers, and enforcing minimum reviewer coverage on existing PRs.
+
+## Recipe: assign a fixed reviewer list
+
+The script below adds every username in `REVIEWERS` to every open PR in `WORKSPACE/REPO`. Existing reviewers are not removed; if a reviewer is already assigned, [`bb pr reviewers add`](/commands/pr/reviewers/#bb-pr-reviewers-add) is a no-op.
+
+```bash
+#!/bin/bash
+# bulk-assign-reviewers.sh
+set -euo pipefail
+
+WORKSPACE="${WORKSPACE:-myworkspace}"
+REPO="${REPO:-myrepo}"
+# Space-separated usernames (Bitbucket handles, not display names)
+REVIEWERS="${REVIEWERS:-alice bob charlie}"
+
+# Optional: skip PRs authored by a reviewer (you can't review your own PR)
+SKIP_SELF_REVIEW="${SKIP_SELF_REVIEW:-true}"
+
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json \
+  --jq '.pullRequests[] | "\(.id)\t\(.author.nickname // .author.display_name)"')
+
+while IFS=$'\t' read -r pr_id author; do
+  [ -n "$pr_id" ] || continue
+  echo "PR #$pr_id (by $author)"
+
+  for reviewer in $REVIEWERS; do
+    if [ "$SKIP_SELF_REVIEW" = "true" ] && [ "$reviewer" = "$author" ]; then
+      echo "  - skip $reviewer (PR author)"
+      continue
+    fi
+
+    if bb pr reviewers add "$pr_id" "$reviewer" \
+         -w "$WORKSPACE" -r "$REPO" >/dev/null 2>&1; then
+      echo "  + added $reviewer"
+    else
+      echo "  ! failed to add $reviewer (user not found, or perms)" >&2
+    fi
+
+    sleep 1   # rate-limit cushion
+  done
+done <<< "$open_prs"
+```
+
+### Usage
+
+```bash
+WORKSPACE=myworkspace REPO=myrepo \
+  REVIEWERS="alice bob charlie" \
+  ./bulk-assign-reviewers.sh
+```
+
+<Aside type="tip">
+`bb pr reviewers add` looks up the user via the Bitbucket API every call, which means each iteration costs one extra request. For very large workloads, fetch the UUIDs once and reuse them — see the next recipe.
+</Aside>
+
+## Recipe: rotation by hash bucket
+
+If you want each PR to get *one* reviewer from a pool — for a round-robin team rotation — hash the PR ID into the reviewer list. This produces a stable, reproducible assignment without a database.
+
+```bash
+#!/bin/bash
+# rotation-assign.sh
+set -euo pipefail
+
+WORKSPACE="${WORKSPACE:-myworkspace}"
+REPO="${REPO:-myrepo}"
+POOL=(alice bob charlie dana)
+
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '.pullRequests[].id')
+
+for pr_id in $open_prs; do
+  idx=$(( pr_id % ${#POOL[@]} ))
+  reviewer="${POOL[$idx]}"
+  echo "PR #$pr_id -> $reviewer"
+  bb pr reviewers add "$pr_id" "$reviewer" -w "$WORKSPACE" -r "$REPO" || true
+  sleep 1
+done
+```
+
+## Handling rate limits
+
+The CLI already retries 429 responses up to 3 times automatically. For *very* large bulk operations (hundreds of PRs × multiple reviewers), prefer:
+
+1. A larger sleep between PRs (`sleep 2` or `sleep 3`).
+2. Splitting the run across cron windows.
+3. Wrapping individual `bb` calls in the [retry wrapper](/recipes/retry-wrapper/) for the rare case of *persistent* 429s.
+
+## Related
+
+- [`bb pr reviewers add`](/commands/pr/reviewers/#bb-pr-reviewers-add) — single-PR command this recipe wraps
+- [`bb repo default-reviewers`](/commands/repo/) — repo-level defaults applied at PR creation time, often a better fit if you want this on *new* PRs only
+- [Reviewers reference](/commands/pr/reviewers/) — full subcommand reference

--- a/docs/src/content/docs/recipes/fork-synchronization.mdx
+++ b/docs/src/content/docs/recipes/fork-synchronization.mdx
@@ -1,0 +1,114 @@
+---
+title: Fork synchronization
+description: Keep a forked Bitbucket repository up to date with its upstream — fetch, rebase, and push using bb and git together.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Fork-based contribution is common in open-source workflows: you fork an upstream repo, work on a feature branch in your fork, and open a PR back to upstream. Forks drift quickly, so you need a routine sync. This recipe combines `bb repo view` to discover the upstream URL and plain `git` for the fetch/rebase/push.
+
+## Prerequisites
+
+- Your local clone is the **fork**, not the upstream.
+- `origin` points at your fork.
+- The upstream is reachable as a separate remote (we'll add it if missing).
+- You have permission to push to your fork's `main` (or whichever branch you want to keep in sync).
+
+## Recipe: one-shot sync
+
+```bash
+#!/bin/bash
+# sync-fork.sh - Keep a fork's main branch in sync with its upstream.
+set -euo pipefail
+
+UPSTREAM_WORKSPACE="${UPSTREAM_WORKSPACE:?set UPSTREAM_WORKSPACE}"
+UPSTREAM_REPO="${UPSTREAM_REPO:?set UPSTREAM_REPO}"
+BRANCH="${BRANCH:-main}"
+
+# 1. Look up the upstream clone URL via bb (HTTPS).
+upstream_url=$(bb repo view \
+  -w "$UPSTREAM_WORKSPACE" -r "$UPSTREAM_REPO" --json \
+  --jq '.links.clone[] | select(.name == "https") | .href')
+
+if [ -z "$upstream_url" ]; then
+  echo "Could not resolve HTTPS clone URL for $UPSTREAM_WORKSPACE/$UPSTREAM_REPO" >&2
+  exit 1
+fi
+
+# 2. Add the upstream remote if it isn't there.
+if ! git remote get-url upstream >/dev/null 2>&1; then
+  echo "Adding upstream remote: $upstream_url"
+  git remote add upstream "$upstream_url"
+else
+  git remote set-url upstream "$upstream_url"
+fi
+
+# 3. Fetch upstream and your fork.
+git fetch upstream "$BRANCH"
+git fetch origin "$BRANCH"
+
+# 4. Switch to the branch and rebase onto upstream.
+git checkout "$BRANCH"
+git rebase "upstream/$BRANCH"
+
+# 5. Push the rebased branch back to your fork.
+#    Use --force-with-lease, NOT --force, so concurrent fork-side pushes aren't clobbered.
+git push --force-with-lease origin "$BRANCH"
+
+echo "Fork '$BRANCH' synced with upstream $UPSTREAM_WORKSPACE/$UPSTREAM_REPO"
+```
+
+### Usage
+
+```bash
+UPSTREAM_WORKSPACE=acme \
+  UPSTREAM_REPO=widget \
+  BRANCH=main \
+  ./sync-fork.sh
+```
+
+<Aside type="caution">
+The script rebases instead of merging. If `main` on your fork has commits that aren't on upstream, the rebase will rewrite their hashes — anyone else pulling from your fork's `main` will see history change. Use a merge instead (`git merge upstream/$BRANCH`) if your fork shares `main` with collaborators.
+</Aside>
+
+## Recipe: sync, then open a PR for a feature branch
+
+A common follow-up: after syncing `main`, rebase your feature branch and open a cross-fork PR back to upstream. `bb pr create` accepts source branch + destination workspace/repo, so you can target the upstream from your fork.
+
+```bash
+#!/bin/bash
+# sync-and-pr.sh
+set -euo pipefail
+
+UPSTREAM_WORKSPACE="${UPSTREAM_WORKSPACE:?}"
+UPSTREAM_REPO="${UPSTREAM_REPO:?}"
+FORK_WORKSPACE="${FORK_WORKSPACE:?}"   # your workspace
+FORK_REPO="${FORK_REPO:?}"             # your fork's repo slug
+FEATURE_BRANCH="${FEATURE_BRANCH:?}"
+TITLE="${TITLE:-Update from $FEATURE_BRANCH}"
+
+# 1. Sync main, then rebase the feature branch onto fresh main.
+BRANCH=main ./sync-fork.sh
+
+git checkout "$FEATURE_BRANCH"
+git rebase main
+git push --force-with-lease origin "$FEATURE_BRANCH"
+
+# 2. Open a PR in the upstream repo, sourced from the fork's branch.
+#    Bitbucket Cloud uses cross-repo PRs by passing the source as a fork.
+bb pr create \
+  -w "$UPSTREAM_WORKSPACE" -r "$UPSTREAM_REPO" \
+  -t "$TITLE" \
+  -s "$FEATURE_BRANCH" \
+  -d main
+```
+
+<Aside type="tip">
+Cross-fork PR creation in Bitbucket Cloud requires that the upstream repo allows forks-as-sources and that you have read access. Check the Bitbucket UI once if `bb pr create` rejects the request — the error message from the API is forwarded as the CLI exit reason.
+</Aside>
+
+## Related
+
+- [Repository Context](/guides/repository-context/) — how `bb` resolves workspace/repo from your git remote
+- [`bb repo view`](/commands/repo/) — used here to fetch the upstream HTTPS clone URL
+- [`bb pr create`](/commands/pr/create-and-edit/) — for the second recipe's cross-fork PR

--- a/docs/src/content/docs/recipes/index.mdx
+++ b/docs/src/content/docs/recipes/index.mdx
@@ -1,0 +1,47 @@
+---
+title: Recipes
+description: Cookbook of common Bitbucket CLI workflows — auto-merge, bulk reviewer assignment, fork sync, jq analytics, and retry wrappers.
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+A cookbook of ready-to-copy workflows that combine `bb` commands with `jq` and shell to solve the patterns we see most often. Each recipe is a complete, runnable script — drop it into a CI job or a dotfile and adjust workspace/repo names.
+
+If you are looking for the *primitives* these recipes are built on, see the [Scripting & Automation guide](/guides/scripting/) and the [CI/CD Integration guide](/guides/cicd/).
+
+## Available recipes
+
+<CardGrid>
+  <LinkCard
+    title="Auto-merge when CI is green"
+    href="/recipes/auto-merge-on-ci-green/"
+    description="Poll bb pr checks until all checks pass, then merge — the GitOps-friendly way."
+  />
+  <LinkCard
+    title="Bulk reviewer assignment"
+    href="/recipes/bulk-reviewer-assignment/"
+    description="Assign a fixed list of reviewers across many open PRs (team rotations, onboarding)."
+  />
+  <LinkCard
+    title="Fork synchronization"
+    href="/recipes/fork-synchronization/"
+    description="Fetch upstream, rebase your fork, and push the result for fork-based contribution flows."
+  />
+  <LinkCard
+    title="Reporting & analytics with jq"
+    href="/recipes/reporting-analytics/"
+    description="Count PRs per state, sum diff sizes, group by author, and export to CSV."
+  />
+  <LinkCard
+    title="Retry wrapper for transient failures"
+    href="/recipes/retry-wrapper/"
+    description="A shell wrapper that retries bb invocations with exponential backoff for persistent flakes."
+  />
+</CardGrid>
+
+## Conventions used in these recipes
+
+- All recipes assume `bb auth login` has already succeeded (interactively or via `BB_USERNAME` / `BB_API_TOKEN` env vars).
+- `WORKSPACE` and `REPO` are referenced as shell variables — set them at the top of the script or export them from your CI environment.
+- The CLI already retries transient HTTP 429 / 5xx errors up to 3 times with exponential backoff. The [retry wrapper recipe](/recipes/retry-wrapper/) is only for failures that persist past that.
+- `--json` output shapes are stable; see the [JSON Output reference](/reference/json-output/) for the envelope structure of list-style commands.

--- a/docs/src/content/docs/recipes/reporting-analytics.mdx
+++ b/docs/src/content/docs/recipes/reporting-analytics.mdx
@@ -1,0 +1,166 @@
+---
+title: Reporting & analytics with jq
+description: Count PRs per state, sum diff sizes, group by author, and export to CSV — practical jq filters built on bb pr list --json.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The [Scripting guide](/guides/scripting/#common-jq-patterns) lists three starter jq patterns. This recipe expands that into a small analytics toolkit you can paste into a weekly report job.
+
+All recipes assume:
+
+```bash
+WORKSPACE=myworkspace
+REPO=myrepo
+```
+
+## Count PRs per state
+
+`bb pr list` only returns one state at a time, so to count across all states fetch each separately and combine:
+
+```bash
+for state in OPEN MERGED DECLINED SUPERSEDED; do
+  count=$(bb pr list -w "$WORKSPACE" -r "$REPO" -s "$state" --json --jq '.count')
+  printf "%-12s %s\n" "$state" "$count"
+done
+```
+
+Sample output:
+
+```
+OPEN         12
+MERGED       340
+DECLINED     8
+SUPERSEDED   2
+```
+
+If you only need a snapshot of currently open PRs grouped by state attribute, a one-liner suffices:
+
+```bash
+bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '
+  .pullRequests
+  | group_by(.state)
+  | map({ state: .[0].state, count: length })
+'
+```
+
+## Sum additions and deletions across PRs
+
+`pr list` does not include diff stats — they come from `bb pr diff <id> --json --stat` (or equivalent). For aggregate volume, walk every PR and sum:
+
+```bash
+#!/bin/bash
+total_added=0
+total_deleted=0
+
+for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --json \
+                 --jq '.pullRequests[].id'); do
+  stats=$(bb pr diff "$pr_id" -w "$WORKSPACE" -r "$REPO" --stat --json)
+  added=$(echo "$stats" | jq '[.files[].additions] | add // 0')
+  deleted=$(echo "$stats" | jq '[.files[].deletions] | add // 0')
+  total_added=$(( total_added + added ))
+  total_deleted=$(( total_deleted + deleted ))
+  sleep 1
+done
+
+echo "Total added: $total_added"
+echo "Total deleted: $total_deleted"
+```
+
+<Aside type="tip">
+This makes one HTTP request per PR. For a few dozen PRs it's fine; for hundreds, schedule it overnight or scope to a date range with `--jq '... | select(.updated_on >= "2025-01-01")'` before the inner loop.
+</Aside>
+
+## Group by author with counts
+
+```bash
+bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '
+  .pullRequests
+  | group_by(.author.nickname // .author.display_name)
+  | map({
+      author: (.[0].author.nickname // .[0].author.display_name),
+      count: length,
+      ids: [.[].id]
+    })
+  | sort_by(-.count)
+'
+```
+
+This sorts authors by descending PR count and includes the IDs for drilldown.
+
+## Top reviewers across merged PRs
+
+Useful for identifying review load. Iterates over merged PRs and counts approvals per reviewer:
+
+```bash
+bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --limit 200 --json --jq '
+  [
+    .pullRequests[].participants[]
+    | select(.approved == true)
+    | .user.nickname // .user.display_name
+  ]
+  | group_by(.)
+  | map({ reviewer: .[0], approvals: length })
+  | sort_by(-.approvals)
+'
+```
+
+## CSV export
+
+To export an open-PRs report into a spreadsheet, use jq's `@csv`:
+
+```bash
+bb pr list -w "$WORKSPACE" -r "$REPO" --limit 500 --json --jq '
+  ["id","title","author","state","created_on","source","destination"],
+  (
+    .pullRequests[]
+    | [
+        .id,
+        .title,
+        (.author.nickname // .author.display_name),
+        .state,
+        .created_on,
+        .source.branch.name,
+        .destination.branch.name
+      ]
+  )
+  | @csv
+' > prs.csv
+
+head -3 prs.csv
+```
+
+Sample output:
+
+```
+"id","title","author","state","created_on","source","destination"
+42,"Add login button","alice","OPEN","2025-01-04T09:11:00Z","feat/login","main"
+43,"Fix typo in README","bob","OPEN","2025-01-04T11:22:00Z","fix/typo","main"
+```
+
+## PR cycle time (created → merged)
+
+```bash
+bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --limit 100 --json --jq '
+  [
+    .pullRequests[]
+    | {
+        id,
+        title,
+        hours: (
+          (.updated_on  | fromdateiso8601)
+          - (.created_on | fromdateiso8601)
+        ) / 3600
+      }
+  ]
+  | sort_by(.hours)
+'
+```
+
+`updated_on` on a merged PR approximates the merge time; for exact merge time, walk `bb pr activity <id>` and find the merge event.
+
+## Related
+
+- [Scripting & Automation guide](/guides/scripting/) — JSON output, exit codes, primitive jq patterns
+- [JSON Output reference](/reference/json-output/) — the envelope shape for list-style commands
+- [`bb pr list`](/commands/pr/) — flags like `-s`, `--limit`, `--json`, `--jq`

--- a/docs/src/content/docs/recipes/retry-wrapper.mdx
+++ b/docs/src/content/docs/recipes/retry-wrapper.mdx
@@ -1,0 +1,157 @@
+---
+title: Retry wrapper for transient failures
+description: A small shell wrapper that retries bb invocations with exponential backoff when the built-in retry isn't enough.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The CLI already retries HTTP 429, 502, 503, and 504 responses up to **3 times** with exponential backoff — see [Built-in Resilience](/guides/scripting/#built-in-resilience). For nearly every workflow that's enough.
+
+This recipe is for the cases where it isn't:
+
+- A long-running batch job that hits the rate-limit envelope and needs *more* than 3 retries.
+- Network flakes where DNS or TLS itself misbehaves and never reaches the CLI's retry layer.
+- A dependent system (CI runner, proxy) that occasionally rejects requests.
+
+## What you'll see when retry kicks in
+
+The built-in retry is silent on success. On the third and final failure you'll see an error like:
+
+```
+Error: API request failed: 429 Too Many Requests
+```
+
+If you also pass `--json`, the structured error shape on stderr looks like:
+
+```json
+{
+  "error": {
+    "code": "API_ERROR",
+    "message": "API request failed: 429 Too Many Requests"
+  }
+}
+```
+
+That JSON shape is stable — see the [Error Codes reference](/reference/error-codes/). If you see this and the operation is idempotent, retrying is safe.
+
+<Aside type="caution">
+**Don't blanket-retry mutating commands.** `bb pr create`, `bb pr merge`, `bb pr approve`, and similar can succeed *server-side* even when the response read fails. A retry might create a duplicate PR or re-approve. Limit the wrapper below to read-only commands or commands you've made idempotent (e.g., check existence before creating).
+</Aside>
+
+## Recipe: bb-with-retry wrapper
+
+```bash
+#!/bin/bash
+# bb-retry.sh - Run a bb command with exponential backoff.
+#
+# Usage:
+#   ./bb-retry.sh pr list -w myworkspace -r myrepo --json
+#
+# Env vars:
+#   MAX_ATTEMPTS    default 5
+#   INITIAL_DELAY   default 2 (seconds)
+#   MAX_DELAY       default 60 (seconds)
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+INITIAL_DELAY="${INITIAL_DELAY:-2}"
+MAX_DELAY="${MAX_DELAY:-60}"
+
+attempt=1
+delay="$INITIAL_DELAY"
+
+while true; do
+  if bb "$@"; then
+    exit 0
+  fi
+  exit_code=$?
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "bb $* failed after $attempt attempts (exit $exit_code)" >&2
+    exit "$exit_code"
+  fi
+
+  # Add jitter: ±25% of the current delay
+  jitter=$(( RANDOM % (delay / 2 + 1) - delay / 4 ))
+  sleep_time=$(( delay + jitter ))
+  [ "$sleep_time" -lt 1 ] && sleep_time=1
+
+  echo "bb $* failed (exit $exit_code); retry $((attempt + 1))/$MAX_ATTEMPTS in ${sleep_time}s" >&2
+  sleep "$sleep_time"
+
+  attempt=$(( attempt + 1 ))
+  delay=$(( delay * 2 ))
+  [ "$delay" -gt "$MAX_DELAY" ] && delay="$MAX_DELAY"
+done
+```
+
+### Usage
+
+```bash
+chmod +x bb-retry.sh
+
+# Read-only: safe to retry freely.
+./bb-retry.sh pr list -w myworkspace -r myrepo --json > prs.json
+
+# Tune the cap for big jobs.
+MAX_ATTEMPTS=10 INITIAL_DELAY=5 ./bb-retry.sh pr view 42 --json
+```
+
+## Recipe: retry only on a specific error code
+
+If you only want to retry on rate-limit errors and *not* on, say, authentication failures, parse the structured error:
+
+```bash
+#!/bin/bash
+# bb-retry-on-rate-limit.sh
+set -euo pipefail
+
+MAX_ATTEMPTS=5
+attempt=1
+delay=2
+
+while true; do
+  err_file=$(mktemp)
+  if bb "$@" 2> "$err_file"; then
+    rm -f "$err_file"
+    exit 0
+  fi
+
+  err_msg=$(cat "$err_file")
+  rm -f "$err_file"
+
+  # Retry only on rate-limit / transient gateway errors.
+  if echo "$err_msg" | grep -qE '429|502|503|504'; then
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+      echo "$err_msg" >&2
+      exit 1
+    fi
+    echo "Transient error, retrying in ${delay}s..." >&2
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+    attempt=$(( attempt + 1 ))
+    continue
+  fi
+
+  # Non-transient: fail fast.
+  echo "$err_msg" >&2
+  exit 1
+done
+```
+
+## When *not* to write your own retry
+
+The wrappers above are the right answer when the built-in retry has been exhausted. They are *not* the right answer for:
+
+- **Auth failures** (`Authentication required`) — retrying won't help; fix the credentials.
+- **404 / not-found errors** — these don't get more found over time.
+- **Validation errors** (`requireOption()` failures) — these are bugs in your script, not transient.
+
+The CLI exits with code `1` for all of these, same as for transient errors. Use the JSON error shape on stderr (`.error.code`) to distinguish them rather than retrying everything.
+
+## Related
+
+- [Scripting & Automation: Built-in Resilience](/guides/scripting/#built-in-resilience)
+- [Error Codes reference](/reference/error-codes/) — the stable `.error.code` values to branch on
+- [JSON Output reference](/reference/json-output/) — the success/error envelope shapes


### PR DESCRIPTION
## Summary

Adds a new top-level **Recipes** section to the documentation site with five ready-to-copy workflows that users previously had to assemble from primitives (closes #184):

- **[Auto-merge when CI is green](docs/src/content/docs/recipes/auto-merge-on-ci-green.mdx)** — the priority recipe from the issue. Polls `bb pr checks` until all statuses are `SUCCESSFUL`, then merges. Includes the JSON shape of `bb pr checks` output and an `all-green` jq filter.
- **[Bulk reviewer assignment](docs/src/content/docs/recipes/bulk-reviewer-assignment.mdx)** — assigns a list of usernames across all open PRs (skips self-review by default). Plus a hash-bucket rotation variant.
- **[Fork synchronization](docs/src/content/docs/recipes/fork-synchronization.mdx)** — uses `bb repo view` to discover the upstream HTTPS clone URL, then drives `git fetch` / `rebase` / `push --force-with-lease`. Plus a follow-up recipe for opening a cross-fork PR.
- **[Reporting & analytics with jq](docs/src/content/docs/recipes/reporting-analytics.mdx)** — counts PRs per state, sums additions/deletions, groups by author, finds top reviewers, exports CSV, and computes cycle time.
- **[Retry wrapper for transient failures](docs/src/content/docs/recipes/retry-wrapper.mdx)** — explains what the built-in retry looks like to the user, then provides a `bb-retry.sh` wrapper with exponential backoff + jitter and a code-aware variant. Calls out the danger of blanket-retrying mutating commands.

The issue mentioned two structure options. I went with the **new top-level section** (per the issue's recommendation that it's more discoverable and lets recipes link in from command docs). Existing Scripting and CI/CD guides now link into the relevant recipes.

## Test plan

- [x] `bun run docs:build` — all 6 new pages generate cleanly (33 total pages built)
- [x] `bun run format:check` — clean
- [x] `bun run lint` — clean
- [x] Sidebar registered in `docs/astro.config.mjs` with a "New" badge
- [x] Cross-links added from `guides/cicd.mdx` (auto-merge tip) and `guides/scripting.mdx` (Recipes section pointer)
- [x] Changeset added (`patch`)
- [ ] Manual eyes-on review of the auto-merge recipe — make sure the `bb pr checks --json` envelope shape documented matches the actual command output (verified against `src/commands/pr/checks.command.ts:57-65`)

Closes #184