### PR TITLE
feat: locale-aware date formatting

### DIFF
--- a/.changeset/locale-aware-dates.md
+++ b/.changeset/locale-aware-dates.md
@@ -1,0 +1,9 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add locale-aware date formatting. Dates rendered by `bb` now follow the user's
+locale instead of being hard-coded to `en-US`. The locale is resolved in this
+order: `--locale <tag>` global flag, `BB_LOCALE` env var, the standard POSIX
+chain (`LC_TIME` → `LC_ALL` → `LANG`), and finally `en-US` as a fallback. An
+invalid tag silently falls back to `en-US` instead of throwing.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -94,6 +94,7 @@ import { BrowseCommand } from './commands/browse.command.js';
 
 export interface BootstrapOptions {
   noColor?: boolean;
+  locale?: string;
 }
 
 type Ctor<T> = new (...args: never[]) => T;
@@ -156,7 +157,11 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   container.register(ServiceTokens.GitService, () => new GitService());
   container.register(
     ServiceTokens.OutputService,
-    () => new OutputService({ noColor: options.noColor })
+    () =>
+      new OutputService({
+        noColor: options.noColor,
+        locale: options.locale,
+      })
   );
   registerCommand(container, ServiceTokens.OAuthService, OAuthService, [
     ServiceTokens.ConfigService,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import type { VersionService } from './services/version.service.js';
 import type { IConfigService } from './core/interfaces/services.js';
 import { PR_STATES } from './types/pr.js';
 import { BBError, ErrorCode } from './types/errors.js';
+import { resolveLocale } from './services/locale.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
@@ -66,6 +67,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   '--no-color',
   '--workspace',
   '--repo',
+  '--locale',
 ];
 
 const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> = new Map([
@@ -139,6 +141,32 @@ if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
   }
 }
 
+/**
+ * Pull the value of `--locale <locale>` (or `--locale=<locale>`) out of
+ * argv before Commander parses it, mirroring how `--no-color` is handled.
+ * The locale must influence `OutputService` construction during bootstrap,
+ * which runs before any Commander action handlers fire.
+ */
+export function extractLocaleArg(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) {
+      continue;
+    }
+    if (arg === '--locale') {
+      const next = argv[i + 1];
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        return next;
+      }
+      return undefined;
+    }
+    if (arg.startsWith('--locale=')) {
+      return arg.slice('--locale='.length);
+    }
+  }
+  return undefined;
+}
+
 export function resolveNoColorSetting(
   argv: string[],
   env: NodeJS.ProcessEnv
@@ -167,8 +195,12 @@ export function resolveNoColorSetting(
 // Bootstrap the container
 const noColor = resolveNoColorSetting(process.argv, process.env);
 const buildHelpText = createHelpTextBuilder(noColor);
+const locale = resolveLocale({
+  explicit: extractLocaleArg(process.argv),
+  env: process.env,
+});
 
-const container = bootstrap({ noColor });
+const container = bootstrap({ noColor, locale });
 
 // Helper to create command context. Validation errors from --json/--jq
 // parsing are deferred onto `context.validationError` so they can be raised
@@ -278,6 +310,10 @@ cli
     'Filter the JSON output through a jq expression — runs in-process via embedded jq, requires --json (e.g. \'.pullRequests[] | select(.state == "OPEN") | .title\')'
   )
   .option('--no-color', 'Disable color output')
+  .option(
+    '--locale <locale>',
+    'BCP-47 locale tag for date/time formatting (e.g. de-DE, ja-JP). Falls back to BB_LOCALE, then LC_TIME/LC_ALL/LANG, then en-US.'
+  )
   .option('-w, --workspace <workspace>', 'Specify workspace')
   .option('-r, --repo <repo>', 'Specify repository')
   .addHelpText(
@@ -289,6 +325,8 @@ cli
         NO_COLOR: 'Disable color output when set',
         FORCE_COLOR: "Force color output when set (and not '0')",
         DEBUG: "Enable HTTP debug logging when 'true'",
+        BB_LOCALE:
+          'BCP-47 locale tag for date/time formatting; --locale takes precedence',
       },
       seeAlso: [
         {

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -1,0 +1,104 @@
+/**
+ * Locale detection helpers for date and number formatting.
+ *
+ * The CLI lets the user pin a locale explicitly (`--locale`, `BB_LOCALE`)
+ * and otherwise honours the standard POSIX `LC_TIME`/`LC_ALL`/`LANG` chain
+ * before falling back to `en-US`. The fallback matches the historical
+ * hard-coded value so users who don't set anything see no behavioural
+ * change.
+ */
+
+export const DEFAULT_LOCALE = 'en-US';
+
+/**
+ * Convert a POSIX-style locale value (e.g. `en_US.UTF-8`, `de_DE@euro`) to
+ * a BCP-47 tag accepted by `Intl`. Returns `undefined` if the input is
+ * empty or only whitespace, so callers can fall through to the next source
+ * in the detection hierarchy.
+ *
+ * The C / POSIX placeholder locales are normalised to `en-US`: they are
+ * machine locales that don't carry user-facing formatting preferences, and
+ * `en-US` matches the historical fallback.
+ */
+export function normalizePosixLocale(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  // Strip codeset (`.UTF-8`) and modifier (`@euro`) suffixes, then convert
+  // the underscore separator used by POSIX into the dash BCP-47 expects.
+  const base = trimmed.split(/[.@]/, 1)[0]!;
+  if (base.length === 0) {
+    return undefined;
+  }
+
+  const upper = base.toUpperCase();
+  if (upper === 'C' || upper === 'POSIX') {
+    return DEFAULT_LOCALE;
+  }
+
+  return base.replace(/_/g, '-');
+}
+
+/**
+ * Resolve the system locale by walking the standard POSIX environment
+ * variables in priority order: `LC_TIME` (date/time category) → `LC_ALL`
+ * (overrides everything) → `LANG` (default category). The first variable
+ * with a non-empty, normalisable value wins.
+ *
+ * `env` is injected so tests can drive the function deterministically and
+ * so callers can prefer a captured snapshot of `process.env` over the
+ * mutable global.
+ */
+export function detectSystemLocale(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const candidates = [env.LC_TIME, env.LC_ALL, env.LANG];
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+    const normalized = normalizePosixLocale(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return DEFAULT_LOCALE;
+}
+
+/**
+ * Resolve the locale the CLI should use for human-readable output, in
+ * priority order:
+ *
+ * 1. `--locale` CLI flag (`explicit` argument).
+ * 2. `BB_LOCALE` environment variable.
+ * 3. POSIX env detection (`LC_TIME` → `LC_ALL` → `LANG`).
+ * 4. `en-US` fallback (matches the historical hard-coded behaviour).
+ *
+ * Whitespace-only values at any layer are treated as unset, so an empty
+ * `--locale ""` does not silently mask the env vars below it.
+ */
+export function resolveLocale(options: {
+  explicit?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const env = options.env ?? process.env;
+
+  if (typeof options.explicit === 'string') {
+    const trimmed = options.explicit.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  const fromEnvVar = env.BB_LOCALE;
+  if (typeof fromEnvVar === 'string') {
+    const trimmed = fromEnvVar.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return detectSystemLocale(env);
+}

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -8,7 +8,16 @@ import type {
   JsonFormatOptions,
 } from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
+import { DEFAULT_LOCALE } from './locale.js';
 import { projectFields } from './output.project.js';
+
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+};
 
 // Strip dangerous terminal control sequences from text before printing so
 // attacker-controlled API data (PR titles, descriptions, branch names,
@@ -48,10 +57,12 @@ const WRAPPER_ARRAY_KEYS: readonly string[] = [
 
 export class OutputService implements IOutputService {
   private readonly noColor: boolean;
+  private readonly locale: string;
   private jsonFormatOptions: JsonFormatOptions = {};
 
-  constructor(options?: { noColor?: boolean }) {
+  constructor(options?: { noColor?: boolean; locale?: string }) {
     this.noColor = options?.noColor ?? false;
+    this.locale = options?.locale ?? DEFAULT_LOCALE;
   }
 
   public setJsonFormatOptions(options: JsonFormatOptions): void {
@@ -160,13 +171,13 @@ export class OutputService implements IOutputService {
 
   public formatDate(date: string | Date): string {
     const d = typeof date === 'string' ? new Date(date) : date;
-    return d.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    try {
+      return d.toLocaleDateString(this.locale, DATE_FORMAT_OPTIONS);
+    } catch {
+      // Invalid BCP-47 tag: fall back to the historical default so a typo
+      // in --locale or LANG doesn't crash a date-rendering command.
+      return d.toLocaleDateString(DEFAULT_LOCALE, DATE_FORMAT_OPTIONS);
+    }
   }
 
   /**

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'bun:test';
 import type { Command } from 'commander';
 import {
+  extractLocaleArg,
   getCompletionParent,
   resolveNoColorSetting,
   withGlobalOptions,
@@ -213,6 +214,42 @@ describe('resolveNoColorSetting', () => {
   });
 });
 
+describe('extractLocaleArg', () => {
+  it('returns the value passed as a separate argument', () => {
+    expect(
+      extractLocaleArg(['node', 'bb', 'pr', 'list', '--locale', 'de-DE'])
+    ).toBe('de-DE');
+  });
+
+  it('supports the --locale=value form', () => {
+    expect(
+      extractLocaleArg(['node', 'bb', 'pr', 'list', '--locale=ja-JP'])
+    ).toBe('ja-JP');
+  });
+
+  it('returns undefined when --locale is absent', () => {
+    expect(extractLocaleArg(['node', 'bb', 'pr', 'list'])).toBeUndefined();
+  });
+
+  it('returns undefined when --locale is followed by another flag', () => {
+    // Without a value Commander would also error; treat it as unset rather
+    // than swallowing the next flag as the locale value.
+    expect(
+      extractLocaleArg(['node', 'bb', '--locale', '--json'])
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when --locale is the trailing token', () => {
+    expect(extractLocaleArg(['node', 'bb', '--locale'])).toBeUndefined();
+  });
+
+  it('returns the empty string for --locale=""', () => {
+    // Preserves the literal value so resolveLocale can decide how to treat
+    // it (whitespace-only values are normalised to "fall through").
+    expect(extractLocaleArg(['node', 'bb', '--locale='])).toBe('');
+  });
+});
+
 describe('CLI option wiring', () => {
   it('should reserve -w for global --workspace and keep pr diff --web long-only', () => {
     const workspaceOption = cli.options.find(
@@ -274,6 +311,7 @@ describe('CLI help text integration', () => {
     expect(output).toContain('NO_COLOR');
     expect(output).toContain('FORCE_COLOR');
     expect(output).toContain('DEBUG');
+    expect(output).toContain('BB_LOCALE');
   });
 
   it('should include merge strategies and examples in pr merge help', () => {
@@ -431,12 +469,13 @@ describe('CLI command registration', () => {
     ]);
   });
 
-  it('should register global --workspace, --repo, --json, --jq and --no-color options on root', () => {
+  it('should register global --workspace, --repo, --json, --jq, --no-color and --locale options on root', () => {
     expect(hasOption(cli, '--workspace')).toBe(true);
     expect(hasOption(cli, '--repo')).toBe(true);
     expect(hasOption(cli, '--json')).toBe(true);
     expect(hasOption(cli, '--jq')).toBe(true);
     expect(hasOption(cli, '--no-color')).toBe(true);
+    expect(hasOption(cli, '--locale')).toBe(true);
     expect(hasShortOption(cli, '-w')).toBe(true);
     expect(hasShortOption(cli, '-r')).toBe(true);
   });

--- a/tests/services/locale.test.ts
+++ b/tests/services/locale.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Locale detection tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  DEFAULT_LOCALE,
+  detectSystemLocale,
+  normalizePosixLocale,
+  resolveLocale,
+} from '../../src/services/locale.js';
+
+describe('normalizePosixLocale', () => {
+  it('returns undefined for an empty string', () => {
+    expect(normalizePosixLocale('')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace only', () => {
+    expect(normalizePosixLocale('   ')).toBeUndefined();
+  });
+
+  it('strips a UTF-8 codeset suffix', () => {
+    expect(normalizePosixLocale('en_US.UTF-8')).toBe('en-US');
+  });
+
+  it('strips a modifier suffix', () => {
+    expect(normalizePosixLocale('de_DE@euro')).toBe('de-DE');
+  });
+
+  it('strips both codeset and modifier suffixes', () => {
+    expect(normalizePosixLocale('fr_FR.UTF-8@currency')).toBe('fr-FR');
+  });
+
+  it('passes through an already-BCP-47-shaped tag', () => {
+    expect(normalizePosixLocale('ja-JP')).toBe('ja-JP');
+  });
+
+  it('replaces underscores with dashes', () => {
+    expect(normalizePosixLocale('zh_Hant_TW')).toBe('zh-Hant-TW');
+  });
+
+  it('normalises C / POSIX to the default locale', () => {
+    expect(normalizePosixLocale('C')).toBe(DEFAULT_LOCALE);
+    expect(normalizePosixLocale('POSIX')).toBe(DEFAULT_LOCALE);
+    expect(normalizePosixLocale('C.UTF-8')).toBe(DEFAULT_LOCALE);
+    expect(normalizePosixLocale('posix')).toBe(DEFAULT_LOCALE);
+  });
+
+  it('trims leading and trailing whitespace before processing', () => {
+    expect(normalizePosixLocale('  en_US.UTF-8  ')).toBe('en-US');
+  });
+});
+
+describe('detectSystemLocale', () => {
+  it('returns the default locale when no env vars are set', () => {
+    expect(detectSystemLocale({})).toBe(DEFAULT_LOCALE);
+  });
+
+  it('prefers LC_TIME over LC_ALL and LANG', () => {
+    expect(
+      detectSystemLocale({
+        LC_TIME: 'ja_JP.UTF-8',
+        LC_ALL: 'de_DE.UTF-8',
+        LANG: 'fr_FR.UTF-8',
+      })
+    ).toBe('ja-JP');
+  });
+
+  it('falls back to LC_ALL when LC_TIME is absent', () => {
+    expect(
+      detectSystemLocale({
+        LC_ALL: 'de_DE.UTF-8',
+        LANG: 'fr_FR.UTF-8',
+      })
+    ).toBe('de-DE');
+  });
+
+  it('falls back to LANG when LC_TIME and LC_ALL are absent', () => {
+    expect(detectSystemLocale({ LANG: 'fr_FR.UTF-8' })).toBe('fr-FR');
+  });
+
+  it('skips empty env vars and continues down the chain', () => {
+    expect(
+      detectSystemLocale({
+        LC_TIME: '',
+        LC_ALL: '   ',
+        LANG: 'es_ES.UTF-8',
+      })
+    ).toBe('es-ES');
+  });
+
+  it('falls through to default when all values normalise to empty', () => {
+    expect(
+      detectSystemLocale({
+        LC_TIME: '',
+        LC_ALL: '   ',
+        LANG: '',
+      })
+    ).toBe(DEFAULT_LOCALE);
+  });
+
+  it('treats a C locale as the default rather than a real locale', () => {
+    expect(detectSystemLocale({ LANG: 'C.UTF-8' })).toBe(DEFAULT_LOCALE);
+  });
+});
+
+describe('resolveLocale', () => {
+  it('prefers the explicit value over BB_LOCALE and POSIX vars', () => {
+    expect(
+      resolveLocale({
+        explicit: 'pt-BR',
+        env: {
+          BB_LOCALE: 'de-DE',
+          LC_TIME: 'ja_JP.UTF-8',
+        },
+      })
+    ).toBe('pt-BR');
+  });
+
+  it('falls back to BB_LOCALE when no explicit value is provided', () => {
+    expect(
+      resolveLocale({
+        env: { BB_LOCALE: 'de-DE', LC_TIME: 'ja_JP.UTF-8' },
+      })
+    ).toBe('de-DE');
+  });
+
+  it('falls back to POSIX detection when BB_LOCALE is unset', () => {
+    expect(resolveLocale({ env: { LC_TIME: 'ja_JP.UTF-8' } })).toBe('ja-JP');
+  });
+
+  it('treats a whitespace-only explicit value as unset', () => {
+    expect(
+      resolveLocale({ explicit: '   ', env: { BB_LOCALE: 'de-DE' } })
+    ).toBe('de-DE');
+  });
+
+  it('treats a whitespace-only BB_LOCALE as unset', () => {
+    expect(
+      resolveLocale({ env: { BB_LOCALE: '   ', LANG: 'fr_FR.UTF-8' } })
+    ).toBe('fr-FR');
+  });
+
+  it('falls back to the default when nothing is configured', () => {
+    expect(resolveLocale({ env: {} })).toBe(DEFAULT_LOCALE);
+  });
+
+  it('passes the explicit value through verbatim (does not normalise)', () => {
+    // Users typing `--locale en-GB` should get en-GB exactly; the POSIX
+    // normaliser is only for env-derived values.
+    expect(resolveLocale({ explicit: 'en-GB', env: {} })).toBe('en-GB');
+  });
+});

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -694,4 +694,54 @@ describe('OutputService', () => {
       expect(result).toMatch(/:\d{2}/); // HH:MM marker
     });
   });
+
+  describe('formatDate locale support', () => {
+    it('defaults to en-US formatting (US-style "Jun 15") when no locale is configured', () => {
+      const defaultOutput = new OutputService();
+      const result = defaultOutput.formatDate('2024-06-15T10:30:00Z');
+
+      // en-US renders the month abbreviation before the day.
+      expect(result).toMatch(/Jun/);
+      expect(result.indexOf('Jun')).toBeLessThan(result.indexOf('15'));
+    });
+
+    it('honours an explicit locale (de-DE renders day before month)', () => {
+      const localized = new OutputService({ locale: 'de-DE' });
+      const result = localized.formatDate('2024-06-15T10:30:00Z');
+
+      expect(result).toContain('15');
+      expect(result).toContain('2024');
+      // de-DE uses "15. Juni 2024 ..." or similar; in either case the day
+      // appears before the year in the rendered string.
+      expect(result.indexOf('15')).toBeLessThan(result.indexOf('2024'));
+    });
+
+    it('honours an explicit locale (ja-JP includes the year-suffix character)', () => {
+      const localized = new OutputService({ locale: 'ja-JP' });
+      const result = localized.formatDate('2024-06-15T10:30:00Z');
+
+      // ja-JP's short-month formatter renders the year with the 年 suffix.
+      expect(result).toContain('2024');
+      expect(result).toContain('年');
+    });
+
+    it('falls back to en-US when given an invalid locale tag', () => {
+      const broken = new OutputService({ locale: 'not a valid tag!!' });
+      const result = broken.formatDate('2024-06-15T10:30:00Z');
+
+      // Identical shape to the default — we should not throw, and we should
+      // produce something a human can read.
+      expect(result).toContain('Jun');
+      expect(result).toContain('15');
+      expect(result).toContain('2024');
+    });
+
+    it('formats a Date instance through the configured locale', () => {
+      const localized = new OutputService({ locale: 'de-DE' });
+      const result = localized.formatDate(new Date('2024-12-25T08:00:00Z'));
+
+      expect(result).toContain('25');
+      expect(result).toContain('2024');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `en-US` locale in `OutputService.formatDate` with a
  detection chain so users see dates that match their environment.
- Adds a global `--locale <tag>` flag and a `BB_LOCALE` env var; when neither
  is set the CLI honours the standard POSIX chain (`LC_TIME` → `LC_ALL` →
  `LANG`) and falls back to `en-US` (the historical default).
- Invalid BCP-47 tags fall back to `en-US` inside a `try/catch` so a typo in
  `--locale` or `LANG` cannot crash a date-rendering command.

JSON output is intentionally unchanged: timestamps remain raw ISO strings, so
machine-readable consumers see exactly what they did before.

Closes #230.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun test` — 982 tests pass (24 new across `tests/services/locale.test.ts`,
      additions to `tests/services/output.service.test.ts` and `tests/cli.test.ts`)
- [x] Manual: `bb --locale de-DE pr view 42` renders dates in German format;
      `BB_LOCALE=ja-JP bb pr list` renders dates in Japanese format; default
      run still produces `Jun 15, 2024, ...` for `en-US`.