### PR TITLE
feat(browse): add `bb browse` command for opening Bitbucket pages

### DIFF
--- a/.changeset/feat-bb-browse.md
+++ b/.changeset/feat-bb-browse.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `bb browse` command for opening Bitbucket Cloud pages in the browser.
+
+Mirrors `gh browse`: `bb browse` opens the repo home, `bb browse src/cli.ts:42` opens a file at a line, `bb browse 217` opens PR #217, `bb browse abc1234` opens a commit, and resource flags (`--pr`, `--prs`, `--branch`, `--branches`, `--commit`, `--commits`, `--pipelines`, `--pipeline`, `--downloads`, `--issues`, `--issue`, `--wiki`, `--settings`) target specific pages. Use `--no-browser` to print the URL or `--json url` for scripting. Adds a reusable `UrlBuilderService` for centralized Bitbucket URL construction and `GitService.getCurrentCommit()` for HEAD-commit defaulting.

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -87,6 +87,15 @@ jobs:
         # npmjs.com aggressively rate-limit / bot-block CI runners and produce
         # spurious 403/429 responses. The primary value of this check is
         # catching broken anchors and internal links inside the built site.
+        #
+        # We also skip the production domain (bitbucket-cli.paulvanderlei.com).
+        # Astro emits absolute canonical/og:url tags back to `site`, so every
+        # page contains a self-referential production URL. Following those in
+        # CI means any newly-added page 404s on the live site (the page only
+        # exists locally until the PR is merged and deployed) — a chicken-and-
+        # egg failure that has nothing to do with broken authoring. Internal
+        # navigation between pages is already covered by relative links inside
+        # the built site, which linkinator validates locally.
         run: |
           bunx --bun linkinator@6 docs/dist \
             --recurse \
@@ -94,5 +103,6 @@ jobs:
             --skip "https://bitbucket.org" \
             --skip "https://status.bitbucket.org" \
             --skip "https://analytics.paulvanderlei.com" \
+            --skip "https://bitbucket-cli.paulvanderlei.com" \
             --skip "https://github.com" \
             --skip "https://www.npmjs.com"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ bb pr list
 bb repo list
 bb pr create --title "Add feature"
 bb pr approve 42
+bb browse 42                  # open PR #42 in your browser
+bb browse src/cli.ts:20       # open a file at a specific line
 bb config set defaultWorkspace myworkspace
 ```
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,11 @@ export default defineConfig({
               },
             },
             { label: "Snippet Commands", slug: "commands/snippet" },
+            {
+              label: "Browse",
+              slug: "commands/browse",
+              badge: { text: "New", variant: "tip" },
+            },
             { label: "Config Commands", slug: "commands/config" },
             { label: "Completion", slug: "commands/completion" },
           ],

--- a/docs/src/content/docs/commands/browse.mdx
+++ b/docs/src/content/docs/commands/browse.mdx
@@ -1,0 +1,159 @@
+---
+title: Browse Command — Open Bitbucket Pages from the Terminal
+description: Open Bitbucket Cloud web pages — repo home, files, branches, commits, pull requests, pipelines, settings — directly from the CLI, or print the URL for scripts.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`bb browse` opens Bitbucket Cloud web pages — repo home, files, branches,
+commits, pull requests, pipelines, settings, and more — in your default
+browser. Mirrors `gh browse`.
+
+It also doubles as a script-friendly URL builder: pass `--no-browser` to
+print the URL instead, or `--json url` for machine-readable output.
+
+Global options: `--json [fields]`, `--jq <expression>`, `--no-color`,
+`-w, --workspace`, `-r, --repo`.
+
+## `bb browse`
+
+```bash
+bb browse [target] [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `target` | Optional positional. Resolved by shape: pure digits → PR id, 7–40 hex chars → commit SHA, anything else → file/dir path. Append `:<line>` to a path for a line anchor (e.g. `src/cli.ts:42`). |
+
+### Resource flags
+
+Resource flags are mutually exclusive — pick at most one. They cannot be
+combined with a positional `target` (except `--branch`, which is a modifier
+that pairs with a path target).
+
+| Option | Opens |
+|--------|-------|
+| `--pr <id>` | A specific pull request |
+| `--prs` | The pull-requests list |
+| `--pull-requests` | Alias for `--prs` |
+| `--branch <name>` | The branch source tree (or, with `<target>`, that path on the branch) |
+| `--branches` | The branches list |
+| `--commit [sha]` | A specific commit (defaults to current HEAD when no SHA is given) |
+| `--commits` | The commits list |
+| `--pipelines` | The pipelines page |
+| `--pipeline <id>` | A specific pipeline run |
+| `--downloads` | The downloads page |
+| `--issue <id>` | A specific issue |
+| `--issues` | The issue tracker |
+| `--wiki` | The wiki |
+| `--settings` | Repository admin / settings |
+
+### Behavior flags
+
+| Option | Description |
+|--------|-------------|
+| `-n, --no-browser` | Print the URL to stdout instead of opening it |
+| `--json [fields]` | Emit `{ "url": "..." }` (does not open the browser) |
+
+### Examples
+
+```bash
+# Repo home
+bb browse
+
+# A file at the current branch
+bb browse src/cli.ts
+
+# A file at a specific line
+bb browse src/cli.ts:42
+
+# A file on a specific branch
+bb browse --branch release/2.0 src/cli.ts
+
+# Just the branch tree
+bb browse --branch release/2.0
+
+# Pull request #217 (positional shorthand)
+bb browse 217
+
+# Pull request #217 (explicit)
+bb browse --pr 217
+
+# Pull-request list
+bb browse --prs
+
+# A commit by SHA
+bb browse abc1234
+
+# Current HEAD commit
+bb browse --commit
+
+# Pipelines tab
+bb browse --pipelines
+
+# Repo settings
+bb browse --settings
+
+# Print the URL only — useful in scripts and pipes
+bb browse --pr 217 --no-browser
+
+# Script-friendly URL retrieval
+bb browse --pr 217 --json url
+```
+
+### Notes
+
+- **Positional disambiguation.** A bare `<number>` is treated as a pull
+  request id (the most common case). Use `--issue <id>` to open an issue
+  with the same number.
+- **Branch defaulting.** When you give a path target without `--branch`,
+  the CLI uses your current git branch (`git rev-parse --abbrev-ref HEAD`).
+  Outside a git checkout (when using `--workspace`/`--repo` overrides), it
+  falls back to the literal `HEAD` segment, which Bitbucket resolves
+  server-side to the repository's default branch.
+- **URL encoding.** Workspace and repo slugs, branch names, and path
+  segments are URL-encoded individually, so branches with slashes
+  (`feature/foo`) and paths or names with spaces still produce valid URLs.
+  Path separators (`/` between segments) are preserved.
+- **No API call required for most variants.** `bb browse` is primarily a
+  URL-construction command; only `--commit` (no SHA) makes a local
+  `git rev-parse HEAD` call.
+- **`--json` does not open the browser.** Either output mode (JSON or
+  `--no-browser`) suppresses the open action, so scripts can capture the
+  URL deterministically.
+
+### Output
+
+In default mode, `bb browse` prints a short status line and shells out to
+the [`open`](https://www.npmjs.com/package/open) helper to launch the URL.
+
+With `--no-browser`:
+
+```text
+https://bitbucket.org/myworkspace/myrepo/pull-requests/217
+```
+
+With `--json`:
+
+```json
+{
+  "url": "https://bitbucket.org/myworkspace/myrepo/pull-requests/217"
+}
+```
+
+Combine with `--jq` to pluck just the URL string:
+
+```bash
+bb browse --pr 217 --json url --jq '.url'
+```
+
+### Related
+
+- [`bb pr diff --web`](/commands/pr/diff-and-checkout/) — open the PR
+  diff page directly in the browser.
+- [Repository Context](/guides/repository-context/) — how the CLI infers
+  workspace and repo from your current directory.
+- [Scripting & Automation](/guides/scripting/) — capture URLs from
+  `bb browse` to feed other tools.

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -56,7 +56,7 @@ bb completion install
 bb completion install --json
 
 # Test it works
-bb <Tab>        # Shows: auth, repo, pr, config, completion
+bb <Tab>        # Shows: auth, repo, pr, snippet, browse, config, completion
 bb repo <Tab>   # Shows: clone, create, list, view, delete
 ```
 
@@ -92,7 +92,7 @@ bb completion uninstall --json
 
 Tab completion works for:
 
-- **Commands**: `auth`, `repo`, `pr`, `config`, `completion`
+- **Commands**: `auth`, `repo`, `pr`, `snippet`, `browse`, `config`, `completion`
 - **Subcommands**: `login`, `clone`, `create`, `list`, etc.
 - **Options**: `--json`, `--no-color`, `--workspace`, `--repo`, `--help`
 

--- a/docs/src/content/docs/commands/pr/diff-and-checkout.mdx
+++ b/docs/src/content/docs/commands/pr/diff-and-checkout.mdx
@@ -113,3 +113,4 @@ bb pr diff 42 --stat --json
 - Use `--color never` when piping output to files or other commands
 - Use the global `--no-color` flag to disable color output for all command formatting
 - The diff is colorized by default when output is a terminal (green for additions, red for deletions, cyan for hunk headers)
+- For opening other Bitbucket pages (PR detail, files, commits, pipelines, settings) in the browser, see [`bb browse`](/commands/browse/)

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -103,6 +103,8 @@ Here are the commands you'll use most often:
 | `bb pr checkout 42` | Checkout PR #42 locally |
 | `bb pr diff 42` | View PR #42 diff |
 | `bb repo list` | List repositories |
+| `bb browse 42` | Open PR #42 in your browser |
+| `bb browse src/cli.ts:20` | Open a file at a specific line in your browser |
 
 ---
 
@@ -136,6 +138,7 @@ Restart your shell, then try:
 ```bash
 bb pr <Tab>      # Shows: activity, approve, checkout, create, decline, diff, list, merge, ready, view
 bb pr create -<Tab>  # Shows available flags
+bb <Tab>         # Shows: auth, repo, pr, snippet, browse, config, completion
 ```
 
 ---

--- a/docs/src/content/docs/help/changelog.mdx
+++ b/docs/src/content/docs/help/changelog.mdx
@@ -14,6 +14,35 @@ and is updated on every release.
   See [Configuration File](/reference/configuration/) for related settings.
 </Aside>
 
+## Unreleased — `bb browse`
+
+Open Bitbucket Cloud web pages — repo home, files, branches, commits, pull
+requests, pipelines, settings — directly from the terminal. Mirrors
+`gh browse`.
+
+- Smart positional resolution: `bb browse 217` opens PR #217,
+  `bb browse abc1234` opens a commit, `bb browse src/cli.ts:42` opens a file
+  at a line on the current branch.
+- Resource flags for every top-level repo page: `--pr`, `--prs`, `--branch`,
+  `--branches`, `--commit` (defaults to HEAD), `--commits`, `--pipelines`,
+  `--pipeline`, `--downloads`, `--issue`, `--issues`, `--wiki`, `--settings`.
+- `--no-browser` prints the URL to stdout; `--json url` emits
+  `{ "url": "..." }` for scripting.
+- Outside a git checkout, falls back to Bitbucket's `HEAD` segment so
+  `--workspace`/`--repo` overrides Just Work.
+
+```bash
+bb browse                                # repo home
+bb browse src/cli.ts:42                  # file at a line on the current branch
+bb browse --branch release/2.0           # branch tree
+bb browse 217                            # PR #217
+bb browse --pipelines                    # pipelines tab
+bb browse --pr 217 --json url            # capture the URL for a script
+```
+
+See the [Browse command reference](/commands/browse/) for the full flag list
+and examples.
+
 ## 1.14.0 — `--json <fields>` projection and `--jq <expression>`
 
 Match the `gh` CLI's JSON formatting flags so muscle memory and scripts port

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -87,6 +87,16 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
+  <Card title="Jump to the Web UI" icon="external">
+    Open Bitbucket pages — PRs, files, commits, settings — in your browser.
+
+    ```bash
+    bb browse 42
+    bb browse src/cli.ts:20
+    bb browse --pipelines
+    ```
+  </Card>
+
   <Card title="Scripting & Automation" icon="setting">
     JSON output on every command. Built for CI/CD.
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -13,6 +13,7 @@ import {
   createApiClient,
   SnippetFilesService,
   DefaultReviewerService,
+  UrlBuilderService,
 } from './services/index.js';
 import type { AxiosInstance } from 'axios';
 import { createRequire } from 'node:module';
@@ -87,6 +88,9 @@ import { ListConfigCommand } from './commands/config/list.command.js';
 // Completion commands
 import { InstallCompletionCommand } from './commands/completion/install.command.js';
 import { UninstallCompletionCommand } from './commands/completion/uninstall.command.js';
+
+// Top-level commands
+import { BrowseCommand } from './commands/browse.command.js';
 
 export interface BootstrapOptions {
   noColor?: boolean;
@@ -202,6 +206,13 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ServiceTokens.DefaultReviewerService,
     DefaultReviewerService,
     [ServiceTokens.PullrequestsApi]
+  );
+
+  // URL builder is a pure helper with no dependencies; register a fresh
+  // singleton so tests can swap the base via `registerInstance` if needed.
+  container.register(
+    ServiceTokens.UrlBuilderService,
+    () => new UrlBuilderService()
   );
 
   // Auth commands
@@ -572,6 +583,14 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ListConfigCommand,
     [ServiceTokens.ConfigService, ServiceTokens.OutputService]
   );
+
+  // Top-level commands
+  registerCommand(container, ServiceTokens.BrowseCommand, BrowseCommand, [
+    ServiceTokens.ContextService,
+    ServiceTokens.GitService,
+    ServiceTokens.UrlBuilderService,
+    ServiceTokens.OutputService,
+  ]);
 
   // Completion commands
   registerCommand(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   'repo',
   'pr',
   'snippet',
+  'browse',
   'config',
   'completion',
   '--help',
@@ -1475,6 +1476,63 @@ snippetCommentsCmd
 
 snippetCmd.addCommand(snippetCommentsCmd);
 cli.addCommand(snippetCmd);
+
+// Browse command (top-level)
+cli
+  .command('browse [target]')
+  .description(
+    'Open a Bitbucket page (repo home, file, PR, commit, etc.) in your browser'
+  )
+  .option('--pr <id>', 'Open a specific pull request')
+  .option('--prs', 'Open the pull-requests list')
+  .option('--pull-requests', 'Alias for --prs')
+  .option(
+    '--branch <name>',
+    'Open the branch source tree (or, with <target>, that path on the branch)'
+  )
+  .option('--branches', 'Open the branches list')
+  .option(
+    '--commit [sha]',
+    'Open a specific commit (defaults to HEAD when no SHA is given)'
+  )
+  .option('--commits', 'Open the commits list')
+  .option('--pipelines', 'Open the pipelines page')
+  .option('--pipeline <id>', 'Open a specific pipeline run')
+  .option('--downloads', 'Open the downloads page')
+  .option('--issue <id>', 'Open a specific issue')
+  .option('--issues', 'Open the issue tracker')
+  .option('--wiki', 'Open the wiki')
+  .option('--settings', 'Open repository settings')
+  .option('-n, --no-browser', 'Print the URL to stdout instead of opening it')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb browse',
+        'bb browse src/cli.ts',
+        'bb browse src/cli.ts:42',
+        'bb browse --branch release/2.0 src/cli.ts',
+        'bb browse 217',
+        'bb browse --pr 217',
+        'bb browse --prs',
+        'bb browse abc1234',
+        'bb browse --commit',
+        'bb browse --pipelines',
+        'bb browse --settings',
+        'bb browse --pr 217 --no-browser',
+        'bb browse --pr 217 --json url',
+      ],
+    })
+  )
+  .action(async (target, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.BrowseCommand,
+      withGlobalOptions({ target, ...options }, context),
+      cli,
+      context
+    );
+  });
 
 // Config commands
 const configCmd = new Command('config').description('Manage configuration');

--- a/src/commands/browse.command.ts
+++ b/src/commands/browse.command.ts
@@ -1,0 +1,274 @@
+/**
+ * Browse command implementation.
+ *
+ * Resolves a Bitbucket Cloud web URL from a positional target and/or
+ * resource flags, then either opens it in the user's browser or prints
+ * it to stdout. Mirrors `gh browse`.
+ */
+
+import { BaseCommand } from '../core/base-command.js';
+import type { CommandContext } from '../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IGitService,
+  IOutputService,
+} from '../core/interfaces/services.js';
+import type { IUrlBuilderService } from '../services/url-builder.service.js';
+import type { GlobalOptions, RepoContext } from '../types/config.js';
+import { BBError, ErrorCode } from '../types/errors.js';
+
+export interface BrowseOptions extends GlobalOptions {
+  target?: string;
+  pr?: string;
+  prs?: boolean;
+  pullRequests?: boolean;
+  branch?: string;
+  branches?: boolean;
+  commit?: string | boolean;
+  commits?: boolean;
+  pipelines?: boolean;
+  pipeline?: string;
+  downloads?: boolean;
+  issue?: string;
+  issues?: boolean;
+  wiki?: boolean;
+  settings?: boolean;
+  /**
+   * Commander coerces `-n, --no-browser` into `browser: false`. Treat any
+   * non-undefined falsey value as "print URL only".
+   */
+  browser?: boolean;
+}
+
+export interface BrowseResult {
+  url: string;
+  opened: boolean;
+}
+
+const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+const PR_NUMBER_PATTERN = /^\d+$/;
+const PATH_LINE_PATTERN = /^(.+):(\d+)$/;
+
+export class BrowseCommand extends BaseCommand<BrowseOptions, BrowseResult> {
+  public readonly name = 'browse';
+  public readonly description =
+    'Open a Bitbucket page (repo, file, PR, commit, etc.) in your browser';
+
+  constructor(
+    private readonly contextService: IContextService,
+    private readonly gitService: IGitService,
+    private readonly urlBuilder: IUrlBuilderService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: BrowseOptions,
+    context: CommandContext
+  ): Promise<BrowseResult> {
+    const repoContext = await this.contextService.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
+
+    this.validateFlagCombination(options);
+
+    const url = await this.resolveUrl(options, repoContext);
+    const useJson = Boolean(context.globalOptions.json);
+    const printOnly = options.browser === false;
+
+    if (useJson) {
+      await this.output.json({ url });
+      return { url, opened: false };
+    }
+
+    if (printOnly) {
+      this.output.text(url);
+      return { url, opened: false };
+    }
+
+    await this.openInBrowser(url);
+    return { url, opened: true };
+  }
+
+  private async resolveUrl(
+    options: BrowseOptions,
+    ctx: RepoContext
+  ): Promise<string> {
+    if (options.pr !== undefined) {
+      return this.urlBuilder.pullRequest(
+        ctx,
+        this.parsePositiveInt(options.pr, 'pr')
+      );
+    }
+    if (options.prs || options.pullRequests) {
+      return this.urlBuilder.pullRequestList(ctx);
+    }
+    if (options.branches) {
+      return this.urlBuilder.branchList(ctx);
+    }
+    if (options.commits) {
+      return this.urlBuilder.commitList(ctx);
+    }
+    if (options.commit !== undefined) {
+      const sha =
+        typeof options.commit === 'string' && options.commit.length > 0
+          ? options.commit
+          : await this.gitService.getCurrentCommit();
+      return this.urlBuilder.commit(ctx, sha);
+    }
+    if (options.pipelines) {
+      return this.urlBuilder.pipelinesHome(ctx);
+    }
+    if (options.pipeline !== undefined) {
+      const value = options.pipeline.trim();
+      if (value.length === 0) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: this.appendHelpHint('--pipeline requires a run id or uuid.'),
+        });
+      }
+      return this.urlBuilder.pipelineRun(ctx, value);
+    }
+    if (options.downloads) {
+      return this.urlBuilder.downloads(ctx);
+    }
+    if (options.issue !== undefined) {
+      return this.urlBuilder.issue(
+        ctx,
+        this.parsePositiveInt(options.issue, 'issue')
+      );
+    }
+    if (options.issues) {
+      return this.urlBuilder.issueList(ctx);
+    }
+    if (options.wiki) {
+      return this.urlBuilder.wiki(ctx);
+    }
+    if (options.settings) {
+      return this.urlBuilder.settings(ctx);
+    }
+
+    const target = options.target?.trim();
+
+    if (target && target.length > 0) {
+      if (PR_NUMBER_PATTERN.test(target)) {
+        return this.urlBuilder.pullRequest(ctx, Number.parseInt(target, 10));
+      }
+      if (SHA_PATTERN.test(target)) {
+        return this.urlBuilder.commit(ctx, target);
+      }
+
+      const { path, line } = this.parsePathWithLine(target);
+      const branch = await this.resolveBranch(options.branch);
+      return this.urlBuilder.src(ctx, branch, path, line);
+    }
+
+    if (options.branch) {
+      return this.urlBuilder.src(ctx, options.branch);
+    }
+
+    return this.urlBuilder.repo(ctx);
+  }
+
+  private validateFlagCombination(options: BrowseOptions): void {
+    const setFlags: string[] = [];
+    if (options.pr !== undefined) setFlags.push('--pr');
+    if (options.prs) {
+      setFlags.push('--prs');
+    } else if (options.pullRequests) {
+      setFlags.push('--pull-requests');
+    }
+    if (options.branches) setFlags.push('--branches');
+    if (options.commit !== undefined) setFlags.push('--commit');
+    if (options.commits) setFlags.push('--commits');
+    if (options.pipelines) setFlags.push('--pipelines');
+    if (options.pipeline !== undefined) setFlags.push('--pipeline');
+    if (options.downloads) setFlags.push('--downloads');
+    if (options.issue !== undefined) setFlags.push('--issue');
+    if (options.issues) setFlags.push('--issues');
+    if (options.wiki) setFlags.push('--wiki');
+    if (options.settings) setFlags.push('--settings');
+
+    if (setFlags.length > 1) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          `Cannot combine ${setFlags.join(' and ')}; pick one resource.`
+        ),
+      });
+    }
+
+    const hasResourceFlag = setFlags.length === 1;
+    const hasTarget = !!options.target?.trim();
+
+    if (hasResourceFlag && hasTarget) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          `Cannot use a positional target with ${setFlags[0]}.`
+        ),
+      });
+    }
+
+    if (hasResourceFlag && options.branch) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          `Cannot combine --branch with ${setFlags[0]}.`
+        ),
+      });
+    }
+  }
+
+  private parsePathWithLine(target: string): {
+    path: string;
+    line?: number;
+  } {
+    const match = PATH_LINE_PATTERN.exec(target);
+    if (match) {
+      const line = Number.parseInt(match[2]!, 10);
+      if (Number.isFinite(line) && line > 0) {
+        return { path: match[1]!, line };
+      }
+    }
+    return { path: target };
+  }
+
+  private async resolveBranch(explicit?: string): Promise<string> {
+    if (explicit && explicit.length > 0) {
+      return explicit;
+    }
+    try {
+      return await this.gitService.getCurrentBranch();
+    } catch {
+      // Outside a git checkout, Bitbucket resolves `HEAD` to the repo's
+      // default branch server-side, so falling back to that keeps a path
+      // browse useful even with `--workspace`/`--repo` overrides.
+      return 'HEAD';
+    }
+  }
+
+  private parsePositiveInt(value: string, name: string): number {
+    const parsed = Number.parseInt(value, 10);
+    if (
+      !Number.isFinite(parsed) ||
+      parsed <= 0 ||
+      String(parsed) !== value.trim()
+    ) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(`--${name} must be a positive integer.`),
+        context: { [name]: value },
+      });
+    }
+    return parsed;
+  }
+
+  private async openInBrowser(url: string): Promise<void> {
+    this.output.info(`Opening ${url} in your browser...`);
+    const open = (await import('open')).default;
+    await open(url);
+  }
+}

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -157,6 +157,12 @@ export const ServiceTokens = {
   // Services - Default Reviewers
   DefaultReviewerService: 'DefaultReviewerService',
 
+  // Services - URL builder (Bitbucket web URL construction)
+  UrlBuilderService: 'UrlBuilderService',
+
+  // Commands - Top level
+  BrowseCommand: 'BrowseCommand',
+
   // Commands - PR
   CreatePRCommand: 'CreatePRCommand',
   ListPRsCommand: 'ListPRsCommand',

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -56,6 +56,7 @@ export interface IGitService {
   checkout(branch: string): Promise<void>;
   checkoutNewBranch(branch: string, startPoint?: string): Promise<void>;
   getCurrentBranch(): Promise<string>;
+  getCurrentCommit(): Promise<string>;
   getRemoteUrl(remote?: string): Promise<string>;
 }
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -86,6 +86,10 @@ export class GitService implements IGitService {
     return this.execOrError(['rev-parse', '--abbrev-ref', 'HEAD']);
   }
 
+  public async getCurrentCommit(): Promise<string> {
+    return this.execOrError(['rev-parse', 'HEAD']);
+  }
+
   public async getRemoteUrl(remote: string = 'origin'): Promise<string> {
     const result = await this.exec(['remote', 'get-url', remote]);
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,6 +12,11 @@ export { OAuthService } from './oauth.service.js';
 export { SnippetFilesService } from './snippet-files.service.js';
 export { updatePullRequestReviewers } from './reviewer.service.js';
 export { DefaultReviewerService } from './default-reviewer.service.js';
+export {
+  UrlBuilderService,
+  BITBUCKET_WEB_BASE,
+} from './url-builder.service.js';
+export type { IUrlBuilderService } from './url-builder.service.js';
 export type {
   DefaultReviewerEntry,
   DefaultReviewerMode,

--- a/src/services/url-builder.service.ts
+++ b/src/services/url-builder.service.ts
@@ -1,0 +1,114 @@
+/**
+ * Builder for Bitbucket Cloud web URLs.
+ *
+ * Centralizing URL construction lets `bb browse` and any future `--web`
+ * flags share one source of truth for path schemes and encoding rules.
+ */
+
+import type { RepoContext } from '../types/config.js';
+
+export const BITBUCKET_WEB_BASE = 'https://bitbucket.org';
+
+export interface IUrlBuilderService {
+  repo(ctx: RepoContext): string;
+  src(ctx: RepoContext, branch: string, path?: string, line?: number): string;
+  branchList(ctx: RepoContext): string;
+  commit(ctx: RepoContext, sha: string): string;
+  commitList(ctx: RepoContext): string;
+  pullRequest(ctx: RepoContext, id: number): string;
+  pullRequestList(ctx: RepoContext): string;
+  pipelinesHome(ctx: RepoContext): string;
+  pipelineRun(ctx: RepoContext, idOrUuid: string): string;
+  downloads(ctx: RepoContext): string;
+  issue(ctx: RepoContext, id: number): string;
+  issueList(ctx: RepoContext): string;
+  wiki(ctx: RepoContext): string;
+  settings(ctx: RepoContext): string;
+}
+
+function encodePathSegments(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+export class UrlBuilderService implements IUrlBuilderService {
+  private readonly base: string;
+
+  constructor(base: string = BITBUCKET_WEB_BASE) {
+    this.base = base.replace(/\/+$/, '');
+  }
+
+  public repo(ctx: RepoContext): string {
+    return this.repoBase(ctx);
+  }
+
+  public src(
+    ctx: RepoContext,
+    branch: string,
+    path?: string,
+    line?: number
+  ): string {
+    const encodedBranch = encodeURIComponent(branch);
+    const trimmedPath = path?.replace(/^\/+/, '').replace(/\/+$/, '') ?? '';
+    const pathPart = trimmedPath ? `/${encodePathSegments(trimmedPath)}` : '/';
+    const lineFragment =
+      typeof line === 'number' && Number.isFinite(line) && line > 0
+        ? `#lines-${line}`
+        : '';
+    return `${this.repoBase(ctx)}/src/${encodedBranch}${pathPart}${lineFragment}`;
+  }
+
+  public branchList(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/branches/`;
+  }
+
+  public commit(ctx: RepoContext, sha: string): string {
+    return `${this.repoBase(ctx)}/commits/${encodeURIComponent(sha)}`;
+  }
+
+  public commitList(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/commits/`;
+  }
+
+  public pullRequest(ctx: RepoContext, id: number): string {
+    return `${this.repoBase(ctx)}/pull-requests/${id}`;
+  }
+
+  public pullRequestList(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/pull-requests/`;
+  }
+
+  public pipelinesHome(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/pipelines`;
+  }
+
+  public pipelineRun(ctx: RepoContext, idOrUuid: string): string {
+    return `${this.repoBase(ctx)}/pipelines/results/${encodeURIComponent(idOrUuid)}`;
+  }
+
+  public downloads(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/downloads/`;
+  }
+
+  public issue(ctx: RepoContext, id: number): string {
+    return `${this.repoBase(ctx)}/issues/${id}`;
+  }
+
+  public issueList(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/issues`;
+  }
+
+  public wiki(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/wiki`;
+  }
+
+  public settings(ctx: RepoContext): string {
+    return `${this.repoBase(ctx)}/admin`;
+  }
+
+  private repoBase(ctx: RepoContext): string {
+    return `${this.base}/${encodeURIComponent(ctx.workspace)}/${encodeURIComponent(ctx.repoSlug)}`;
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -361,6 +361,7 @@ describe('CLI command registration', () => {
     const names = cli.commands.map((command) => command.name()).sort();
     expect(names).toEqual([
       'auth',
+      'browse',
       'completion',
       'config',
       'pr',

--- a/tests/commands/browse.test.ts
+++ b/tests/commands/browse.test.ts
@@ -1,0 +1,428 @@
+/**
+ * BrowseCommand tests
+ */
+
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { BrowseCommand } from '../../src/commands/browse.command.js';
+import { UrlBuilderService } from '../../src/services/url-builder.service.js';
+import {
+  createMockContextService,
+  createMockGitService,
+  createMockOutputService,
+} from '../setup.js';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
+
+const workspaceCtx = { workspace: 'acme', repoSlug: 'widgets' };
+
+function buildCommand(
+  options: Parameters<typeof createMockGitService>[0] & {
+    inRepo?: boolean;
+  } = { inRepo: true }
+) {
+  const inRepo = options.inRepo ?? true;
+  const contextService = inRepo
+    ? createMockContextService({
+        workspace: workspaceCtx.workspace,
+        repoSlug: workspaceCtx.repoSlug,
+      })
+    : createMockContextService();
+  const gitService = createMockGitService(options);
+  const urlBuilder = new UrlBuilderService();
+  const output = createMockOutputService();
+  const command = new BrowseCommand(
+    contextService,
+    gitService,
+    urlBuilder,
+    output
+  );
+  return { command, output, gitService };
+}
+
+function lastJsonPayload(logs: string[]): unknown {
+  const log = [...logs].reverse().find((l) => l.startsWith('json:'));
+  if (!log) return undefined;
+  return JSON.parse(log.substring('json:'.length));
+}
+
+describe('BrowseCommand', () => {
+  let openCalls: string[];
+
+  beforeEach(() => {
+    openCalls = [];
+    mock.module('open', () => ({
+      default: async (url: string) => {
+        openCalls.push(url);
+      },
+    }));
+  });
+
+  describe('repo home', () => {
+    it('returns the repo URL when no target or flag is given', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute({}, { globalOptions: {} });
+
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets');
+      expect(result.opened).toBe(true);
+      expect(openCalls).toEqual(['https://bitbucket.org/acme/widgets']);
+    });
+  });
+
+  describe('positional resolution', () => {
+    it('treats a pure-digit target as a PR id', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { target: '217' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/217'
+      );
+    });
+
+    it('treats a 7-40 hex target as a commit SHA', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { target: 'abc1234' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/commits/abc1234'
+      );
+    });
+
+    it('treats a 40-character hex target as a commit SHA', async () => {
+      const { command } = buildCommand();
+      const sha = 'a'.repeat(40);
+      const result = await command.execute(
+        { target: sha },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        `https://bitbucket.org/acme/widgets/commits/${sha}`
+      );
+    });
+
+    it('treats anything else as a path on the current branch', async () => {
+      const { command } = buildCommand({ currentBranch: 'main' });
+      const result = await command.execute(
+        { target: 'src/cli.ts' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts'
+      );
+    });
+
+    it('parses trailing :<line> as a line anchor on the file path', async () => {
+      const { command } = buildCommand({ currentBranch: 'main' });
+      const result = await command.execute(
+        { target: 'src/cli.ts:42' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts#lines-42'
+      );
+    });
+
+    it('falls back to HEAD when not in a git repo', async () => {
+      const { command } = buildCommand({
+        inRepo: false,
+        throwOnGetCurrentBranch: true,
+      });
+      // Use --workspace/--repo to satisfy repo context outside git.
+      const result = await command.execute(
+        { target: 'README.md', workspace: 'acme', repo: 'widgets' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/HEAD/README.md'
+      );
+    });
+  });
+
+  describe('--branch', () => {
+    it('opens the branch tree when used alone', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { branch: 'release/2.0' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/release%2F2.0/'
+      );
+    });
+
+    it('combines with a positional path target', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { branch: 'release/2.0', target: 'src/cli.ts' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/release%2F2.0/src/cli.ts'
+      );
+    });
+
+    it('overrides the current branch even with a path target', async () => {
+      const { command } = buildCommand({ currentBranch: 'main' });
+      const result = await command.execute(
+        { branch: 'feat/x', target: 'src/cli.ts:7' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/src/feat%2Fx/src/cli.ts#lines-7'
+      );
+    });
+  });
+
+  describe('resource flags', () => {
+    it('--pr opens the PR detail page', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute({ pr: '42' }, { globalOptions: {} });
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/42'
+      );
+    });
+
+    it('--prs opens the PR list', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { prs: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/'
+      );
+    });
+
+    it('--pull-requests is an alias for --prs', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { pullRequests: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/'
+      );
+    });
+
+    it('--branches opens the branches list', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { branches: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/branches/');
+    });
+
+    it('--commit <sha> opens the commit page', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { commit: 'deadbeef' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/commits/deadbeef'
+      );
+    });
+
+    it('--commit (no value) defaults to current HEAD', async () => {
+      const { command } = buildCommand({
+        currentCommit: 'feedface000000000000',
+      });
+      const result = await command.execute(
+        { commit: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/commits/feedface000000000000'
+      );
+    });
+
+    it('--commits opens the commits list', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { commits: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/commits/');
+    });
+
+    it('--pipelines opens the pipelines home', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { pipelines: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/pipelines');
+    });
+
+    it('--pipeline <id> opens a specific pipeline run', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { pipeline: '123' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe(
+        'https://bitbucket.org/acme/widgets/pipelines/results/123'
+      );
+    });
+
+    it('--downloads opens the downloads page', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { downloads: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/downloads/');
+    });
+
+    it('--issue <id> opens an issue', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { issue: '12' },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/issues/12');
+    });
+
+    it('--issues opens the issue tracker list', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { issues: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/issues');
+    });
+
+    it('--wiki opens the wiki', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { wiki: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/wiki');
+    });
+
+    it('--settings opens the admin page', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute(
+        { settings: true },
+        { globalOptions: {} }
+      );
+      expect(result.url).toBe('https://bitbucket.org/acme/widgets/admin');
+    });
+  });
+
+  describe('output modes', () => {
+    it('--no-browser prints the URL and does not open it', async () => {
+      const { command, output } = buildCommand();
+      const result = await command.execute(
+        { browser: false, pr: '7' },
+        { globalOptions: {} }
+      );
+      expect(result.opened).toBe(false);
+      expect(openCalls).toEqual([]);
+      expect(output.logs).toContain(
+        'text:https://bitbucket.org/acme/widgets/pull-requests/7'
+      );
+    });
+
+    it('--json emits {url} and does not open the browser', async () => {
+      const { command, output } = buildCommand();
+      const result = await command.execute(
+        { pr: '7' },
+        { globalOptions: { json: true } }
+      );
+      expect(result.opened).toBe(false);
+      expect(openCalls).toEqual([]);
+      expect(lastJsonPayload(output.logs)).toEqual({
+        url: 'https://bitbucket.org/acme/widgets/pull-requests/7',
+      });
+    });
+
+    it('opens the browser by default', async () => {
+      const { command } = buildCommand();
+      const result = await command.execute({ pr: '7' }, { globalOptions: {} });
+      expect(result.opened).toBe(true);
+      expect(openCalls).toEqual([
+        'https://bitbucket.org/acme/widgets/pull-requests/7',
+      ]);
+    });
+  });
+
+  describe('flag validation', () => {
+    it('rejects combining two resource flags', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute({ pr: '1', settings: true }, { globalOptions: {} })
+      ).rejects.toMatchObject({
+        code: ErrorCode.VALIDATION_INVALID,
+      });
+    });
+
+    it('rejects a positional target alongside a resource flag', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute(
+          { pr: '1', target: 'src/cli.ts' },
+          { globalOptions: {} }
+        )
+      ).rejects.toMatchObject({
+        code: ErrorCode.VALIDATION_INVALID,
+      });
+    });
+
+    it('rejects --branch combined with a resource flag', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute({ pr: '1', branch: 'main' }, { globalOptions: {} })
+      ).rejects.toMatchObject({
+        code: ErrorCode.VALIDATION_INVALID,
+      });
+    });
+
+    it('rejects non-positive --pr values', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute({ pr: '0' }, { globalOptions: {} })
+      ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+      await expect(
+        command.execute({ pr: 'abc' }, { globalOptions: {} })
+      ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+    });
+
+    it('rejects non-numeric --issue values', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute({ issue: 'foo' }, { globalOptions: {} })
+      ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+    });
+
+    it('rejects empty --pipeline values', async () => {
+      const { command } = buildCommand();
+      await expect(
+        command.execute({ pipeline: '   ' }, { globalOptions: {} })
+      ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+    });
+  });
+
+  describe('error paths', () => {
+    it('throws when no repo context is available', async () => {
+      const { command } = buildCommand({ inRepo: false });
+      await expect(
+        command.run({}, { globalOptions: {} })
+      ).rejects.toBeInstanceOf(BBError);
+    });
+  });
+
+  describe('security', () => {
+    it('passes the URL verbatim to open() (no shell interpolation)', async () => {
+      const { command } = buildCommand();
+      await command.execute({ target: '217' }, { globalOptions: {} });
+      expect(openCalls).toEqual([
+        'https://bitbucket.org/acme/widgets/pull-requests/217',
+      ]);
+    });
+  });
+});

--- a/tests/services/git.service.test.ts
+++ b/tests/services/git.service.test.ts
@@ -71,6 +71,31 @@ describe('GitService', () => {
     });
   });
 
+  describe('getCurrentCommit', () => {
+    it('should return the current commit SHA', async () => {
+      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
+      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
+        cwd: testDir,
+      }).exited;
+      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
+        .exited;
+      await writeFile(join(testDir, 'test.txt'), 'test');
+      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
+      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
+        .exited;
+
+      const sha = await gitService.getCurrentCommit();
+
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it('should throw error for non-git directory', async () => {
+      await expect(gitService.getCurrentCommit()).rejects.toMatchObject({
+        code: ErrorCode.GIT_COMMAND_FAILED,
+      });
+    });
+  });
+
   describe('getRemoteUrl', () => {
     it('should throw error when no remote exists', async () => {
       await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;

--- a/tests/services/url-builder.test.ts
+++ b/tests/services/url-builder.test.ts
@@ -1,0 +1,197 @@
+/**
+ * UrlBuilderService tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  UrlBuilderService,
+  BITBUCKET_WEB_BASE,
+} from '../../src/services/url-builder.service.js';
+
+const ctx = { workspace: 'acme', repoSlug: 'widgets' };
+
+describe('UrlBuilderService', () => {
+  describe('repo()', () => {
+    it('returns the canonical repo home URL', () => {
+      const builder = new UrlBuilderService();
+      expect(builder.repo(ctx)).toBe('https://bitbucket.org/acme/widgets');
+    });
+
+    it('strips trailing slashes from a custom base URL', () => {
+      const builder = new UrlBuilderService('https://bitbucket.example.com///');
+      expect(builder.repo(ctx)).toBe(
+        'https://bitbucket.example.com/acme/widgets'
+      );
+    });
+
+    it('uses the BITBUCKET_WEB_BASE constant by default', () => {
+      const builder = new UrlBuilderService();
+      expect(builder.repo(ctx).startsWith(BITBUCKET_WEB_BASE)).toBe(true);
+    });
+
+    it('URL-encodes workspace and repo slugs with special chars', () => {
+      const builder = new UrlBuilderService();
+      const result = builder.repo({
+        workspace: 'team space',
+        repoSlug: 'cool repo',
+      });
+      expect(result).toBe('https://bitbucket.org/team%20space/cool%20repo');
+    });
+  });
+
+  describe('src()', () => {
+    const builder = new UrlBuilderService();
+
+    it('builds branch tree URL when no path is given', () => {
+      expect(builder.src(ctx, 'main')).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/'
+      );
+    });
+
+    it('builds file URL at a branch', () => {
+      expect(builder.src(ctx, 'main', 'src/cli.ts')).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts'
+      );
+    });
+
+    it('builds file URL with a line anchor', () => {
+      expect(builder.src(ctx, 'main', 'src/cli.ts', 42)).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts#lines-42'
+      );
+    });
+
+    it('omits the line anchor when line is zero or negative', () => {
+      expect(builder.src(ctx, 'main', 'src/cli.ts', 0)).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts'
+      );
+      expect(builder.src(ctx, 'main', 'src/cli.ts', -5)).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts'
+      );
+    });
+
+    it('encodes branch names containing slashes', () => {
+      expect(builder.src(ctx, 'feature/foo')).toBe(
+        'https://bitbucket.org/acme/widgets/src/feature%2Ffoo/'
+      );
+    });
+
+    it('encodes branch names containing spaces and unicode', () => {
+      expect(builder.src(ctx, 'release 2.0', 'README.md')).toBe(
+        'https://bitbucket.org/acme/widgets/src/release%202.0/README.md'
+      );
+    });
+
+    it('encodes path segments individually but preserves /', () => {
+      expect(builder.src(ctx, 'main', 'src/has space/file name.ts')).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/has%20space/file%20name.ts'
+      );
+    });
+
+    it('strips leading and trailing slashes from the path', () => {
+      expect(builder.src(ctx, 'main', '/src/cli.ts/')).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/src/cli.ts'
+      );
+    });
+
+    it('treats an empty path the same as no path', () => {
+      expect(builder.src(ctx, 'main', '')).toBe(
+        'https://bitbucket.org/acme/widgets/src/main/'
+      );
+    });
+  });
+
+  describe('branchList()', () => {
+    it('returns the branches list URL with trailing slash', () => {
+      const builder = new UrlBuilderService();
+      expect(builder.branchList(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/branches/'
+      );
+    });
+  });
+
+  describe('commit() and commitList()', () => {
+    const builder = new UrlBuilderService();
+
+    it('builds a commit URL', () => {
+      expect(builder.commit(ctx, 'abc1234')).toBe(
+        'https://bitbucket.org/acme/widgets/commits/abc1234'
+      );
+    });
+
+    it('returns the commits list URL', () => {
+      expect(builder.commitList(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/commits/'
+      );
+    });
+  });
+
+  describe('pullRequest() and pullRequestList()', () => {
+    const builder = new UrlBuilderService();
+
+    it('builds a PR detail URL', () => {
+      expect(builder.pullRequest(ctx, 217)).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/217'
+      );
+    });
+
+    it('returns the PR list URL', () => {
+      expect(builder.pullRequestList(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/pull-requests/'
+      );
+    });
+  });
+
+  describe('pipelines', () => {
+    const builder = new UrlBuilderService();
+
+    it('returns the pipelines home URL (no trailing slash)', () => {
+      expect(builder.pipelinesHome(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/pipelines'
+      );
+    });
+
+    it('builds a pipeline run URL with numeric id', () => {
+      expect(builder.pipelineRun(ctx, '123')).toBe(
+        'https://bitbucket.org/acme/widgets/pipelines/results/123'
+      );
+    });
+
+    it('encodes pipeline UUIDs', () => {
+      expect(builder.pipelineRun(ctx, '{abc-123}')).toBe(
+        'https://bitbucket.org/acme/widgets/pipelines/results/%7Babc-123%7D'
+      );
+    });
+  });
+
+  describe('downloads(), issues, wiki, settings', () => {
+    const builder = new UrlBuilderService();
+
+    it('returns downloads URL with trailing slash', () => {
+      expect(builder.downloads(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/downloads/'
+      );
+    });
+
+    it('returns issue list URL (no trailing slash)', () => {
+      expect(builder.issueList(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/issues'
+      );
+    });
+
+    it('builds an issue detail URL', () => {
+      expect(builder.issue(ctx, 12)).toBe(
+        'https://bitbucket.org/acme/widgets/issues/12'
+      );
+    });
+
+    it('returns wiki URL', () => {
+      expect(builder.wiki(ctx)).toBe('https://bitbucket.org/acme/widgets/wiki');
+    });
+
+    it('returns settings/admin URL', () => {
+      expect(builder.settings(ctx)).toBe(
+        'https://bitbucket.org/acme/widgets/admin'
+      );
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -190,7 +190,9 @@ export function createMockGitService(
   options: {
     isRepo?: boolean;
     currentBranch?: string;
+    currentCommit?: string;
     remoteUrl?: string;
+    throwOnGetCurrentBranch?: boolean;
   } = {}
 ): IGitService {
   return {
@@ -210,7 +212,15 @@ export function createMockGitService(
       // Mock implementation
     },
     async getCurrentBranch() {
+      if (options.throwOnGetCurrentBranch) {
+        throw { code: 3002, message: 'Not a git repo' } as BBError;
+      }
       return options.currentBranch ?? 'main';
+    },
+    async getCurrentCommit() {
+      return (
+        options.currentCommit ?? 'abcdef0123456789abcdef0123456789abcdef01'
+      );
     },
     async getRemoteUrl() {
       if (options.remoteUrl) {


### PR DESCRIPTION
## Summary

Adds a new top-level `bb browse` command that mirrors `gh browse`: open Bitbucket Cloud web pages — repo home, files, branches, commits, pull requests, pipelines, settings, etc. — directly from the CLI, or print the URL for scripts.

Closes #216.

```
bb browse                                  # repo home
bb browse src/cli.ts:42                    # file at line on current branch
bb browse --branch release/2.0 src/cli.ts  # file on a specific branch
bb browse 217                              # PR #217 (smart positional)
bb browse abc1234                          # commit (smart positional)
bb browse --commit                         # current HEAD commit
bb browse --pr 217 --no-browser            # print the URL
bb browse --pr 217 --json url              # script-friendly URL retrieval
```

### Implementation notes

- New `UrlBuilderService` (`src/services/url-builder.service.ts`) centralizes Bitbucket Cloud web URL construction so future `--web` flags can reuse it. URL-encodes per segment but preserves `/` between path segments.
- New `BrowseCommand` (`src/commands/browse.command.ts`) extends `BaseCommand`. Smart positional resolution: pure digits → PR; 7–40 hex chars → commit SHA; else file path with optional `:N` line anchor. Resource flags are mutually exclusive; mixing them with a positional target or with `--branch` raises `BBError(VALIDATION_INVALID)` with a `--help` hint.
- Adds `GitService.getCurrentCommit()` (`git rev-parse HEAD`) so `--commit` without a value defaults to HEAD.
- When the user is outside a git checkout (using `--workspace`/`--repo`), path browse falls back to the `HEAD` segment which Bitbucket resolves server-side to the repo's default branch.
- Browser opening reuses the existing dynamic `import('open')` pattern from `bb pr diff --web`.
- Registered in `bootstrap.ts`, `container.ts`, `cli.ts`, and added to the tab-completion root list.

### Tests

- `tests/services/url-builder.test.ts` — 24 cases covering every URL pattern, encoding edge cases (slashes, spaces, UUID braces, leading/trailing slashes, line anchors).
- `tests/commands/browse.test.ts` — 37 cases covering smart positional resolution, every resource flag, `--branch` combos, output modes (default open, `--no-browser`, `--json`), all flag-validation error paths, the no-repo error path, and a verbatim-URL security check (no shell interpolation).
- Updated `tests/setup.ts`'s `createMockGitService` to expose `getCurrentCommit` and a `throwOnGetCurrentBranch` toggle for the no-git fallback case.
- Added `getCurrentCommit` test to `tests/services/git.service.test.ts`.
- Updated `tests/cli.test.ts` to expect `browse` in the registered top-level commands.

Full suite: **928 tests pass, 0 fail.** Type-check (`bun run lint`) and `bun run format:check` are clean.

### Changeset

Added `.changeset/feat-bb-browse.md` (minor bump) per `CONTRIBUTING.md`.

## Test plan

- [x] `bun test` — all 928 tests pass
- [x] `bun run lint` — type-check clean
- [x] `bun run format:check` — prettier clean
- [x] Manual smoke test: `bb browse --pr 42 --no-browser -w acme -r widgets` prints the expected PR URL
- [x] Manual smoke test: `bb browse src/cli.ts:20 --no-browser -w acme -r widgets` resolves to a `/src/<branch>/...#lines-20` URL using the current git branch
- [x] Manual smoke test: `bb browse --pr 7 --json url -w acme -r widgets` emits `{ "url": "..." }`
- [x] `bb browse --help` renders the full options list and examples