### PR TITLE
refactor: centralize section separators via output.separator()

### DIFF
--- a/.changeset/real-rocks-deny.md
+++ b/.changeset/real-rocks-deny.md
@@ -1,0 +1,5 @@
+---
+'bitbucket-cli': patch
+---
+
+Centralize horizontal section dividers behind a new `output.separator()` helper so all framed command output (e.g. `pr view`, `pr checks`, `snippet view`, the version-update banner) uses a consistent gray Unicode rule. The version-update banner now renders through `output.warning()` so it picks up proper warning styling instead of an inline `⚠` glyph.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -322,13 +322,13 @@ cli
       const result = await versionService.checkForUpdate();
       if (result?.updateAvailable) {
         output.text('');
-        output.text('─'.repeat(50));
-        output.text(
-          `⚠ A new version is available: ${result.latestVersion} (you have ${result.currentVersion})`
+        output.separator(50);
+        output.warning(
+          `A new version is available: ${result.latestVersion} (you have ${result.currentVersion})\n` +
+            `  Run '${versionService.getInstallCommand()}' to update\n` +
+            `  Or disable with 'bb config set skipVersionCheck true'`
         );
-        output.text(`  Run '${versionService.getInstallCommand()}' to update`);
-        output.text(`  Or disable with 'bb config set skipVersionCheck true'`);
-        output.text('─'.repeat(50));
+        output.separator(50);
       }
     } catch {
       // Silently ignore version check errors

--- a/src/commands/pr/checks.command.ts
+++ b/src/commands/pr/checks.command.ts
@@ -91,7 +91,7 @@ export class ChecksPRCommand extends BaseCommand<
     this.output.text('');
     const title = this.output.bold('Pull Request #' + prId);
     this.output.text(`${title} - ${count} check${count === 1 ? '' : 's'}`);
-    this.output.text(this.output.gray('-'.repeat(60)));
+    this.output.separator();
   }
 
   private renderStatuses(

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -76,7 +76,7 @@ export class ViewPRCommand extends BaseCommand<
     this.output.text(
       `${this.output.bold(`#${pr.id}`)} ${pr.title}${draftLabel} ${stateColor(`[${pr.state}]`)}`
     );
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.separator();
   }
 
   private renderDescription(pr: Pullrequest): void {
@@ -196,7 +196,7 @@ export class ViewPRCommand extends BaseCommand<
   private renderFooter(pr: Pullrequest): void {
     const links = pr.links as { html?: { href?: string } } | undefined;
     this.output.text('');
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.separator();
     this.output.text(
       `${this.output.dim('URL:')} ${this.output.underline(this.output.blue(links?.html?.href ?? ''))}`
     );

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -138,7 +138,7 @@ export class ViewSnippetCommand extends BaseCommand<
     this.output.text(
       `${this.output.bold(String(snippet.id ?? ''))}  ${snippet.title ?? 'Untitled'}  ${this.output.gray(`[${visibility}]`)}`
     );
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.separator();
 
     const creator = getUserDisplayName(snippet.creator);
     if (creator) {

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -137,6 +137,13 @@ export interface IOutputService {
   info(message: string): void;
   text(message: string): void;
   /**
+   * Render a horizontal visual section divider. Used for framing rich
+   * command output (e.g. `pr view`). Centralizing this keeps the separator
+   * style consistent across commands and lets callers avoid raw repeat
+   * strings. Default width is 60 characters.
+   */
+  separator(width?: number): void;
+  /**
    * Truncate `text` to fit within `maxLength` characters, appending `suffix`
    * when truncation occurs. Returns the input unchanged when it already fits
    * or when `maxLength` is <= 0. The default ellipsis is the three-dot ASCII

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -148,6 +148,14 @@ export class OutputService implements IOutputService {
     console.log(stripControl(message));
   }
 
+  public separator(width = 60): void {
+    if (width <= 0) {
+      console.log('');
+      return;
+    }
+    console.log(this.format('─'.repeat(width), chalk.gray));
+  }
+
   public truncate(text: string, maxLength: number, suffix = '...'): string {
     if (maxLength <= 0 || text.length <= maxLength) {
       return text;

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -301,6 +301,38 @@ describe('OutputService', () => {
     });
   });
 
+  describe('separator', () => {
+    it('should render a 60-character Unicode line by default', () => {
+      output.separator();
+
+      expect(consoleLogs).toHaveLength(1);
+      // Strip ANSI color codes for the character/length assertion
+      const plain = consoleLogs[0]!.replace(/\[[0-9;]*m/g, '');
+      expect(plain).toBe('─'.repeat(60));
+    });
+
+    it('should respect a custom width', () => {
+      output.separator(20);
+
+      const plain = consoleLogs[0]!.replace(/\[[0-9;]*m/g, '');
+      expect(plain).toBe('─'.repeat(20));
+    });
+
+    it('should print an empty line for non-positive widths', () => {
+      output.separator(0);
+      output.separator(-5);
+
+      expect(consoleLogs).toEqual(['', '']);
+    });
+
+    it('should emit no ANSI codes when noColor is true', () => {
+      const noColorOutput = new OutputService({ noColor: true });
+      noColorOutput.separator(10);
+
+      expect(consoleLogs[0]).toBe('─'.repeat(10));
+    });
+  });
+
   describe('formatDate', () => {
     it('should format ISO date string', () => {
       const result = output.formatDate('2024-06-15T10:30:00.000Z');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -293,6 +293,9 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     text(message: string) {
       logs.push(`text:${message}`);
     },
+    separator(width = 60) {
+      logs.push(`separator:${width}`);
+    },
     truncate(text: string, maxLength: number, suffix = '...') {
       if (maxLength <= 0 || text.length <= maxLength) {
         return text;


### PR DESCRIPTION
## Summary

Closes #229.

- Adds a new `separator(width?: number)` method to `IOutputService` / `OutputService`. It renders a gray Unicode `─` rule (default width 60), goes through `format()` so it honours `noColor`, and emits a blank line for non-positive widths.
- Replaces ad-hoc `output.text(this.output.gray('─'.repeat(60)))` (and the lone `'-'.repeat(60)` in `pr checks`) across `pr view`, `pr checks`, `snippet view`, and the CLI version-update banner with the shared helper. No more raw separator strings in `*.command.ts`.
- Routes the version-update banner through `output.warning()` so it picks up the proper yellow `⚠` styling instead of a manually-inlined glyph wrapped in `output.text()`.
- Updates the `IOutputService` mock in `tests/setup.ts` so command tests can satisfy the new method.
- Adds dedicated `describe('separator')` coverage in `tests/services/output.service.test.ts` (default width, custom width, non-positive widths, noColor behavior).

The `── ${name} ──` file-label decoration in `snippet view` is left alone — it's a label, not a horizontal rule. The `'-'.repeat(width)` divider inside `OutputService.table()` is also untouched: that's a structural column-aligned ASCII divider, a different concern from visual section dividers.

## Test plan

- [x] `bun run lint` (tsc --noEmit)
- [x] `bun run format:check`
- [x] `bun test` — 952 pass / 0 fail
- [ ] Manual: run `bb pr view <id>`, `bb pr checks <id>`, `bb snippet view <id>` and confirm the dividers render as a single continuous gray line on a Unicode terminal
- [ ] Manual: trigger the version-update path and confirm the banner now shows the yellow `⚠` warning prefix on its first line
- [ ] Manual: re-run with `--no-color` / `NO_COLOR=1` and confirm separators still print plain `─` characters with no escape codes