### PR TITLE
docs: reconcile CLI help, docs, and code (#181)

### DIFF
--- a/.changeset/docs-cli-drift-fix.md
+++ b/.changeset/docs-cli-drift-fix.md
@@ -1,0 +1,11 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Reconcile drift between CLI help, docs, and code (issue #181).
+
+- `bb auth login --app-password`: clarify that app passwords are deprecated and the flag opts into API token auth.
+- `bb pr list --mine`: tighten help text to say "PRs where you are a reviewer (not authored by you)" so the meaning isn't ambiguous.
+- `bb pr reviewers add` / `remove`: rename the positional from `<username>` to `<user>`, document that it accepts an account ID or `{uuid}`, and update examples (Bitbucket Cloud no longer accepts the legacy login name).
+- `bb snippet create --file` / `bb snippet edit --file`: note in help that the flag is variadic and can be repeated.
+- Docs: add the auto-managed `lastVersionCheck` config key to the configuration reference and include `default-reviewers` in the `bb repo <Tab>` completion example.

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -57,7 +57,7 @@ bb completion install --json
 
 # Test it works
 bb <Tab>        # Shows: auth, repo, pr, snippet, browse, config, completion
-bb repo <Tab>   # Shows: clone, create, list, view, delete
+bb repo <Tab>   # Shows: clone, create, list, view, delete, default-reviewers
 ```
 
 ---

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -26,6 +26,7 @@ The configuration file stores your CLI settings and authentication credentials.
 | `skipVersionCheck` | Disable update notifications (default: false) |
 | `versionCheckInterval` | Days between update checks (default: 1) |
 | `prCreateIncludeDefaultReviewers` | Auto-add the repo's default reviewers on `bb pr create` (default: false) |
+| `lastVersionCheck` | Timestamp of the last update check. Auto-managed by the CLI; read-only from a user's perspective (do not set manually) |
 
 ### Configuration File Format
 

--- a/docs/src/content/docs/commands/pr/reviewers.mdx
+++ b/docs/src/content/docs/commands/pr/reviewers.mdx
@@ -13,6 +13,15 @@ Global options available on all PR commands: `--json`, `--no-color`, `-w, --work
 This page covers reviewers on **existing** pull requests. To manage the repository's **default reviewers** — the list Bitbucket auto-suggests when someone opens a PR — see [`bb repo default-reviewers`](/commands/repo/#bb-repo-default-reviewers). `bb pr create` can also auto-apply them via `--default-reviewers` or the `prCreateIncludeDefaultReviewers` config key.
 :::
 
+## Identifying users
+
+Bitbucket Cloud no longer accepts the legacy `username` (login name) when modifying reviewers. The `<user>` positional accepts either:
+
+- An **account ID**, e.g. `712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f`
+- A **UUID** wrapped in braces, e.g. `{c1cb1bb5-2e32-456e-a373-43978dc12aa1}`
+
+Both forms are returned by `bb pr reviewers list --json` (the `account_id` and `uuid` fields), so you can pipe the output of one command into another to script reviewer changes. See [`bb pr create`](/commands/pr/create-and-edit/#bb-pr-create) for matching `--reviewer` examples.
+
 ## `bb pr reviewers`
 
 ### Subcommands
@@ -20,8 +29,8 @@ This page covers reviewers on **existing** pull requests. To manage the reposito
 | Subcommand | Description |
 |------------|-------------|
 | `list <id>` | List reviewers on a pull request |
-| `add <id> <username>` | Add a reviewer to a pull request |
-| `remove <id> <username>` | Remove a reviewer from a pull request |
+| `add <id> <user>` | Add a reviewer to a pull request |
+| `remove <id> <user>` | Remove a reviewer from a pull request |
 
 ---
 
@@ -70,10 +79,10 @@ bb pr reviewers list 42 --json
 
 ## `bb pr reviewers add`
 
-Add a reviewer to a pull request by username.
+Add a reviewer to a pull request by account ID or UUID. The legacy `username` (login name) is not accepted by Bitbucket Cloud — see [Identifying users](#identifying-users).
 
 ```bash
-bb pr reviewers add <id> <username>
+bb pr reviewers add <id> <user>
 ```
 
 ### Arguments
@@ -81,7 +90,7 @@ bb pr reviewers add <id> <username>
 | Argument | Description |
 |----------|-------------|
 | `id` | Pull request ID |
-| `username` | Username of the user to add as reviewer |
+| `user` | Account ID (e.g. `712020:3cfed7e0-…`) or UUID (`{c1cb1bb5-…}`) of the user to add |
 
 ### Options
 
@@ -94,14 +103,17 @@ bb pr reviewers add <id> <username>
 ### Examples
 
 ```bash
-# Add johndoe as reviewer to PR #42
-bb pr reviewers add 42 johndoe
+# Add reviewer by account ID
+bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
+
+# Add reviewer by UUID (note the braces)
+bb pr reviewers add 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
 
 # Add reviewer in specific repository
-bb pr reviewers add 42 johndoe -w myworkspace -r myrepo
+bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" -w myworkspace -r myrepo
 
 # Add reviewer and get result as JSON
-bb pr reviewers add 42 johndoe --json
+bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --json
 ```
 
 ### Notes
@@ -114,10 +126,10 @@ bb pr reviewers add 42 johndoe --json
 
 ## `bb pr reviewers remove`
 
-Remove a reviewer from a pull request.
+Remove a reviewer from a pull request by account ID or UUID. The legacy `username` (login name) is not accepted by Bitbucket Cloud — see [Identifying users](#identifying-users).
 
 ```bash
-bb pr reviewers remove <id> <username>
+bb pr reviewers remove <id> <user>
 ```
 
 ### Arguments
@@ -125,7 +137,7 @@ bb pr reviewers remove <id> <username>
 | Argument | Description |
 |----------|-------------|
 | `id` | Pull request ID |
-| `username` | Username of the reviewer to remove |
+| `user` | Account ID (e.g. `712020:3cfed7e0-…`) or UUID (`{c1cb1bb5-…}`) of the reviewer to remove |
 
 ### Options
 
@@ -138,14 +150,17 @@ bb pr reviewers remove <id> <username>
 ### Examples
 
 ```bash
-# Remove johndoe as reviewer from PR #42
-bb pr reviewers remove 42 johndoe
+# Remove reviewer by account ID
+bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
+
+# Remove reviewer by UUID (note the braces)
+bb pr reviewers remove 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
 
 # Remove reviewer in specific repository
-bb pr reviewers remove 42 johndoe -w myworkspace -r myrepo
+bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" -w myworkspace -r myrepo
 
 # Remove reviewer and get result as JSON
-bb pr reviewers remove 42 johndoe --json
+bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --json
 ```
 
 ### Notes

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -371,7 +371,10 @@ authCmd
     '-p, --password <password>',
     'Bitbucket API token (implies API token auth)'
   )
-  .option('--app-password', 'Use API token authentication instead of OAuth')
+  .option(
+    '--app-password',
+    'Use API token authentication (instead of OAuth). App passwords are deprecated; use API tokens.'
+  )
   .option('--client-id <clientId>', 'Custom OAuth consumer client ID')
   .option(
     '--client-secret <clientSecret>',
@@ -721,7 +724,10 @@ prCmd
     'OPEN'
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
-  .option('--mine', 'Show only PRs where you are a reviewer')
+  .option(
+    '--mine',
+    'Show only PRs where you are a reviewer (not authored by you)'
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -1147,8 +1153,10 @@ prReviewersCmd
   });
 
 prReviewersCmd
-  .command('add <id> <username>')
-  .description('Add a reviewer to a pull request')
+  .command('add <id> <user>')
+  .description(
+    'Add a reviewer to a pull request (user is an account ID or {uuid})'
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -1158,19 +1166,21 @@ prReviewersCmd
       ],
     })
   )
-  .action(async (id, username, options) => {
+  .action(async (id, user, options) => {
     const context = createContext(cli);
     await runCommand(
       ServiceTokens.AddReviewerPRCommand,
-      withGlobalOptions({ id, username, ...options }, context),
+      withGlobalOptions({ id, username: user, ...options }, context),
       cli,
       context
     );
   });
 
 prReviewersCmd
-  .command('remove <id> <username>')
-  .description('Remove a reviewer from a pull request')
+  .command('remove <id> <user>')
+  .description(
+    'Remove a reviewer from a pull request (user is an account ID or {uuid})'
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -1180,11 +1190,11 @@ prReviewersCmd
       ],
     })
   )
-  .action(async (id, username, options) => {
+  .action(async (id, user, options) => {
     const context = createContext(cli);
     await runCommand(
       ServiceTokens.RemoveReviewerPRCommand,
-      withGlobalOptions({ id, username, ...options }, context),
+      withGlobalOptions({ id, username: user, ...options }, context),
       cli,
       context
     );
@@ -1259,7 +1269,10 @@ snippetCmd
   .command('create')
   .description('Create a new snippet')
   .option('-t, --title <title>', 'Snippet title')
-  .option('-f, --file <path...>', 'File(s) to include')
+  .option(
+    '-f, --file <path...>',
+    'File(s) to include (variadic; pass multiple paths or repeat the flag)'
+  )
   .option('--private', 'Create a private snippet (default)')
   .option('--public', 'Create a public snippet')
   .addHelpText(
@@ -1290,7 +1303,7 @@ snippetCmd
   .option('--public', 'Make snippet public')
   .option(
     '-f, --file <path...>',
-    'Replace/add file(s) (sends multipart update)'
+    'Replace/add file(s) (variadic; pass multiple paths or repeat the flag; sends multipart update)'
   )
   .addHelpText(
     'after',

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -312,6 +312,67 @@ describe('CLI help text integration', () => {
     expect(output).toContain('defaultWorkspace');
     expect(output).toContain('skipVersionCheck');
     expect(output).toContain('versionCheckInterval');
+    // Issue #181: prCreateIncludeDefaultReviewers must be discoverable from
+    // `bb config set --help` so users learn about it without grepping the docs.
+    expect(output).toContain('prCreateIncludeDefaultReviewers');
+  });
+
+  it('should list prCreateIncludeDefaultReviewers in config get readable keys', () => {
+    const configCmd = cli.commands.find((c) => c.name() === 'config')!;
+    const getCmd = configCmd.commands.find((c) => c.name() === 'get')!;
+    const output = captureHelp(getCmd);
+
+    expect(output).toContain('Readable config keys:');
+    expect(output).toContain('prCreateIncludeDefaultReviewers');
+  });
+
+  it('should describe --mine without ambiguity (reviewer, not author)', () => {
+    const prCmd = cli.commands.find((c) => c.name() === 'pr')!;
+    const listCmd = prCmd.commands.find((c) => c.name() === 'list')!;
+    const output = captureHelp(listCmd);
+
+    // The natural reading of "PRs where you are a reviewer" is ambiguous;
+    // help must spell out it excludes PRs you authored. Commander wraps the
+    // option description, so collapse whitespace before asserting.
+    const flat = output.replace(/\s+/g, ' ');
+    expect(flat).toContain('not authored by you');
+  });
+
+  it('should mark app passwords as deprecated in auth login --app-password help', () => {
+    const authCmd = cli.commands.find((c) => c.name() === 'auth')!;
+    const loginCmd = authCmd.commands.find((c) => c.name() === 'login')!;
+    const output = captureHelp(loginCmd);
+
+    expect(output).toContain('--app-password');
+    expect(output).toContain('API token authentication');
+    expect(output).toContain('App passwords are deprecated');
+  });
+
+  it('should advertise variadic --file in snippet create help', () => {
+    const snippetCmd = cli.commands.find((c) => c.name() === 'snippet')!;
+    const createCmd = snippetCmd.commands.find((c) => c.name() === 'create')!;
+    const output = captureHelp(createCmd);
+
+    // Issue #181: --file is variadic but help didn't say so.
+    expect(output).toContain('variadic');
+    expect(output).toContain('-f config.yml -f setup.sh');
+  });
+
+  it('should show pr reviewers add/remove accept account ID or UUID', () => {
+    const prCmd = cli.commands.find((c) => c.name() === 'pr')!;
+    const reviewersCmd = prCmd.commands.find((c) => c.name() === 'reviewers')!;
+    const addCmd = reviewersCmd.commands.find((c) => c.name() === 'add')!;
+    const removeCmd = reviewersCmd.commands.find((c) => c.name() === 'remove')!;
+
+    const addOutput = captureHelp(addCmd);
+    expect(addOutput).toContain('<user>');
+    expect(addOutput).toContain('account ID');
+    expect(addOutput).toContain('{uuid}');
+
+    const removeOutput = captureHelp(removeCmd);
+    expect(removeOutput).toContain('<user>');
+    expect(removeOutput).toContain('account ID');
+    expect(removeOutput).toContain('{uuid}');
   });
 });
 
@@ -634,7 +695,7 @@ describe('CLI leaf command options', () => {
     ]);
     expect(required(requireCommand('pr', 'reviewers', 'add'))).toEqual([
       'id',
-      'username',
+      'user',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Closes #181. Reconciles small mismatches across `--help`, the docs site, and the source — none are blockers individually but collectively they erode trust.

### CLI help (`src/cli.ts`)

- **`bb auth login --app-password`**: clarify that app passwords are deprecated and the flag opts into API token auth.
- **`bb pr list --mine`**: tighten help text — `Show only PRs where you are a reviewer (not authored by you)` so the meaning isn't ambiguous.
- **`bb pr reviewers add` / `remove`**: rename the positional from `<username>` to `<user>` and document that it accepts an account ID or `{uuid}` (Bitbucket Cloud no longer accepts the legacy login name). The internal `username` field is preserved at the command interface, so the action handler still maps `user → username` to keep the command class unchanged.
- **`bb snippet create --file` / `bb snippet edit --file`**: spell out in the help description that the flag is variadic and can be repeated.

### Docs

- `docs/src/content/docs/commands/config.mdx`: add the auto-managed `lastVersionCheck` config key (referenced in CHANGELOG v1.11.1) with a note that it's read-only from the user's perspective.
- `docs/src/content/docs/commands/pr/reviewers.mdx`: rewrite to use `<user>`, add an "Identifying users" section, and switch examples from `johndoe` to account ID / UUID forms.
- `docs/src/content/docs/commands/completion.mdx`: include `default-reviewers` in the `bb repo <Tab>` example.

### Tests (`tests/cli.test.ts`)

- New help-text assertions for: `prCreateIncludeDefaultReviewers` listed in both `config get` and `config set` help, `--mine` says "not authored by you", `--app-password` flags app passwords as deprecated, snippet `create --file` advertises "variadic", and `pr reviewers add`/`remove` help mentions `<user>` + `account ID` + `{uuid}`.
- Update `registeredArguments` assertion for `pr reviewers add` to expect `['id', 'user']`.

### Verified

- `--color` flag scope: already documented at `docs/src/content/docs/commands/pr/diff-and-checkout.mdx:74` (option table + examples), so the env-vars page note that `--color` is "only on `bb pr diff`" is correct — no change needed.
- `prCreateIncludeDefaultReviewers` was already in `bb config set --help`'s `Settable config keys` (added in a prior PR); locked it in with a regression test.

## Test plan

- [x] `bun test` — 933 passing
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [ ] Spot-check `bb auth login --help`, `bb pr list --help`, `bb pr reviewers add --help`, `bb snippet create --help` after merge