### PR TITLE
refactor: extract --yes confirmation pattern to BaseCommand

### DIFF
--- a/.changeset/require-confirmation-helper.md
+++ b/.changeset/require-confirmation-helper.md
@@ -1,0 +1,19 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Standardize the `--yes` confirmation pattern across destructive commands.
+The duplicated check and `BBError` throw is extracted into
+`BaseCommand.requireConfirmation()`, and the trailing instruction is now a
+consistent `Use --yes to confirm.` (previously a mix of
+`Use --yes to confirm.` and `Use --yes to confirm deletion.`).
+
+Affected commands:
+
+- `repo delete`
+- `repo default-reviewers remove`
+- `pr comments delete`
+- `snippet delete`
+- `snippet comments delete`
+
+The warning text describing the action being gated is unchanged.

--- a/src/commands/pr/comments.delete.command.ts
+++ b/src/commands/pr/comments.delete.command.ts
@@ -10,7 +10,6 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteCommentPROptions extends GlobalOptions {
   yes?: boolean;
@@ -43,14 +42,10 @@ export class DeleteCommentPRCommand extends BaseCommand<
     const prId = this.parsePositiveInt(options.prId, 'pr-id');
     const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
-    if (!options.yes) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          `This will permanently delete comment #${commentId} on PR #${prId}.\n` +
-          'Use --yes to confirm deletion.',
-      });
-    }
+    this.requireConfirmation(
+      options.yes,
+      `This will permanently delete comment #${commentId} on PR #${prId}.`
+    );
 
     await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsCommentIdDelete(
       {

--- a/src/commands/repo/default-reviewers.remove.command.ts
+++ b/src/commands/repo/default-reviewers.remove.command.ts
@@ -11,7 +11,6 @@ import type {
 import type { UsersApi } from '../../generated/api.js';
 import type { DefaultReviewerService } from '../../services/default-reviewer.service.js';
 import type { GlobalOptions } from '../../types/config.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface RemoveDefaultReviewerOptions extends GlobalOptions {
   username: string;
@@ -43,15 +42,11 @@ export class RemoveDefaultReviewerCommand extends BaseCommand<
       context
     );
 
-    if (!options.yes) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          `This will remove ${options.username} from the default reviewers of ` +
-          `${repoContext.workspace}/${repoContext.repoSlug}.\n` +
-          'Use --yes to confirm.',
-      });
-    }
+    this.requireConfirmation(
+      options.yes,
+      `This will remove ${options.username} from the default reviewers of ` +
+        `${repoContext.workspace}/${repoContext.repoSlug}.`
+    );
 
     // Same as add: resolve via the users API so nicknames work.
     const userResponse = await this.usersApi.usersSelectedUserGet({

--- a/src/commands/repo/delete.command.ts
+++ b/src/commands/repo/delete.command.ts
@@ -10,7 +10,6 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi } from '../../generated/api.js';
 import type { GlobalOptions } from '../../types/config.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteRepoOptions extends GlobalOptions {
   yes?: boolean;
@@ -50,14 +49,10 @@ export class DeleteRepoCommand extends BaseCommand<
     const repoContext =
       await this.contextService.requireRepoContext(contextOptions);
 
-    if (!yes) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          `This will permanently delete ${repoContext.workspace}/${repoContext.repoSlug}.\n` +
-          'Use --yes to confirm deletion.',
-      });
-    }
+    this.requireConfirmation(
+      yes,
+      `This will permanently delete ${repoContext.workspace}/${repoContext.repoSlug}.`
+    );
 
     await this.repositoriesApi.repositoriesWorkspaceRepoSlugDelete({
       workspace: repoContext.workspace,

--- a/src/commands/snippet/comments.delete.command.ts
+++ b/src/commands/snippet/comments.delete.command.ts
@@ -9,7 +9,6 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteSnippetCommentOptions {
   workspace?: string;
@@ -44,14 +43,10 @@ export class DeleteSnippetCommentCommand extends BaseCommand<
 
     const commentId = this.parsePositiveInt(options.commentId, 'comment-id');
 
-    if (!options.yes) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          `This will permanently delete comment #${commentId} on snippet ${options.snippetId}.\n` +
-          'Use --yes to confirm deletion.',
-      });
-    }
+    this.requireConfirmation(
+      options.yes,
+      `This will permanently delete comment #${commentId} on snippet ${options.snippetId}.`
+    );
 
     await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsCommentIdDelete({
       workspace,

--- a/src/commands/snippet/delete.command.ts
+++ b/src/commands/snippet/delete.command.ts
@@ -9,7 +9,6 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetsApi } from '../../generated/api.js';
-import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface DeleteSnippetOptions {
   workspace?: string;
@@ -39,14 +38,10 @@ export class DeleteSnippetCommand extends BaseCommand<
       options.workspace ?? context.globalOptions.workspace
     );
 
-    if (!options.yes) {
-      throw new BBError({
-        code: ErrorCode.VALIDATION_REQUIRED,
-        message:
-          `This will permanently delete snippet ${options.id}.\n` +
-          'Use --yes to confirm deletion.',
-      });
-    }
+    this.requireConfirmation(
+      options.yes,
+      `This will permanently delete snippet ${options.id}.`
+    );
 
     await this.snippetsApi.snippetsWorkspaceEncodedIdDelete({
       workspace,

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -165,6 +165,22 @@ export abstract class BaseCommand<
   }
 
   /**
+   * Gate a destructive action on an explicit confirmation flag (typically
+   * `--yes`). Throws a standard `BBError` so the warning and the
+   * "Use --yes to confirm." instruction stay consistent across commands.
+   */
+  protected requireConfirmation(
+    confirmed: boolean | undefined,
+    warning: string
+  ): void {
+    if (confirmed) return;
+    throw new BBError({
+      code: ErrorCode.VALIDATION_REQUIRED,
+      message: `${warning}\nUse --yes to confirm.`,
+    });
+  }
+
+  /**
    * Validate a string option against a set of allowed values
    */
   protected parseEnumOption<T extends string>(

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -3024,7 +3024,7 @@ describe('DeleteCommentPRCommand', () => {
 
     await expect(
       command.execute({ prId: '42', commentId: '7' }, { globalOptions: {} })
-    ).rejects.toThrow('Use --yes to confirm deletion');
+    ).rejects.toThrow('Use --yes to confirm');
   });
 });
 

--- a/tests/commands/snippet.test.ts
+++ b/tests/commands/snippet.test.ts
@@ -777,7 +777,7 @@ describe('DeleteSnippetCommand', () => {
 
     await expect(
       cmd.run({ id: 'kypj', workspace: 'workspace' }, makeContext())
-    ).rejects.toThrow('Use --yes to confirm deletion');
+    ).rejects.toThrow('Use --yes to confirm');
   });
 });
 
@@ -986,6 +986,6 @@ describe('DeleteSnippetCommentCommand', () => {
         { snippetId: 'kypj', commentId: '1', workspace: 'workspace' },
         makeContext()
       )
-    ).rejects.toThrow('Use --yes to confirm deletion');
+    ).rejects.toThrow('Use --yes to confirm');
   });
 });

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -98,6 +98,13 @@ class TestCommandWithParseHelpers extends BaseCommand<
   ): T {
     return this.parseEnumOption(value, name, allowed);
   }
+
+  public callRequireConfirmation(
+    confirmed: boolean | undefined,
+    warning: string
+  ): void {
+    return this.requireConfirmation(confirmed, warning);
+  }
 }
 
 describe('BaseCommand', () => {
@@ -500,6 +507,54 @@ describe('BaseCommand', () => {
       const command = new TestCommandWithParseHelpers(output);
 
       expect(command.callParsePositiveInt('  7  ', 'id')).toBe(7);
+    });
+  });
+
+  describe('requireConfirmation', () => {
+    it('returns without throwing when confirmed is true', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() =>
+        command.callRequireConfirmation(true, 'This will delete things.')
+      ).not.toThrow();
+    });
+
+    it('throws BBError when confirmed is false', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() =>
+        command.callRequireConfirmation(false, 'This will delete things.')
+      ).toThrow(BBError);
+    });
+
+    it('throws BBError when confirmed is undefined', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() =>
+        command.callRequireConfirmation(undefined, 'This will delete things.')
+      ).toThrow(BBError);
+    });
+
+    it('uses VALIDATION_REQUIRED error code', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      try {
+        command.callRequireConfirmation(undefined, 'This will delete things.');
+        expect(true).toBe(false); // should not reach here
+      } catch (error) {
+        expect((error as BBError).code).toBe(ErrorCode.VALIDATION_REQUIRED);
+      }
+    });
+
+    it('embeds the warning and standardized confirmation suffix', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(() =>
+        command.callRequireConfirmation(
+          undefined,
+          'This will permanently delete repo/x.'
+        )
+      ).toThrow('This will permanently delete repo/x.\nUse --yes to confirm.');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #228 (Part B).

- Adds `BaseCommand.requireConfirmation(confirmed, warning)` to gate destructive actions on `--yes`, replacing the duplicated `if (!yes) throw new BBError(...)` block in five commands.
- Standardizes the trailing instruction to a single `Use --yes to confirm.` line — previously a mix of `Use --yes to confirm.` and `Use --yes to confirm deletion.`.

Affected commands: `repo delete`, `repo default-reviewers remove`, `pr comments delete`, `snippet delete`, `snippet comments delete`.

> Part A of #228 (replacing raw `Number.parseInt` with `parsePositiveInt`) was already completed in a prior change — every PR command now uses `parsePositiveInt`. This PR closes the issue by addressing the remaining Part B.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun test` passes (953 tests)
- [x] New unit tests for `requireConfirmation` cover: confirmed=true (no throw), confirmed=false/undefined (throws), error code is `VALIDATION_REQUIRED`, message embeds the warning and the standardized suffix
- [x] Existing snippet/PR delete tests updated to assert the new standardized substring (`Use --yes to confirm`)