### PR TITLE
fix: standardize empty-result messages on output.info()

### DIFF
--- a/.changeset/empty-result-info-consistency.md
+++ b/.changeset/empty-result-info-consistency.md
@@ -1,0 +1,17 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Standardize empty-result messages on `output.info()` so all list/query
+commands present a consistent blue `ℹ` icon when there is nothing to show.
+
+Updated commands:
+
+- `repo list` — `No repositories found`
+- `pr list` — `No <state> pull requests found`
+- `snippet list` — `No snippets found`
+- `config list` — `No configuration set`
+- `pr view` — `No reviewers assigned` (was a gray plain-text line)
+
+The eight other commands that emit empty-result messages already use
+`output.info()`; they are unchanged.

--- a/src/commands/config/list.command.ts
+++ b/src/commands/config/list.command.ts
@@ -92,7 +92,7 @@ export class ListConfigCommand extends BaseCommand<void, void> {
     ]);
 
     if (rows.length === 0) {
-      this.output.text('No configuration set');
+      this.output.info('No configuration set');
     } else {
       this.output.table(['KEY', 'VALUE'], rows);
     }

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -91,7 +91,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     }
 
     if (values.length === 0) {
-      this.output.text(`No ${state.toLowerCase()} pull requests found`);
+      this.output.info(`No ${state.toLowerCase()} pull requests found`);
       return;
     }
 

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -160,7 +160,7 @@ export class ViewPRCommand extends BaseCommand<
 
     if (reviewers.length === 0) {
       this.output.text('');
-      this.output.text(this.output.gray('No reviewers assigned'));
+      this.output.info('No reviewers assigned');
       return;
     }
 

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -63,7 +63,7 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     }
 
     if (repos.length === 0) {
-      this.output.text('No repositories found');
+      this.output.info('No repositories found');
       return;
     }
 

--- a/src/commands/snippet/list.command.ts
+++ b/src/commands/snippet/list.command.ts
@@ -80,7 +80,7 @@ export class ListSnippetsCommand extends BaseCommand<
     }
 
     if (snippets.length === 0) {
-      this.output.text('No snippets found');
+      this.output.info('No snippets found');
       return;
     }
 

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -364,8 +364,6 @@ describe('ListConfigCommand', () => {
     const command = new ListConfigCommand(configService, output);
     await command.execute(undefined, { globalOptions: {} });
 
-    expect(
-      output.logs.some((log) => log.includes('No configuration set'))
-    ).toBe(true);
+    expect(output.logs).toContain('info:No configuration set');
   });
 });

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -621,9 +621,7 @@ describe('ListPRsCommand', () => {
     );
     await command.execute({}, { globalOptions: {} });
 
-    expect(
-      output.logs.some((log) => log.includes('No open pull requests found'))
-    ).toBe(true);
+    expect(output.logs).toContain('info:No open pull requests found');
   });
 
   it('should label draft pull requests', async () => {
@@ -841,9 +839,7 @@ describe('ViewPRCommand', () => {
     const command = new ViewPRCommand(pullrequestsApi, contextService, output);
     await command.execute({ id: '1' }, { globalOptions: {} });
 
-    expect(
-      output.logs.some((log) => log.includes('No reviewers assigned'))
-    ).toBe(true);
+    expect(output.logs).toContain('info:No reviewers assigned');
   });
 
   it('should render approved, changes requested, and pending reviewer statuses', async () => {

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -222,9 +222,7 @@ describe('ListReposCommand', () => {
     );
     await command.execute({ workspace: 'empty' }, { globalOptions: {} });
 
-    expect(
-      output.logs.some((log) => log.includes('No repositories found'))
-    ).toBe(true);
+    expect(output.logs).toContain('info:No repositories found');
   });
 
   it('should list repos when json flag is set', async () => {

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -266,9 +266,7 @@ describe('ListSnippetsCommand', () => {
 
     await cmd.run({ workspace: 'workspace' }, makeContext());
 
-    expect(output.logs.some((log) => log.includes('No snippets found'))).toBe(
-      true
-    );
+    expect(output.logs).toContain('info:No snippets found');
   });
 
   it('should resolve workspace from config when not provided', async () => {


### PR DESCRIPTION
## Summary

- Standardize empty-result messages across list/query commands on `output.info()` so users see a consistent blue `ℹ` icon instead of mixed plain-text / gray styling
- Updated: `repo list`, `pr list`, `snippet list`, `config list`, `pr view` (reviewers section). The eight other commands already used `output.info()` and are unchanged
- Tightened existing tests to assert the `info:` prefix specifically so the consistency is enforced going forward

Closes #224

## Test plan

- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `bun test` — all 948 tests pass
- [x] Changeset added (patch)