### PR TITLE
fix(api-client): route retry messages through IOutputService

### DIFF
--- a/.changeset/api-client-output-service.md
+++ b/.changeset/api-client-output-service.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Route API client retry messages through `IOutputService.warning()` so they no longer bypass the output layer. Retries are now silenced in `--json` mode (preventing stderr noise from leaking into structured pipelines) and outside JSON mode they render with the standard `⚠` prefix and respect `--no-color`. `DEBUG=true` HTTP traces continue to use raw `console.debug` by design — they are an opt-in developer channel.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -121,7 +121,14 @@ function registerApiClient<T>(
     const oauthService = container.resolve<OAuthService>(
       ServiceTokens.OAuthService
     );
-    const axiosInstance = createApiClient(credentialStore, oauthService);
+    const outputService = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    const axiosInstance = createApiClient(
+      credentialStore,
+      outputService,
+      oauthService
+    );
     return new ctor(undefined, undefined, axiosInstance);
   });
 }
@@ -186,7 +193,10 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     const oauthService = container.resolve<OAuthService>(
       ServiceTokens.OAuthService
     );
-    return createApiClient(credentialStore, oauthService);
+    const outputService = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return createApiClient(credentialStore, outputService, oauthService);
   });
   container.register(ServiceTokens.SnippetsApi, () => {
     const axiosInstance = container.resolve<AxiosInstance>(

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -30,6 +30,7 @@ export abstract class BaseCommand<
     this.output.setJsonFormatOptions({
       fields: context.globalOptions.jsonFields,
       jq: context.globalOptions.jq,
+      json: context.globalOptions.json,
     });
 
     try {

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -121,6 +121,7 @@ export interface ISnippetFilesService {
 export interface JsonFormatOptions {
   fields?: string[];
   jq?: string;
+  json?: boolean;
 }
 
 /**
@@ -130,6 +131,7 @@ export interface IOutputService {
   json(data: unknown): Promise<void>;
   jsonError(data: unknown): void;
   setJsonFormatOptions(options: JsonFormatOptions): void;
+  isJsonMode(): boolean;
   table(headers: string[], rows: string[][]): void;
   success(message: string): void;
   error(message: string): void;

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -7,7 +7,10 @@ import axios, {
   type AxiosError,
   type InternalAxiosRequestConfig,
 } from 'axios';
-import type { ICredentialStore } from '../core/interfaces/services.js';
+import type {
+  ICredentialStore,
+  IOutputService,
+} from '../core/interfaces/services.js';
 import type { OAuthService } from './oauth.service.js';
 import { BBError, ErrorCode, APIError } from '../types/errors.js';
 
@@ -93,8 +96,14 @@ function redactRequestUrl(
   }
 }
 
+// DEBUG=true logs (`[HTTP] ...`) intentionally use raw `console.debug` rather
+// than `IOutputService` because they are an opt-in developer-troubleshooting
+// channel: they bypass the user-facing output format (including --json) so the
+// payload remains readable when piped, and they should be visible regardless of
+// any future output-suppression flags. See issue #223 for the full discussion.
 export function createApiClient(
   credentialStore: ICredentialStore,
+  output: IOutputService,
   oauthService?: OAuthService
 ): AxiosInstance {
   const instance = axios.create({
@@ -188,9 +197,15 @@ export function createApiClient(
             const status = error.response.status;
             const label =
               status === 429 ? 'Rate limited' : `Server error (${status})`;
-            console.error(
-              `${label}, retrying in ${(delay / 1000).toFixed(1)}s (attempt ${config.__retryCount}/${MAX_RETRIES})...`
-            );
+            // Suppress retry chatter in --json mode so it doesn't pollute the
+            // structured pipeline reading from this process. Outside JSON mode,
+            // route through `output.warning()` for the standard ⚠ prefix and
+            // --no-color handling.
+            if (!output.isJsonMode()) {
+              output.warning(
+                `${label}, retrying in ${(delay / 1000).toFixed(1)}s (attempt ${config.__retryCount}/${MAX_RETRIES})...`
+              );
+            }
             await sleep(delay);
             return instance(config);
           }

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -58,6 +58,10 @@ export class OutputService implements IOutputService {
     this.jsonFormatOptions = { ...options };
   }
 
+  public isJsonMode(): boolean {
+    return this.jsonFormatOptions.json === true;
+  }
+
   public async json(data: unknown): Promise<void> {
     const { fields, jq } = this.jsonFormatOptions;
 

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -383,10 +383,15 @@ describe('BaseCommand', () => {
     });
 
     it('should push and clear json format options around execute()', async () => {
-      const calls: Array<{ fields?: string[]; jq?: string }> = [];
+      const calls: Array<{ fields?: string[]; jq?: string; json?: boolean }> =
+        [];
       const spyOutput = {
         ...output,
-        setJsonFormatOptions(opts: { fields?: string[]; jq?: string }) {
+        setJsonFormatOptions(opts: {
+          fields?: string[];
+          jq?: string;
+          json?: boolean;
+        }) {
           calls.push({ ...opts });
         },
       };
@@ -404,14 +409,22 @@ describe('BaseCommand', () => {
       );
 
       // First call sets the options, finally{} resets to {}.
-      expect(calls).toEqual([{ fields: ['id', 'title'], jq: '.[] | .id' }, {}]);
+      expect(calls).toEqual([
+        { fields: ['id', 'title'], jq: '.[] | .id', json: true },
+        {},
+      ]);
     });
 
     it('should reset json format options even when execute throws', async () => {
-      const calls: Array<{ fields?: string[]; jq?: string }> = [];
+      const calls: Array<{ fields?: string[]; jq?: string; json?: boolean }> =
+        [];
       const spyOutput = {
         ...output,
-        setJsonFormatOptions(opts: { fields?: string[]; jq?: string }) {
+        setJsonFormatOptions(opts: {
+          fields?: string[];
+          jq?: string;
+          json?: boolean;
+        }) {
           calls.push({ ...opts });
         },
       };
@@ -421,7 +434,10 @@ describe('BaseCommand', () => {
         command.run({}, { globalOptions: { json: true, jsonFields: ['id'] } })
       ).rejects.toThrow('Test error');
 
-      expect(calls).toEqual([{ fields: ['id'], jq: undefined }, {}]);
+      expect(calls).toEqual([
+        { fields: ['id'], jq: undefined, json: true },
+        {},
+      ]);
     });
   });
 

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'bun:test';
 import { createApiClient } from '../../src/services/api-client.service.js';
 import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
-import { createMockConfigService } from '../setup.js';
+import { createMockConfigService, createMockOutputService } from '../setup.js';
 import type { AxiosInstance } from 'axios';
 
 function mockConfigService() {
@@ -155,7 +155,11 @@ describe('createApiClient - OAuth auth', () => {
     const mockAdapter = createMockAdapter([
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockOAuthConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -168,7 +172,11 @@ describe('createApiClient - OAuth auth', () => {
     const mockAdapter = createMockAdapter([
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -185,7 +193,11 @@ describe('createApiClient - OAuth auth', () => {
       { status: 401, data: { error: { message: 'Unauthorized' } } },
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockOAuthConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -204,7 +216,11 @@ describe('createApiClient - OAuth auth', () => {
       { status: 401, data: { error: { message: 'Unauthorized' } } },
       { status: 401, data: { error: { message: 'Still unauthorized' } } },
     ]);
-    client = createApiClient(mockOAuthConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -227,7 +243,11 @@ describe('createApiClient - OAuth auth', () => {
     const mockAdapter = createMockAdapter([
       { status: 401, data: { error: { message: 'Unauthorized' } } },
     ]);
-    client = createApiClient(mockOAuthConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -246,7 +266,11 @@ describe('createApiClient - OAuth auth', () => {
       { status: 401, data: { error: { message: 'Unauthorized' } } },
     ]);
     // basic auth config, but oauthService is provided
-    client = createApiClient(mockConfigService(), oauthMock.service);
+    client = createApiClient(
+      mockConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -286,7 +310,7 @@ describe('createApiClient - retry/backoff', () => {
     const mockAdapter = createMockAdapter([
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -301,7 +325,8 @@ describe('createApiClient - retry/backoff', () => {
       { status: 429, data: { error: { message: 'Rate limited' } } },
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockConfigService());
+    const output = createMockOutputService();
+    client = createApiClient(mockConfigService(), output);
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -309,7 +334,9 @@ describe('createApiClient - retry/backoff', () => {
     expect(response.status).toBe(200);
     expect(response.data).toEqual({ ok: true });
     expect(mockAdapter.getCallCount()).toBe(2);
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(output.logs.some((l) => l.startsWith('warning:Rate limited'))).toBe(
+      true
+    );
   });
 
   it('retries on 502 and succeeds on second attempt', async () => {
@@ -317,7 +344,7 @@ describe('createApiClient - retry/backoff', () => {
       { status: 502, data: {} },
       { status: 200, data: { recovered: true } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -335,7 +362,7 @@ describe('createApiClient - retry/backoff', () => {
       { status: 429, data: { error: { message: 'Rate limited' } } },
       { status: 429, data: { error: { message: 'Rate limited' } } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -356,7 +383,7 @@ describe('createApiClient - retry/backoff', () => {
     const mockAdapter = createMockAdapter([
       { status: 404, data: { error: { message: 'Not found' } } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -376,7 +403,7 @@ describe('createApiClient - retry/backoff', () => {
     const mockAdapter = createMockAdapter([
       { status: 401, data: { error: { message: 'Unauthorized' } } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -409,7 +436,7 @@ describe('createApiClient - retry/backoff', () => {
       },
       { status: 200, data: { ok: true } },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     const response = await client.get('/test');
@@ -422,7 +449,7 @@ describe('createApiClient - retry/backoff', () => {
 
   it('throws BBError with NETWORK_ERROR on network failure', async () => {
     const networkMock = createNetworkErrorAdapter();
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = networkMock.adapter as any;
 
     try {
@@ -484,7 +511,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
         },
       },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -508,7 +535,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
         data: { error: 'invalid_grant', access_token: 'leaked' },
       },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -539,7 +566,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
         },
       },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -558,7 +585,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
         data: { access_token: 'should-never-log' },
       },
     ]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -577,7 +604,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
     cyclic.self = cyclic;
 
     const mockAdapter = createMockAdapter([{ status: 200, data: cyclic }]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -596,7 +623,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
     child.parent = parent;
 
     const mockAdapter = createMockAdapter([{ status: 200, data: parent }]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -608,7 +635,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
   it('logs request method and URL when DEBUG is set', async () => {
     process.env.DEBUG = 'true';
     const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/some/resource');
@@ -621,7 +648,7 @@ describe('createApiClient - DEBUG response logging redaction', () => {
   it('redacts query strings from request URL DEBUG logs', async () => {
     process.env.DEBUG = 'true';
     const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    client = createApiClient(mockConfigService());
+    client = createApiClient(mockConfigService(), createMockOutputService());
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/some/resource?token=abc&other=xyz');
@@ -668,7 +695,10 @@ describe('createApiClient - authentication header', () => {
       });
     };
 
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = adapter as any;
 
     await client.get('/test');
@@ -702,7 +732,11 @@ describe('createApiClient - authentication header', () => {
     const oauthMock = createMockOAuthService({
       validToken: 'the-bearer-token',
     });
-    const client = createApiClient(mockOAuthConfigService(), oauthMock.service);
+    const client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
     client.defaults.adapter = adapter as any;
 
     await client.get('/test');
@@ -736,7 +770,10 @@ describe('createApiClient - Retry-After parsing', () => {
       { status: 429, data: {} },
       { status: 200, data: { ok: true } },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -763,7 +800,10 @@ describe('createApiClient - Retry-After parsing', () => {
       },
       { status: 200, data: { ok: true } },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -788,7 +828,10 @@ describe('createApiClient - Retry-After parsing', () => {
       },
       { status: 200, data: { ok: true } },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     await client.get('/test');
@@ -822,7 +865,10 @@ describe('createApiClient - error message extraction', () => {
         data: { error: { message: 'Bitbucket: invalid field' } },
       },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -841,7 +887,10 @@ describe('createApiClient - error message extraction', () => {
         data: { message: 'Flat error message' },
       },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -854,7 +903,10 @@ describe('createApiClient - error message extraction', () => {
 
   it('falls back to axios error.message when no body message exists', async () => {
     const mockAdapter = createMockAdapter([{ status: 418, data: null }]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -872,7 +924,10 @@ describe('createApiClient - error message extraction', () => {
         data: { error: { message: { nested: 'object' } } },
       },
     ]);
-    const client = createApiClient(mockConfigService());
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
     client.defaults.adapter = mockAdapter.adapter as any;
 
     try {
@@ -882,5 +937,116 @@ describe('createApiClient - error message extraction', () => {
       expect(typeof (err as APIError).message).toBe('string');
       expect((err as APIError).message).not.toBe('[object Object]');
     }
+  });
+});
+
+describe('createApiClient - retry messages route through IOutputService', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let consoleWarnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+      fn();
+      return 0 as any;
+    }) as any;
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('routes 429 retry notice through output.warning() rather than console.error', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const output = createMockOutputService();
+    const client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const warnings = output.logs.filter((l) => l.startsWith('warning:'));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Rate limited');
+    expect(warnings[0]).toContain('attempt 1/3');
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('labels non-429 retryable statuses as "Server error"', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 503, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const output = createMockOutputService();
+    const client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const warnings = output.logs.filter((l) => l.startsWith('warning:'));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Server error (503)');
+  });
+
+  it('emits one warning per retry attempt before exhausting', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: {} },
+      { status: 429, data: {} },
+      { status: 429, data: {} },
+      { status: 429, data: {} },
+    ]);
+    const output = createMockOutputService();
+    const client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch {
+      // expected
+    }
+
+    const warnings = output.logs.filter((l) => l.startsWith('warning:'));
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain('attempt 1/3');
+    expect(warnings[1]).toContain('attempt 2/3');
+    expect(warnings[2]).toContain('attempt 3/3');
+  });
+
+  it('suppresses retry warnings when output is in JSON mode', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const output = createMockOutputService();
+    output.setJsonFormatOptions({ json: true });
+    const client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const warnings = output.logs.filter((l) => l.startsWith('warning:'));
+    expect(warnings).toHaveLength(0);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not emit any warning when the first attempt succeeds', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 200, data: { ok: true } },
+    ]);
+    const output = createMockOutputService();
+    const client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    await client.get('/test');
+
+    const warnings = output.logs.filter((l) => l.startsWith('warning:'));
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -195,6 +195,33 @@ describe('OutputService', () => {
     });
   });
 
+  describe('isJsonMode', () => {
+    it('returns false by default', () => {
+      expect(output.isJsonMode()).toBe(false);
+    });
+
+    it('returns true after setJsonFormatOptions({ json: true })', () => {
+      output.setJsonFormatOptions({ json: true });
+      expect(output.isJsonMode()).toBe(true);
+    });
+
+    it('returns false when json is false or undefined', () => {
+      output.setJsonFormatOptions({ json: false });
+      expect(output.isJsonMode()).toBe(false);
+
+      output.setJsonFormatOptions({ fields: ['id'] });
+      expect(output.isJsonMode()).toBe(false);
+    });
+
+    it('clears json mode when options are reset to {}', () => {
+      output.setJsonFormatOptions({ json: true });
+      expect(output.isJsonMode()).toBe(true);
+
+      output.setJsonFormatOptions({});
+      expect(output.isJsonMode()).toBe(false);
+    });
+  });
+
   describe('jsonError', () => {
     it('should output compact JSON to stderr', () => {
       output.jsonError({ name: 'BBError', code: 4003, message: 'Invalid key' });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -262,6 +262,7 @@ export function createMockContextService(
 
 export function createMockOutputService(): IOutputService & { logs: string[] } {
   const logs: string[] = [];
+  let jsonMode = false;
 
   return {
     logs,
@@ -271,8 +272,11 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     jsonError(data: unknown) {
       logs.push(`jsonError:${JSON.stringify(data)}`);
     },
-    setJsonFormatOptions() {
-      // No-op in tests; commands log raw payloads via `json:` prefix.
+    setJsonFormatOptions(options) {
+      jsonMode = options.json === true;
+    },
+    isJsonMode() {
+      return jsonMode;
     },
     table(headers: string[], rows: string[][]) {
       logs.push(`table:${headers.join(',')}`);


### PR DESCRIPTION
## Summary

- Replace the raw `console.error` retry log in `src/services/api-client.service.ts` with `output.warning()` so retries respect `--no-color` and gain the standard `⚠` prefix.
- Suppress retry notifications entirely while `--json` is active to keep structured pipelines free of stderr noise (the previous behaviour leaked unformatted text into JSON consumers).
- Add `IOutputService.isJsonMode()` (driven from `BaseCommand.run()` via `setJsonFormatOptions({ json })`) so any service that needs the flag can read it without re-plumbing global options.
- Inject `IOutputService` into `createApiClient()` from `bootstrap.ts` (both the generic registration helper and the snippets axios factory).
- Keep `DEBUG=true` HTTP traces on `console.debug` — the issue accepts that tradeoff and a comment now records the decision.

Closes #223.

## Test plan

- [x] `bun run lint` (TypeScript strict)
- [x] `bun run format:check`
- [x] `bun test` — 957 tests pass
- [x] New tests assert: retry notice routes through `output.warning()`, non-429 retryable statuses get a `Server error (NNN)` label, one warning per retry attempt, JSON mode suppresses warnings AND keeps `console.warn`/`console.error` silent, successful first attempts emit no warning, `OutputService.isJsonMode()` reflects `setJsonFormatOptions` correctly.