### PR TITLE
feat(errors): make error messages actionable with next-step guidance

### DIFF
--- a/.changeset/actionable-error-messages.md
+++ b/.changeset/actionable-error-messages.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Make error messages actionable with next-step guidance: auth errors mention both `bb auth login` and the `BB_USERNAME`/`BB_API_TOKEN` env vars; `CONTEXT_REPO_NOT_FOUND` distinguishes between not being in a git repo, missing remote, and non-Bitbucket remotes; 404s on `bb pr view`, `bb repo view`, and `bb snippet view` now name the missing resource; network errors point to `DEBUG=true` and proxy/CA troubleshooting; `bb config get` for hidden keys explains why and points at `bb config list`; `bb pr create` validation includes a `--help` footer; `bb auth login` distinguishes invalid credentials from rate limiting; `bb pr comment` lists the three valid mode combinations.

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { UsersApi } from '../../generated/api.js';
 import type { OAuthService } from '../../services/oauth.service.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import { APIError, BBError, ErrorCode } from '../../types/errors.js';
 
 export interface LoginOptions {
   username?: string;
@@ -133,10 +133,34 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
       );
     } catch (error) {
       await this.credentialStore.clearCredentials();
-      throw new BBError({
-        code: ErrorCode.AUTH_INVALID,
-        message: `Authentication failed: ${error instanceof Error ? error.message : String(error)}`,
-      });
+      throw this.wrapLoginError(error);
     }
+  }
+
+  private wrapLoginError(error: unknown): BBError {
+    const detail = error instanceof Error ? error.message : String(error);
+
+    if (error instanceof APIError) {
+      if (error.statusCode === 401 || error.statusCode === 403) {
+        return new BBError({
+          code: ErrorCode.AUTH_INVALID,
+          message: `Invalid username or token: ${detail}. Verify your Bitbucket username and that the API token is current and has the required scopes.`,
+          cause: error,
+        });
+      }
+      if (error.statusCode === 429) {
+        return new BBError({
+          code: ErrorCode.API_RATE_LIMITED,
+          message: `Bitbucket API rate-limited: ${detail}. Wait a moment and try again.`,
+          cause: error,
+        });
+      }
+    }
+
+    return new BBError({
+      code: ErrorCode.AUTH_INVALID,
+      message: `Authentication failed: ${detail}`,
+      cause: error instanceof Error ? error : undefined,
+    });
   }
 }

--- a/src/commands/auth/token.command.ts
+++ b/src/commands/auth/token.command.ts
@@ -43,7 +43,8 @@ export class TokenCommand extends BaseCommand<void, void> {
     if (!credentials.username || !credentials.apiToken) {
       throw new BBError({
         code: ErrorCode.AUTH_REQUIRED,
-        message: "Not authenticated. Run 'bb auth login' first.",
+        message:
+          "Not authenticated. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.",
       });
     }
 

--- a/src/commands/config/get.command.ts
+++ b/src/commands/config/get.command.ts
@@ -38,7 +38,9 @@ export class GetConfigCommand extends BaseCommand<{ key: string }, void> {
     if (GetConfigCommand.HIDDEN_KEYS.includes(key)) {
       throw new BBError({
         code: ErrorCode.CONFIG_INVALID_KEY,
-        message: `Cannot display '${key}' - use 'bb auth token' to get authentication credentials`,
+        message:
+          `Cannot display '${key}' - it is part of your authentication credentials, not config. ` +
+          `Use 'bb auth token' to retrieve credentials, or run 'bb config list' to see readable keys.`,
         context: { key },
       });
     }

--- a/src/commands/pr/comment.command.ts
+++ b/src/commands/pr/comment.command.ts
@@ -41,18 +41,30 @@ export class CommentPRCommand extends BaseCommand<
     context: CommandContext
   ): Promise<void> {
     // Validate inline flag combinations
+    const validModesNote =
+      'Valid modes: (1) general comment (no flags); (2) file-level comment (--file + --line-to or --line-from); (3) inline comment with line range (--file + --line-from + --line-to).';
+
     if ((options.lineTo || options.lineFrom) && !options.file) {
       throw new BBError({
         code: ErrorCode.VALIDATION_REQUIRED,
-        message: '--file is required when using --line-to or --line-from',
+        message: this.appendHelpHint(
+          `--file is required when using --line-to or --line-from. ${validModesNote}`
+        ),
+        context: {
+          validModes: ['general', 'file', 'inline'],
+        },
       });
     }
 
     if (options.file && !options.lineTo && !options.lineFrom) {
       throw new BBError({
         code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          'At least one of --line-to or --line-from is required when using --file',
+        message: this.appendHelpHint(
+          `At least one of --line-to or --line-from is required when using --file. ${validModesNote}`
+        ),
+        context: {
+          validModes: ['general', 'file', 'inline'],
+        },
       });
     }
 

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -59,7 +59,9 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
     if (!options.title) {
       throw new BBError({
         code: ErrorCode.VALIDATION_REQUIRED,
-        message: 'Pull request title is required. Use --title option.',
+        message: this.appendHelpHint(
+          'Pull request title is required. Use --title option.'
+        ),
       });
     }
 

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi, Pullrequest } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
 
 export interface ViewPROptions extends GlobalOptions {}
 
@@ -39,13 +40,17 @@ export class ViewPRCommand extends BaseCommand<
 
     const prId = this.parseIntOption(options.id, 'id');
 
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-        }
+    const response = await this.pullrequestsApi
+      .repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pullRequestId: prId,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Pull request #${prId} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+        )
       );
 
     const pr = response.data;

--- a/src/commands/repo/view.command.ts
+++ b/src/commands/repo/view.command.ts
@@ -11,6 +11,7 @@ import type {
 import type { RepositoriesApi } from '../../generated/api.js';
 import { getCloneLinks, getLinkHref } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
 
 export interface ViewRepoOptions extends GlobalOptions {
   repository?: string;
@@ -47,11 +48,17 @@ export class ViewRepoCommand extends BaseCommand<ViewRepoOptions, void> {
     const repoContext =
       await this.contextService.requireRepoContext(contextOptions);
 
-    const response =
-      await this.repositoriesApi.repositoriesWorkspaceRepoSlugGet({
+    const response = await this.repositoriesApi
+      .repositoriesWorkspaceRepoSlugGet({
         workspace: repoContext.workspace,
         repoSlug: repoContext.repoSlug,
-      });
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Repository ${repoContext.workspace}/${repoContext.repoSlug} not found.`
+        )
+      );
 
     const repo = response.data;
 

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -14,7 +14,11 @@ import {
   getUserDisplayName,
   getLinkHref,
 } from '../../services/response-parsers.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
+import {
+  BBError,
+  ErrorCode,
+  rethrowWithNotFoundContext,
+} from '../../types/errors.js';
 
 export interface ViewSnippetOptions {
   workspace?: string;
@@ -48,10 +52,17 @@ export class ViewSnippetCommand extends BaseCommand<
       options.workspace ?? context.globalOptions.workspace
     );
 
-    const response = await this.snippetsApi.snippetsWorkspaceEncodedIdGet({
-      workspace,
-      encodedId: options.id,
-    });
+    const response = await this.snippetsApi
+      .snippetsWorkspaceEncodedIdGet({
+        workspace,
+        encodedId: options.id,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Snippet ${options.id} not found in workspace ${workspace}.`
+        )
+      );
 
     const snippet = response.data as Snippet & Record<string, unknown>;
     const fileNames = this.extractFileNames(snippet);

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -93,12 +93,40 @@ export abstract class BaseCommand<
     message?: string
   ): T {
     if (value === undefined || value === null || value === '') {
+      const baseMessage = message || `Option --${name} is required`;
       throw new BBError({
         code: ErrorCode.VALIDATION_REQUIRED,
-        message: message || `Option --${name} is required`,
+        message: this.appendHelpHint(baseMessage),
       });
     }
     return value;
+  }
+
+  /**
+   * Append a `--help` footer pointing back at the active command path so
+   * users can discover the full option list when validation fails.
+   */
+  protected appendHelpHint(message: string): string {
+    const commandPath = this.getCommandPath();
+    const target = commandPath ? `bb ${commandPath} --help` : 'bb --help';
+    return `${message} Run \`${target}\` for usage.`;
+  }
+
+  private getCommandPath(): string {
+    const argv = process.argv.slice(2);
+    const tokens: string[] = [];
+    for (const arg of argv) {
+      if (arg.startsWith('-')) break;
+      tokens.push(arg);
+    }
+    // The trailing token is typically a positional argument value (e.g. PR id);
+    // include only the leading subcommands. The simplest reliable signal is to
+    // stop once we have the first two tokens, matching the `bb <group> <cmd>`
+    // shape used throughout the CLI. Fall back to whatever we have.
+    if (tokens.length >= 2) {
+      return `${tokens[0]} ${tokens[1]}`;
+    }
+    return tokens.join(' ');
   }
 
   /**

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -205,7 +205,8 @@ export function createApiClient(
       } else if (error.request) {
         throw new BBError({
           code: ErrorCode.NETWORK_ERROR,
-          message: 'Network error: Unable to reach Bitbucket API',
+          message:
+            "Network error: Unable to reach Bitbucket API. Run with DEBUG=true for details. If you're behind a proxy or using a custom CA, check your environment.",
           cause: error,
         });
       } else {

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -195,7 +195,7 @@ export class ConfigService implements IConfigService, ICredentialStore {
       throw new BBError({
         code: ErrorCode.AUTH_REQUIRED,
         message:
-          "Authentication required. Run 'bb auth login' to authenticate.",
+          "Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.",
       });
     }
 
@@ -258,7 +258,7 @@ export class ConfigService implements IConfigService, ICredentialStore {
       throw new BBError({
         code: ErrorCode.AUTH_REQUIRED,
         message:
-          "OAuth authentication required. Run 'bb auth login' to authenticate.",
+          "OAuth authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.",
       });
     }
 

--- a/src/services/context.service.ts
+++ b/src/services/context.service.ts
@@ -10,6 +10,17 @@ import type {
 import { BBError, ErrorCode } from '../types/errors.js';
 import type { RepoContext, GlobalOptions } from '../types/config.js';
 
+type RepoContextFailureReason =
+  | 'not_a_git_repo'
+  | 'no_remote'
+  | 'remote_not_bitbucket';
+
+interface GitRepoContextResult {
+  context: RepoContext | null;
+  reason: RepoContextFailureReason | null;
+  remoteUrl: string | null;
+}
+
 export class ContextService implements IContextService {
   constructor(
     private readonly gitService: IGitService,
@@ -51,18 +62,28 @@ export class ContextService implements IContextService {
    * Get repository context from current git repository
    */
   public async getRepoContextFromGit(): Promise<RepoContext | null> {
+    const result = await this.inspectGitRepoContext();
+    return result.context;
+  }
+
+  private async inspectGitRepoContext(): Promise<GitRepoContextResult> {
     const isRepo = await this.gitService.isRepository();
     if (!isRepo) {
-      return null;
+      return { context: null, reason: 'not_a_git_repo', remoteUrl: null };
     }
 
+    let remoteUrl: string;
     try {
-      const remoteUrl = await this.gitService.getRemoteUrl();
-      return this.parseRemoteUrl(remoteUrl);
+      remoteUrl = await this.gitService.getRemoteUrl();
     } catch {
-      // No remote configured - that's okay, just return null
-      return null;
+      return { context: null, reason: 'no_remote', remoteUrl: null };
     }
+
+    const context = this.parseRemoteUrl(remoteUrl);
+    if (!context) {
+      return { context: null, reason: 'remote_not_bitbucket', remoteUrl };
+    }
+    return { context, reason: null, remoteUrl };
   }
 
   /**
@@ -74,22 +95,35 @@ export class ContextService implements IContextService {
   public async getRepoContext(
     options: GlobalOptions
   ): Promise<RepoContext | null> {
+    const result = await this.resolveRepoContext(options);
+    return result.context;
+  }
+
+  private async resolveRepoContext(
+    options: GlobalOptions
+  ): Promise<GitRepoContextResult> {
     // If both workspace and repo are provided via options, use them
     if (options.workspace && options.repo) {
       return {
-        workspace: options.workspace,
-        repoSlug: options.repo,
+        context: { workspace: options.workspace, repoSlug: options.repo },
+        reason: null,
+        remoteUrl: null,
       };
     }
 
     // Try to get from current git repo
-    const gitContext = await this.getRepoContextFromGit();
+    const gitResult = await this.inspectGitRepoContext();
+    const gitContext = gitResult.context;
 
     // If only workspace is provided, use it with git-detected repo
     if (options.workspace && gitContext) {
       return {
-        workspace: options.workspace,
-        repoSlug: gitContext.repoSlug,
+        context: {
+          workspace: options.workspace,
+          repoSlug: gitContext.repoSlug,
+        },
+        reason: null,
+        remoteUrl: gitResult.remoteUrl,
       };
     }
 
@@ -99,14 +133,14 @@ export class ContextService implements IContextService {
       const workspace = gitContext?.workspace || config.defaultWorkspace;
       if (workspace) {
         return {
-          workspace,
-          repoSlug: options.repo,
+          context: { workspace, repoSlug: options.repo },
+          reason: null,
+          remoteUrl: gitResult.remoteUrl,
         };
       }
     }
 
-    // Fall back to git context
-    return gitContext;
+    return gitResult;
   }
 
   /**
@@ -115,18 +149,38 @@ export class ContextService implements IContextService {
   public async requireRepoContext(
     options: GlobalOptions
   ): Promise<RepoContext> {
-    const context = await this.getRepoContext(options);
+    const result = await this.resolveRepoContext(options);
 
-    if (!context) {
+    if (!result.context) {
       throw new BBError({
         code: ErrorCode.CONTEXT_REPO_NOT_FOUND,
-        message:
-          'Could not determine repository. Use --workspace and --repo options, ' +
-          'or run this command from within a Bitbucket repository.',
+        message: this.buildRepoNotFoundMessage(result.reason, result.remoteUrl),
+        context: {
+          reason: result.reason ?? 'unknown',
+          ...(result.remoteUrl ? { remoteUrl: result.remoteUrl } : {}),
+        },
       });
     }
 
-    return context;
+    return result.context;
+  }
+
+  private buildRepoNotFoundMessage(
+    reason: RepoContextFailureReason | null,
+    remoteUrl: string | null
+  ): string {
+    const fallback =
+      'Use --workspace and --repo options, or run this command from within a Bitbucket repository.';
+    switch (reason) {
+      case 'not_a_git_repo':
+        return `Not in a git repository. ${fallback}`;
+      case 'no_remote':
+        return `Git repository has no remote configured. Add a Bitbucket remote with \`git remote add origin <url>\`, or ${fallback.charAt(0).toLowerCase()}${fallback.slice(1)}`;
+      case 'remote_not_bitbucket':
+        return `Remote ${remoteUrl ? `'${remoteUrl}' ` : ''}is not a Bitbucket URL. ${fallback}`;
+      default:
+        return `Could not determine repository. ${fallback}`;
+    }
   }
 
   /**

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -121,6 +121,20 @@ export class APIError extends BBError {
   }
 }
 
+/**
+ * If `error` is a 404 APIError, replace its message with a contextual one
+ * that names the missing resource. Other errors are rethrown unchanged.
+ */
+export function rethrowWithNotFoundContext(
+  error: unknown,
+  notFoundMessage: string
+): never {
+  if (error instanceof APIError && error.statusCode === 404) {
+    throw new APIError(notFoundMessage, 404, error.response, error.context);
+  }
+  throw error;
+}
+
 export class GitError extends BBError {
   public readonly command: string;
   public readonly exitCode: number;

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -2598,9 +2598,10 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_REQUIRED);
-      expect((error as BBError).message).toBe(
+      expect((error as BBError).message).toContain(
         '--file is required when using --line-to or --line-from'
       );
+      expect((error as BBError).message).toContain('Valid modes:');
     }
   });
 
@@ -2627,9 +2628,10 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_REQUIRED);
-      expect((error as BBError).message).toBe(
+      expect((error as BBError).message).toContain(
         '--file is required when using --line-to or --line-from'
       );
+      expect((error as BBError).message).toContain('Valid modes:');
     }
   });
 
@@ -2656,9 +2658,10 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_REQUIRED);
-      expect((error as BBError).message).toBe(
+      expect((error as BBError).message).toContain(
         'At least one of --line-to or --line-from is required when using --file'
       );
+      expect((error as BBError).message).toContain('Valid modes:');
     }
   });
 

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -432,9 +432,10 @@ describe('createApiClient - retry/backoff', () => {
       expect(err).toBeInstanceOf(BBError);
       const bbErr = err as BBError;
       expect(bbErr.code).toBe(ErrorCode.NETWORK_ERROR);
-      expect(bbErr.message).toBe(
+      expect(bbErr.message).toContain(
         'Network error: Unable to reach Bitbucket API'
       );
+      expect(bbErr.message).toContain('DEBUG=true');
     }
 
     // Network errors are not retried (no response object)


### PR DESCRIPTION
## Summary

Closes #182. Several common failure modes were missing actionable next-step guidance, and the API error path dropped Bitbucket-specific context. This PR addresses each item from the issue:

- **Auth errors** now mention both `bb auth login` and the `BB_USERNAME` / `BB_API_TOKEN` env vars (`config.service.ts` and `auth/token.command.ts`).
- **`CONTEXT_REPO_NOT_FOUND`** distinguishes between (1) not in a git repo, (2) git repo with no remote, and (3) remote is not Bitbucket. JSON output includes a `reason` field on `error.context`.
- **404 errors** from `bb pr view`, `bb repo view`, and `bb snippet view` are wrapped with a contextual message that names the missing resource (PR id, workspace/repo slug, snippet id).
- **Network errors** append `Run with DEBUG=true for details. If you're behind a proxy or using a custom CA, check your environment.`
- **`bb config get`** on hidden keys (e.g. `apiToken`) now explains *why* the key is hidden and points at `bb config list` for readable keys.
- **Validation errors** thrown via `BaseCommand.requireOption` now include a `Run \`bb <command> --help\` for usage.` footer derived from the active command path. The same helper is reused by `bb pr create --title` and `bb pr comment` mode validation.
- **`bb auth login`** wrapping distinguishes 401/403 (`Invalid username or token: …`), 429 (`Bitbucket API rate-limited: …`), and generic failures.
- **`bb pr comment`** validation lists the three valid mode combinations (general / file-level / inline-with-lines) so users can see what's valid from a single error.

## Test plan

- [x] `bun run lint` — type-check passes
- [x] `bun run format:check` — Prettier clean
- [x] `bun test` — all 863 tests pass (existing comment-mode tests and api-client network test were updated to match the new actionable messages)
- [ ] Manual: `bb pr list` with no creds shows the new auth hint
- [ ] Manual: `bb pr view 999999` in a repo prints `Pull request #999999 not found in <ws>/<repo>.`
- [ ] Manual: `bb pr create` without `--title` ends with `Run \`bb pr create --help\` for usage.`
- [ ] Manual: `bb pr comment 1 "msg" --line-to 5` prints the three valid modes