### PR TITLE
refactor: phase 1 architectural cleanups

### DIFF
--- a/.changeset/architectural-phase-1.md
+++ b/.changeset/architectural-phase-1.md
@@ -1,0 +1,34 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Architectural Phase 1: leverage moves across services and commands.
+
+- Add `OutputService.truncate()` and remove four duplicate command-local
+  copies. Inline `slice + ellipsis` patterns in `pr comments list`,
+  `snippet comments list` and `pr edit` now go through the shared helper.
+- Add `BaseCommand.parsePositiveInt()` (strict: rejects "1abc", "1.5",
+  zero, negatives) and migrate all `--id`, comment-id, line-to/line-from
+  parsers to it. Removes the local `parsePositiveInt` in `bb browse`.
+  Error messages now consistently end with a `Run \`bb … --help\` for
+  usage.` hint.
+- Add `IContextService.requireRepoContextFor(options, context)` to
+  replace the boilerplate
+  `requireRepoContext({ ...context.globalOptions, ...options })` that
+  appeared in 23 commands.
+- Add a 60-second default timeout to `GitService` so a stalled `git`
+  subprocess no longer hangs the CLI; configurable via the constructor.
+- Wrap `JSON.parse` in `ConfigService.getConfig()` so a corrupted config
+  file surfaces a `BBError(CONFIG_READ_FAILED)` with a precise message
+  instead of a generic `SyntaxError`.
+- Wrap the dynamic `import('jq-wasm')` in `OutputService.runJq` so a
+  missing/broken jq runtime surfaces a `BBError(JQ_FAILED)` with
+  remediation guidance.
+- Surface causes for opportunistic failures (`version-check` network
+  errors, `oauth` browser-open failures) when `DEBUG=true`. Behavior is
+  unchanged when DEBUG is unset.
+- Make `pr comments list` and `pr reviewers list` JSON output include
+  `workspace` and `repoSlug` for parity with the other list commands.
+- Build now emits sourcemaps (`bun build --sourcemap`).
+- CI now runs `bun run lint:docs` so error-code and env-var docs cannot
+  drift unnoticed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Lint docs (error codes & env vars)
+        run: bun run lint:docs
+
       - name: Check formatting
         run: bun run format:check
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target bun --external tabtab",
+    "build": "bun build src/index.ts --outdir dist --target bun --sourcemap --external tabtab",
     "test": "bun test",
     "lint": "tsc --noEmit",
     "lint:docs": "bun scripts/check-error-codes-docs.ts && bun scripts/check-env-vars-docs.ts",

--- a/src/commands/browse.command.ts
+++ b/src/commands/browse.command.ts
@@ -67,10 +67,10 @@ export class BrowseCommand extends BaseCommand<BrowseOptions, BrowseResult> {
     options: BrowseOptions,
     context: CommandContext
   ): Promise<BrowseResult> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     this.validateFlagCombination(options);
 
@@ -154,7 +154,10 @@ export class BrowseCommand extends BaseCommand<BrowseOptions, BrowseResult> {
 
     if (target && target.length > 0) {
       if (PR_NUMBER_PATTERN.test(target)) {
-        return this.urlBuilder.pullRequest(ctx, Number.parseInt(target, 10));
+        return this.urlBuilder.pullRequest(
+          ctx,
+          this.parsePositiveInt(target, 'target')
+        );
       }
       if (SHA_PATTERN.test(target)) {
         return this.urlBuilder.commit(ctx, target);
@@ -248,22 +251,6 @@ export class BrowseCommand extends BaseCommand<BrowseOptions, BrowseResult> {
       // browse useful even with `--workspace`/`--repo` overrides.
       return 'HEAD';
     }
-  }
-
-  private parsePositiveInt(value: string, name: string): number {
-    const parsed = Number.parseInt(value, 10);
-    if (
-      !Number.isFinite(parsed) ||
-      parsed <= 0 ||
-      String(parsed) !== value.trim()
-    ) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_INVALID,
-        message: this.appendHelpHint(`--${name} must be a positive integer.`),
-        context: { [name]: value },
-      });
-    }
-    return parsed;
   }
 
   private async openInBrowser(url: string): Promise<void> {

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -55,12 +55,12 @@ export class ActivityPRCommand extends BaseCommand<
     options: { id: string } & ActivityPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
     const filterTypes = this.parseTypeFilter(options.type);
     const limit = parseLimit(options.limit);
 
@@ -226,14 +226,14 @@ export class ActivityPRCommand extends BaseCommand<
       case 'comment': {
         const content = getRawContent(activity.comment?.content) ?? '';
         const id = activity.comment?.id ? `#${activity.comment.id}` : '';
-        const snippet = this.truncate(content, 80);
+        const snippet = this.output.truncate(content, 80);
         return [id, snippet].filter(Boolean).join(' ');
       }
       case 'approval':
         return 'approved';
       case 'changes_requested': {
         const reason = activity.changes_requested?.reason;
-        return reason ? this.truncate(reason, 80) : 'changes requested';
+        return reason ? this.output.truncate(reason, 80) : 'changes requested';
       }
       case 'merge':
         return this.formatCommitDetail(activity.merge?.commit?.hash, 'merged');
@@ -246,7 +246,7 @@ export class ActivityPRCommand extends BaseCommand<
           return `state: ${activity.update.state}`;
         }
         if (activity.update?.title) {
-          return `title: ${this.truncate(activity.update.title, 60)}`;
+          return `title: ${this.output.truncate(activity.update.title, 60)}`;
         }
         if (activity.update?.description) {
           return 'description updated';
@@ -265,12 +265,5 @@ export class ActivityPRCommand extends BaseCommand<
 
     const shortHash = hash.slice(0, 7);
     return label ? `${label} ${shortHash}` : shortHash;
-  }
-
-  private truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) {
-      return text;
-    }
-    return text.substring(0, maxLength - 3) + '...';
   }
 }

--- a/src/commands/pr/approve.command.ts
+++ b/src/commands/pr/approve.command.ts
@@ -32,12 +32,12 @@ export class ApprovePRCommand extends BaseCommand<
     options: { id: string } & ApprovePROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdApprovePost(
       {

--- a/src/commands/pr/checkout.command.ts
+++ b/src/commands/pr/checkout.command.ts
@@ -36,12 +36,12 @@ export class CheckoutPRCommand extends BaseCommand<
     options: { id: string } & CheckoutPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const prResponse =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(

--- a/src/commands/pr/checks.command.ts
+++ b/src/commands/pr/checks.command.ts
@@ -33,12 +33,12 @@ export class ChecksPRCommand extends BaseCommand<
     options: { id: string } & ChecksPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const response =
       await this.commitStatusesApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdStatusesGet(
@@ -107,7 +107,7 @@ export class ChecksPRCommand extends BaseCommand<
       return [
         `${stateIcon} ${stateLabel}`,
         this.output.bold(name),
-        this.truncate(description, 40),
+        this.output.truncate(description, 40),
         status.updated_on ? this.output.formatDate(status.updated_on) : '-',
       ];
     });
@@ -171,12 +171,5 @@ export class ChecksPRCommand extends BaseCommand<
       },
       { successful: 0, failed: 0, pending: 0 }
     );
-  }
-
-  private truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) {
-      return text;
-    }
-    return text.substring(0, maxLength - 3) + '...';
   }
 }

--- a/src/commands/pr/comment.command.ts
+++ b/src/commands/pr/comment.command.ts
@@ -68,43 +68,26 @@ export class CommentPRCommand extends BaseCommand<
       });
     }
 
-    if (options.lineTo) {
-      const parsed = Number.parseInt(options.lineTo, 10);
-      if (Number.isNaN(parsed) || parsed < 1) {
-        throw new BBError({
-          code: ErrorCode.VALIDATION_INVALID,
-          message: '--line-to must be a positive integer',
-        });
-      }
-    }
+    const lineTo = options.lineTo
+      ? this.parsePositiveInt(options.lineTo, 'line-to')
+      : undefined;
+    const lineFrom = options.lineFrom
+      ? this.parsePositiveInt(options.lineFrom, 'line-from')
+      : undefined;
 
-    if (options.lineFrom) {
-      const parsed = Number.parseInt(options.lineFrom, 10);
-      if (Number.isNaN(parsed) || parsed < 1) {
-        throw new BBError({
-          code: ErrorCode.VALIDATION_INVALID,
-          message: '--line-from must be a positive integer',
-        });
-      }
-    }
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
-
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     // Build inline object when --file is provided
     const inline = options.file
       ? {
           path: options.file,
-          ...(options.lineTo
-            ? { to: Number.parseInt(options.lineTo, 10) }
-            : {}),
-          ...(options.lineFrom
-            ? { from: Number.parseInt(options.lineFrom, 10) }
-            : {}),
+          ...(lineTo !== undefined ? { to: lineTo } : {}),
+          ...(lineFrom !== undefined ? { from: lineFrom } : {}),
         }
       : undefined;
 

--- a/src/commands/pr/comments.delete.command.ts
+++ b/src/commands/pr/comments.delete.command.ts
@@ -35,13 +35,13 @@ export class DeleteCommentPRCommand extends BaseCommand<
     options: { prId: string; commentId: string } & DeleteCommentPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.prId, 'pr-id');
-    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+    const prId = this.parsePositiveInt(options.prId, 'pr-id');
+    const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
     if (!options.yes) {
       throw new BBError({

--- a/src/commands/pr/comments.edit.command.ts
+++ b/src/commands/pr/comments.edit.command.ts
@@ -36,13 +36,13 @@ export class EditCommentPRCommand extends BaseCommand<
     } & EditCommentPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.prId, 'pr-id');
-    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+    const prId = this.parsePositiveInt(options.prId, 'pr-id');
+    const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsCommentIdPut(

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -43,12 +43,12 @@ export class ListCommentsPRCommand extends BaseCommand<
     options: { id: string } & ListCommentsPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
     const limit = parseLimit(options.limit);
 
     const values = await collectPages<PullrequestComment>({
@@ -72,6 +72,8 @@ export class ListCommentsPRCommand extends BaseCommand<
 
     if (context.globalOptions.json) {
       await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
         pullRequestId: prId,
         count: values.length,
         comments: values,
@@ -93,7 +95,7 @@ export class ListCommentsPRCommand extends BaseCommand<
           ? '[deleted]'
           : options.truncate === false
             ? content
-            : content.slice(0, 60) + (content.length > 60 ? '...' : ''),
+            : this.output.truncate(content, 60),
         this.output.formatDate(comment.created_on ?? ''),
       ];
     });

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -65,10 +65,10 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
       });
     }
 
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     let sourceBranch = options.source;
     if (!sourceBranch) {

--- a/src/commands/pr/decline.command.ts
+++ b/src/commands/pr/decline.command.ts
@@ -32,12 +32,12 @@ export class DeclinePRCommand extends BaseCommand<
     options: { id: string } & DeclinePROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdDeclinePost(

--- a/src/commands/pr/diff.command.ts
+++ b/src/commands/pr/diff.command.ts
@@ -44,21 +44,14 @@ export class DiffPRCommand extends BaseCommand<DiffPROptions, void> {
     options: DiffPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     let prId: number;
     if (options.id) {
-      prId = Number.parseInt(options.id, 10);
-      if (Number.isNaN(prId)) {
-        throw new BBError({
-          code: ErrorCode.VALIDATION_INVALID,
-          message: 'Invalid PR ID',
-          context: { id: options.id },
-        });
-      }
+      prId = this.parsePositiveInt(options.id, 'id');
     } else {
       const currentBranch = await this.gitService.getCurrentBranch();
 

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -39,14 +39,14 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
     options: EditPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     let prId: number;
     if (options.id) {
-      prId = Number.parseInt(options.id, 10);
+      prId = this.parsePositiveInt(options.id, 'id');
     } else {
       const currentBranch = await this.gitService.getCurrentBranch();
 
@@ -144,10 +144,7 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
     this.output.success(`Updated pull request #${pr.id}`);
     this.output.text(`  ${this.output.dim('Title:')} ${pr.title}`);
     if (pr.description) {
-      const truncatedDesc =
-        pr.description.length > 100
-          ? pr.description.substring(0, 100) + '...'
-          : pr.description;
+      const truncatedDesc = this.output.truncate(pr.description, 100);
       this.output.text(`  ${this.output.dim('Description:')} ${truncatedDesc}`);
     }
     this.output.text(`  ${this.output.dim('URL:')} ${links?.html?.href}`);

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -40,10 +40,10 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     options: ListPRsOptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     const state = options.state
       ? this.parseEnumOption(options.state, 'state', PR_STATES)
@@ -103,20 +103,13 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
         | undefined;
       return [
         `#${pr.id}`,
-        this.truncate(title ?? '', 50),
+        this.output.truncate(title ?? '', 50),
         pr.author?.display_name ?? 'Unknown',
         `${source?.branch?.name ?? 'unknown'} → ${destination?.branch?.name ?? 'unknown'}`,
       ];
     });
 
     this.output.table(['ID', 'TITLE', 'AUTHOR', 'BRANCHES'], rows);
-  }
-
-  private truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) {
-      return text;
-    }
-    return text.substring(0, maxLength - 3) + '...';
   }
 
   private async buildMineFilter(): Promise<string | undefined> {

--- a/src/commands/pr/merge.command.ts
+++ b/src/commands/pr/merge.command.ts
@@ -43,12 +43,12 @@ export class MergePRCommand extends BaseCommand<
     options: { id: string } & MergePROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const request: {
       type: 'pullrequest_merge_parameters';

--- a/src/commands/pr/ready.command.ts
+++ b/src/commands/pr/ready.command.ts
@@ -32,12 +32,12 @@ export class ReadyPRCommand extends BaseCommand<
     options: { id: string } & ReadyPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = Number.parseInt(options.id, 10);
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdPut(

--- a/src/commands/pr/reviewers.add.command.ts
+++ b/src/commands/pr/reviewers.add.command.ts
@@ -37,12 +37,12 @@ export class AddReviewerPRCommand extends BaseCommand<
     options: AddReviewerPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     // Look up the user to get their UUID
     const userResponse = await this.usersApi.usersSelectedUserGet({

--- a/src/commands/pr/reviewers.list.command.ts
+++ b/src/commands/pr/reviewers.list.command.ts
@@ -34,12 +34,12 @@ export class ListReviewersPRCommand extends BaseCommand<
     options: ListReviewersPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const response =
       await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet(
@@ -55,6 +55,8 @@ export class ListReviewersPRCommand extends BaseCommand<
 
     if (context.globalOptions.json) {
       await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
         pullRequestId: prId,
         count: reviewers.length,
         reviewers,

--- a/src/commands/pr/reviewers.remove.command.ts
+++ b/src/commands/pr/reviewers.remove.command.ts
@@ -37,12 +37,12 @@ export class RemoveReviewerPRCommand extends BaseCommand<
     options: RemoveReviewerPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     // Look up the user to get their UUID
     const userResponse = await this.usersApi.usersSelectedUserGet({

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -33,12 +33,12 @@ export class ViewPRCommand extends BaseCommand<
     options: { id: string } & ViewPROptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
-    const prId = this.parseIntOption(options.id, 'id');
+    const prId = this.parsePositiveInt(options.id, 'id');
 
     const response = await this.pullrequestsApi
       .repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdGet({

--- a/src/commands/repo/default-reviewers.add.command.ts
+++ b/src/commands/repo/default-reviewers.add.command.ts
@@ -36,10 +36,10 @@ export class AddDefaultReviewerCommand extends BaseCommand<
     options: AddDefaultReviewerOptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     // Bitbucket's default-reviewers PUT accepts account_id or {uuid} in the
     // URL path, but not the nickname. Resolve via the users API first so

--- a/src/commands/repo/default-reviewers.list.command.ts
+++ b/src/commands/repo/default-reviewers.list.command.ts
@@ -34,10 +34,10 @@ export class ListDefaultReviewersCommand extends BaseCommand<
     options: ListDefaultReviewersOptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     const mode = options.repoOnly ? 'direct' : 'effective';
     const reviewers = await this.defaultReviewerService.list(repoContext, mode);

--- a/src/commands/repo/default-reviewers.remove.command.ts
+++ b/src/commands/repo/default-reviewers.remove.command.ts
@@ -38,10 +38,10 @@ export class RemoveDefaultReviewerCommand extends BaseCommand<
     options: RemoveDefaultReviewerOptions,
     context: CommandContext
   ): Promise<void> {
-    const repoContext = await this.contextService.requireRepoContext({
-      ...context.globalOptions,
-      ...options,
-    });
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
 
     if (!options.yes) {
       throw new BBError({

--- a/src/commands/snippet/comments.delete.command.ts
+++ b/src/commands/snippet/comments.delete.command.ts
@@ -42,7 +42,7 @@ export class DeleteSnippetCommentCommand extends BaseCommand<
       options.workspace ?? context.globalOptions.workspace
     );
 
-    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+    const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
     if (!options.yes) {
       throw new BBError({

--- a/src/commands/snippet/comments.edit.command.ts
+++ b/src/commands/snippet/comments.edit.command.ts
@@ -45,7 +45,7 @@ export class EditSnippetCommentCommand extends BaseCommand<
       options.workspace ?? context.globalOptions.workspace
     );
 
-    const commentId = this.parseIntOption(options.commentId, 'comment-id');
+    const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
     const body: SnippetComment = {
       type: 'snippet_comment',

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -83,7 +83,7 @@ export class ListSnippetCommentsCommand extends BaseCommand<
         String(comment.id ?? ''),
         getUserDisplayName(comment.user) ?? 'Unknown',
         this.output.formatDate(comment.created_on ?? ''),
-        content.slice(0, 60) + (content.length > 60 ? '...' : ''),
+        this.output.truncate(content, 60),
       ];
     });
 

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -145,6 +145,26 @@ export abstract class BaseCommand<
   }
 
   /**
+   * Parse a string option as a positive integer (>= 1), throwing on invalid
+   * input. Use for IDs, limits, line numbers, and any other count-like option
+   * where zero or negative values would be meaningless. Strict: rejects
+   * trailing/leading non-digit characters (e.g. "1abc", "1.5") so user typos
+   * surface immediately rather than silently truncating.
+   */
+  protected parsePositiveInt(value: string, name: string): number {
+    const trimmed = value.trim();
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== trimmed) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(`--${name} must be a positive integer.`),
+        context: { [name]: value },
+      });
+    }
+    return parsed;
+  }
+
+  /**
    * Validate a string option against a set of allowed values
    */
   protected parseEnumOption<T extends string>(

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -10,6 +10,7 @@ import type {
   RepoContext,
   GlobalOptions,
 } from '../../types/config.js';
+import type { CommandContext } from './commands.js';
 
 /**
  * Application config interface — reading and writing general settings
@@ -68,6 +69,17 @@ export interface IContextService {
   getRepoContextFromGit(): Promise<RepoContext | null>;
   getRepoContext(options: GlobalOptions): Promise<RepoContext | null>;
   requireRepoContext(options: GlobalOptions): Promise<RepoContext>;
+  /**
+   * Convenience used by command implementations: merges the global options
+   * carried on `context` with command-local options before resolving the repo
+   * context. Replaces the boilerplate
+   * `requireRepoContext({ ...context.globalOptions, ...options })` that
+   * previously appeared in every command.
+   */
+  requireRepoContextFor(
+    options: Partial<GlobalOptions>,
+    context: CommandContext
+  ): Promise<RepoContext>;
   requireWorkspace(explicit?: string): Promise<string>;
 }
 
@@ -124,6 +136,13 @@ export interface IOutputService {
   warning(message: string): void;
   info(message: string): void;
   text(message: string): void;
+  /**
+   * Truncate `text` to fit within `maxLength` characters, appending `suffix`
+   * when truncation occurs. Returns the input unchanged when it already fits
+   * or when `maxLength` is <= 0. The default ellipsis is the three-dot ASCII
+   * sequence to match historical output and stay safe across terminals.
+   */
+  truncate(text: string, maxLength: number, suffix?: string): string;
   format(text: string, formatter: (text: string) => string): string;
   dim(text: string): string;
   highlight(text: string): string;

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -130,7 +130,18 @@ export class ConfigService implements IConfigService, ICredentialStore {
       await this.verifyPermissions(this.configFile, CONFIG_FILE_MODE, 'file');
 
       const data = await fs.readFile(this.configFile, 'utf-8');
-      this.configCache = JSON.parse(data) as BBConfig;
+      try {
+        this.configCache = JSON.parse(data) as BBConfig;
+      } catch (parseError) {
+        throw new BBError({
+          code: ErrorCode.CONFIG_READ_FAILED,
+          message:
+            `Config file is not valid JSON: ${this.configFile}. ` +
+            'Fix the file by hand or remove it and run `bb auth login` again.',
+          cause: parseError instanceof Error ? parseError : undefined,
+          context: { configFile: this.configFile },
+        });
+      }
       return this.configCache;
     } catch (error) {
       // File doesn't exist - return empty config

--- a/src/services/context.service.ts
+++ b/src/services/context.service.ts
@@ -7,6 +7,7 @@ import type {
   IGitService,
   IConfigService,
 } from '../core/interfaces/services.js';
+import type { CommandContext } from '../core/interfaces/commands.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 import type { RepoContext, GlobalOptions } from '../types/config.js';
 
@@ -163,6 +164,16 @@ export class ContextService implements IContextService {
     }
 
     return result.context;
+  }
+
+  public async requireRepoContextFor(
+    options: Partial<GlobalOptions>,
+    context: CommandContext
+  ): Promise<RepoContext> {
+    return this.requireRepoContext({
+      ...context.globalOptions,
+      ...options,
+    });
   }
 
   private buildRepoNotFoundMessage(

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -11,11 +11,21 @@ export interface GitExecResult {
   exitCode: number;
 }
 
+/**
+ * Default timeout for `git` subprocess calls. Network-bound commands like
+ * `git clone` or `git fetch` against a slow remote can legitimately take a
+ * while, so this default is generous; callers that want a tighter bound can
+ * pass `cwd` plus a custom `timeoutMs`.
+ */
+const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+
 export class GitService implements IGitService {
   private readonly cwd: string;
+  private readonly timeoutMs: number;
 
-  constructor(cwd?: string) {
+  constructor(cwd?: string, options: { timeoutMs?: number } = {}) {
     this.cwd = cwd ?? process.cwd();
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
   }
 
   private async exec(args: string[], cwd?: string): Promise<GitExecResult> {
@@ -25,15 +35,39 @@ export class GitService implements IGitService {
       stderr: 'pipe',
     });
 
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    const exitCode = await proc.exited;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill();
+      } catch {
+        // The process may have already exited between the timer firing and
+        // the kill landing; that's fine, we surface the timeout below either
+        // way.
+      }
+    }, this.timeoutMs);
 
-    return {
-      stdout: stdout.trim(),
-      stderr: stderr.trim(),
-      exitCode,
-    };
+    try {
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+
+      if (timedOut) {
+        throw new GitError(
+          `git ${args.join(' ')} timed out after ${this.timeoutMs}ms`,
+          `git ${args.join(' ')}`,
+          exitCode
+        );
+      }
+
+      return {
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async execOrError(args: string[], cwd?: string): Promise<string> {
@@ -108,6 +142,6 @@ export class GitService implements IGitService {
    * Create a new instance with a different working directory
    */
   public withCwd(cwd: string): GitService {
-    return new GitService(cwd);
+    return new GitService(cwd, { timeoutMs: this.timeoutMs });
   }
 }

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -373,8 +373,13 @@ export class OAuthService {
         try {
           const open = (await import('open')).default;
           await open(authUrl);
-        } catch {
-          // If browser can't be opened, user can copy the URL
+        } catch (err) {
+          // The CLI keeps working — the user can copy the printed URL — but
+          // tell DEBUG users why nothing opened.
+          if (process.env.DEBUG === 'true') {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(`[oauth] could not open browser: ${message}`);
+          }
         }
         console.error(`If the browser doesn't open, visit:\n${authUrl}\n`);
       });

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -148,6 +148,16 @@ export class OutputService implements IOutputService {
     console.log(stripControl(message));
   }
 
+  public truncate(text: string, maxLength: number, suffix = '...'): string {
+    if (maxLength <= 0 || text.length <= maxLength) {
+      return text;
+    }
+    if (suffix.length >= maxLength) {
+      return text.slice(0, maxLength);
+    }
+    return text.slice(0, maxLength - suffix.length) + suffix;
+  }
+
   public formatDate(date: string | Date): string {
     const d = typeof date === 'string' ? new Date(date) : date;
     return d.toLocaleDateString('en-US', {
@@ -260,7 +270,20 @@ function projectByFieldsRespectingWrapper(
 }
 
 async function runJq(data: unknown, expression: string): Promise<string> {
-  const jq = await import('jq-wasm');
+  let jq: typeof import('jq-wasm');
+  try {
+    jq = await import('jq-wasm');
+  } catch (error) {
+    throw new BBError({
+      code: ErrorCode.JQ_FAILED,
+      message:
+        'Failed to load the embedded jq runtime (jq-wasm). ' +
+        'Reinstall the CLI or report this issue.',
+      cause: error instanceof Error ? error : undefined,
+      context: { expression },
+    });
+  }
+
   let result: { stdout: string; stderr: string; exitCode: number };
   try {
     result = await jq.raw(data as object, expression);

--- a/src/services/version.service.ts
+++ b/src/services/version.service.ts
@@ -68,8 +68,14 @@ export class VersionService {
         latestVersion,
         updateAvailable,
       };
-    } catch {
-      // Silently fail - don't bother user with network errors
+    } catch (error) {
+      // The version check is opportunistic — never block the CLI on it.
+      // Surface the failure to DEBUG callers so a user who's diagnosing
+      // "why am I not seeing the update banner?" can see the cause.
+      if (process.env.DEBUG === 'true') {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[version-check] skipped: ${message}`);
+      }
       return null;
     }
   }

--- a/tests/commands/default-reviewers.test.ts
+++ b/tests/commands/default-reviewers.test.ts
@@ -88,6 +88,12 @@ function createContextService(): IContextService {
     async requireRepoContext() {
       return { workspace: 'ws', repoSlug: 'repo' };
     },
+    async requireRepoContextFor() {
+      return { workspace: 'ws', repoSlug: 'repo' };
+    },
+    async requireWorkspace() {
+      return 'ws';
+    },
   };
 }
 

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -826,7 +826,7 @@ describe('ViewPRCommand', () => {
 
     await expect(
       command.execute({ id: 'abc' }, { globalOptions: {} })
-    ).rejects.toThrow(/--id must be a valid integer/);
+    ).rejects.toThrow(/--id must be a positive integer/);
   });
 
   it('should render "No reviewers assigned" when there are no reviewer participants', async () => {
@@ -1119,7 +1119,7 @@ describe('ActivityPRCommand', () => {
 
     await expect(
       command.execute({ id: 'abc' }, { globalOptions: {} })
-    ).rejects.toThrow(/--id must be a valid integer/);
+    ).rejects.toThrow(/--id must be a positive integer/);
   });
 
   it('should reject an invalid --type value', async () => {
@@ -1737,7 +1737,7 @@ describe('MergePRCommand', () => {
 
     await expect(
       command.execute({ id: 'abc' }, { globalOptions: {} })
-    ).rejects.toThrow(/--id must be a valid integer/);
+    ).rejects.toThrow(/--id must be a positive integer/);
   });
 });
 
@@ -2688,8 +2688,8 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_INVALID);
-      expect((error as BBError).message).toBe(
-        '--line-to must be a positive integer'
+      expect((error as BBError).message).toMatch(
+        /^--line-to must be a positive integer\./
       );
     }
   });
@@ -2717,8 +2717,8 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_INVALID);
-      expect((error as BBError).message).toBe(
-        '--line-to must be a positive integer'
+      expect((error as BBError).message).toMatch(
+        /^--line-to must be a positive integer\./
       );
     }
   });
@@ -2746,8 +2746,8 @@ describe('CommentPRCommand', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(BBError);
       expect((error as BBError).code).toBe(ErrorCode.VALIDATION_INVALID);
-      expect((error as BBError).message).toBe(
-        '--line-from must be a positive integer'
+      expect((error as BBError).message).toMatch(
+        /^--line-from must be a positive integer\./
       );
     }
   });

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -945,7 +945,7 @@ describe('EditSnippetCommentCommand', () => {
         },
         makeContext()
       )
-    ).rejects.toThrow('must be a valid integer');
+    ).rejects.toThrow('must be a positive integer');
   });
 });
 

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -87,6 +87,10 @@ class TestCommandWithParseHelpers extends BaseCommand<
     return this.parseIntOption(value, name);
   }
 
+  public callParsePositiveInt(value: string, name: string): number {
+    return this.parsePositiveInt(value, name);
+  }
+
   public callParseEnumOption<T extends string>(
     value: string,
     name: string,
@@ -442,6 +446,60 @@ describe('BaseCommand', () => {
       expect(() => command.callParseIntOption('', 'limit')).toThrow(
         '--limit must be a valid integer'
       );
+    });
+  });
+
+  describe('parsePositiveInt', () => {
+    it('returns the integer for a positive value', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(command.callParsePositiveInt('42', 'id')).toBe(42);
+    });
+
+    it('rejects zero', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() => command.callParsePositiveInt('0', 'id')).toThrow(
+        '--id must be a positive integer'
+      );
+    });
+
+    it('rejects negative numbers', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() => command.callParsePositiveInt('-1', 'id')).toThrow(
+        '--id must be a positive integer'
+      );
+    });
+
+    it('rejects non-canonical input like "1abc"', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() => command.callParsePositiveInt('1abc', 'id')).toThrow(
+        '--id must be a positive integer'
+      );
+    });
+
+    it('rejects decimals like "1.5"', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() => command.callParsePositiveInt('1.5', 'id')).toThrow(
+        '--id must be a positive integer'
+      );
+    });
+
+    it('rejects empty string', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() => command.callParsePositiveInt('', 'id')).toThrow(
+        '--id must be a positive integer'
+      );
+    });
+
+    it('accepts a value with surrounding whitespace', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(command.callParsePositiveInt('  7  ', 'id')).toBe(7);
     });
   });
 

--- a/tests/services/context.service.test.ts
+++ b/tests/services/context.service.test.ts
@@ -241,6 +241,49 @@ describe('ContextService', () => {
     });
   });
 
+  describe('requireRepoContextFor', () => {
+    it('merges context.globalOptions with command options before resolving', async () => {
+      const gitService = createMockGitService({ isRepo: false });
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      const result = await service.requireRepoContextFor(
+        {},
+        { globalOptions: { workspace: 'gws', repo: 'grepo' } }
+      );
+
+      expect(result).toEqual({ workspace: 'gws', repoSlug: 'grepo' });
+    });
+
+    it('lets command-local options override globals', async () => {
+      const gitService = createMockGitService({ isRepo: false });
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      const result = await service.requireRepoContextFor(
+        { workspace: 'local-ws', repo: 'local-repo' },
+        { globalOptions: { workspace: 'gws', repo: 'grepo' } }
+      );
+
+      expect(result).toEqual({
+        workspace: 'local-ws',
+        repoSlug: 'local-repo',
+      });
+    });
+
+    it('throws CONTEXT_REPO_NOT_FOUND when nothing resolves', async () => {
+      const gitService = createMockGitService({ isRepo: false });
+      const configService = createMockConfigService();
+      const service = new ContextService(gitService, configService);
+
+      await expect(
+        service.requireRepoContextFor({}, { globalOptions: {} })
+      ).rejects.toMatchObject({
+        code: ErrorCode.CONTEXT_REPO_NOT_FOUND,
+      });
+    });
+  });
+
   describe('requireWorkspace', () => {
     it('returns the explicit value when provided', async () => {
       const service = new ContextService(

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -320,6 +320,29 @@ describe('OutputService', () => {
     });
   });
 
+  describe('truncate', () => {
+    it('returns the input unchanged when it fits', () => {
+      expect(output.truncate('hello', 10)).toBe('hello');
+    });
+
+    it('appends the default ellipsis when the input is too long', () => {
+      expect(output.truncate('hello world', 8)).toBe('hello...');
+    });
+
+    it('honors a custom suffix', () => {
+      expect(output.truncate('hello world', 8, '…')).toBe('hello w…');
+    });
+
+    it('returns the input unchanged when maxLength <= 0', () => {
+      expect(output.truncate('hello', 0)).toBe('hello');
+      expect(output.truncate('hello', -1)).toBe('hello');
+    });
+
+    it('falls back to a hard slice when the suffix is longer than maxLength', () => {
+      expect(output.truncate('hello world', 2, '...')).toBe('he');
+    });
+  });
+
   describe('noColor option', () => {
     it('should strip colors when noColor is true', () => {
       const noColorOutput = new OutputService({ noColor: true });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -293,6 +293,15 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     text(message: string) {
       logs.push(`text:${message}`);
     },
+    truncate(text: string, maxLength: number, suffix = '...') {
+      if (maxLength <= 0 || text.length <= maxLength) {
+        return text;
+      }
+      if (suffix.length >= maxLength) {
+        return text.slice(0, maxLength);
+      }
+      return text.slice(0, maxLength - suffix.length) + suffix;
+    },
     format(text: string, formatter: (text: string) => string) {
       return formatter(text);
     },


### PR DESCRIPTION
Closes #220.

## Summary

Implements the **Phase 1** leverage moves from the architectural audit (#220). All items in the issue's checklist are addressed; no structural refactors (those are deferred to Phases 2-4).

- Shared `OutputService.truncate()` — replaces four duplicate copies (`pr/{diff,activity,checks,list}.command.ts`) and three inline `slice + ellipsis` variants.
- `BaseCommand.parsePositiveInt()` — strict (rejects `1abc`, `1.5`, zero, negatives). Migrates ~20 raw `Number.parseInt(options.id, 10)` call sites, including `bb pr approve` (was silently passing `NaN` to the API). Removes the local `parsePositiveInt` in `bb browse`.
- `IContextService.requireRepoContextFor(options, context)` — replaces the `requireRepoContext({ ...context.globalOptions, ...options })` boilerplate in 23 commands.
- `GitService` now has a 60s default subprocess timeout (configurable via constructor) so a stalled `git` no longer hangs the CLI.
- Tightened error edges:
  - `ConfigService.getConfig()` wraps `JSON.parse` so a corrupt config surfaces a `BBError(CONFIG_READ_FAILED)` with a precise remediation message instead of a generic `SyntaxError`.
  - `OutputService.runJq()` wraps `import('jq-wasm')` so a missing runtime raises a typed `BBError(JQ_FAILED)`.
  - `VersionService.checkForUpdate()` and `OAuthService.waitForCallback()` now log their swallowed causes when `DEBUG=true`. Default behavior unchanged.
- `pr comments list` and `pr reviewers list` JSON output now include `workspace` and `repoSlug` for parity with the other list commands.
- `bun build` now emits sourcemaps (`--sourcemap`).
- CI now runs `bun run lint:docs` so error-code/env-var docs cannot drift.

## Out of scope

The deeper structural work — collapsing `src/cli.ts` (1,658 lines), schema-driven `BBConfig`, splitting `OAuthService`/`ConfigService`, end-to-end CLI integration tests — is explicitly **deferred** to Phases 2-4 (separate issues to be filed).

## Test plan

- [x] `bun run lint` passes (TypeScript strict; tsc --noEmit)
- [x] `bun run lint:docs` passes (error codes + env vars in sync)
- [x] `bun test` — 948 pass, 0 fail
- [x] `bun run format:check` clean
- [x] `bun run build` produces `dist/index.js` + `dist/index.js.map`
- [x] Added unit tests for `OutputService.truncate`, `BaseCommand.parsePositiveInt`, `ContextService.requireRepoContextFor`
- [x] Updated `tests/setup.ts` mock `IOutputService` to expose `truncate`
- [ ] Manual smoke: `bb pr view 1`, `bb pr comments list 1 --json`, `bb config get …` from a corrupted JSON config