### PR TITLE
feat: add --no-unicode flag and BB_NO_UNICODE for ASCII fallbacks

### DIFF
--- a/.changeset/no-unicode-flag.md
+++ b/.changeset/no-unicode-flag.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `--no-unicode` flag and `BB_NO_UNICODE` env var to substitute ASCII fallbacks for Unicode glyphs (separators, arrows, status icons, info/warning/error/success symbols) in non-JSON output. Useful for older terminals, constrained CI environments, or fonts that render the original glyphs as boxes. Mirrors the `gh` CLI's `GH_NO_UNICODE`.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -94,6 +94,7 @@ import { BrowseCommand } from './commands/browse.command.js';
 
 export interface BootstrapOptions {
   noColor?: boolean;
+  noUnicode?: boolean;
 }
 
 type Ctor<T> = new (...args: never[]) => T;
@@ -156,7 +157,11 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   container.register(ServiceTokens.GitService, () => new GitService());
   container.register(
     ServiceTokens.OutputService,
-    () => new OutputService({ noColor: options.noColor })
+    () =>
+      new OutputService({
+        noColor: options.noColor,
+        noUnicode: options.noUnicode,
+      })
   );
   registerCommand(container, ServiceTokens.OAuthService, OAuthService, [
     ServiceTokens.ConfigService,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   '--version',
   '--json',
   '--no-color',
+  '--no-unicode',
   '--workspace',
   '--repo',
 ];
@@ -164,11 +165,30 @@ export function resolveNoColorSetting(
   return hasNoColorEnv;
 }
 
+/**
+ * Decide whether the CLI should suppress Unicode glyphs (separators, arrows,
+ * status icons) and fall back to ASCII. Mirrors the precedence used by `gh`
+ * for `GH_NO_UNICODE`: an explicit `--no-unicode` flag wins, otherwise any
+ * non-empty `BB_NO_UNICODE` env var enables it. Resolved before Commander
+ * parses argv so the OutputService and help-text rendering see the same
+ * setting.
+ */
+export function resolveNoUnicodeSetting(
+  argv: string[],
+  env: NodeJS.ProcessEnv
+): boolean {
+  if (argv.includes('--no-unicode')) {
+    return true;
+  }
+  return env.BB_NO_UNICODE !== undefined && env.BB_NO_UNICODE !== '';
+}
+
 // Bootstrap the container
 const noColor = resolveNoColorSetting(process.argv, process.env);
+const noUnicode = resolveNoUnicodeSetting(process.argv, process.env);
 const buildHelpText = createHelpTextBuilder(noColor);
 
-const container = bootstrap({ noColor });
+const container = bootstrap({ noColor, noUnicode });
 
 // Helper to create command context. Validation errors from --json/--jq
 // parsing are deferred onto `context.validationError` so they can be raised
@@ -211,6 +231,7 @@ function createContext(program: Command): CommandContext {
       jsonFields,
       jq: jqOpt,
       noColor: opts.color === false,
+      noUnicode: opts.unicode === false || noUnicode,
       workspace: opts.workspace,
       repo: opts.repo,
     },
@@ -278,6 +299,10 @@ cli
     'Filter the JSON output through a jq expression — runs in-process via embedded jq, requires --json (e.g. \'.pullRequests[] | select(.state == "OPEN") | .title\')'
   )
   .option('--no-color', 'Disable color output')
+  .option(
+    '--no-unicode',
+    'Use ASCII fallbacks for symbols (separators, arrows, status icons) — also enabled by BB_NO_UNICODE'
+  )
   .option('-w, --workspace <workspace>', 'Specify workspace')
   .option('-r, --repo <repo>', 'Specify repository')
   .addHelpText(
@@ -288,6 +313,8 @@ cli
         BB_API_TOKEN: 'Bitbucket API token (fallback for auth login)',
         NO_COLOR: 'Disable color output when set',
         FORCE_COLOR: "Force color output when set (and not '0')",
+        BB_NO_UNICODE:
+          'Use ASCII fallbacks for symbols when set (any non-empty value)',
         DEBUG: "Enable HTTP debug logging when 'true'",
       },
       seeAlso: [
@@ -321,14 +348,16 @@ cli
     try {
       const result = await versionService.checkForUpdate();
       if (result?.updateAvailable) {
+        const separator = output.symbol('─', '-').repeat(50);
+        const warnSym = output.symbol('⚠', '!!');
         output.text('');
-        output.text('─'.repeat(50));
+        output.text(separator);
         output.text(
-          `⚠ A new version is available: ${result.latestVersion} (you have ${result.currentVersion})`
+          `${warnSym} A new version is available: ${result.latestVersion} (you have ${result.currentVersion})`
         );
         output.text(`  Run '${versionService.getInstallCommand()}' to update`);
         output.text(`  Or disable with 'bb config set skipVersionCheck true'`);
-        output.text('─'.repeat(50));
+        output.text(separator);
       }
     } catch {
       // Silently ignore version check errors

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -95,6 +95,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
       return;
     }
 
+    const arrow = this.output.symbol('→', '->');
     const rows = values.map((pr: Pullrequest) => {
       const title = pr.draft ? `[DRAFT] ${pr.title}` : pr.title;
       const source = pr.source as { branch?: { name?: string } } | undefined;
@@ -105,7 +106,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
         `#${pr.id}`,
         this.output.truncate(title ?? '', 50),
         pr.author?.display_name ?? 'Unknown',
-        `${source?.branch?.name ?? 'unknown'} → ${destination?.branch?.name ?? 'unknown'}`,
+        `${source?.branch?.name ?? 'unknown'} ${arrow} ${destination?.branch?.name ?? 'unknown'}`,
       ];
     });
 

--- a/src/commands/pr/view.command.ts
+++ b/src/commands/pr/view.command.ts
@@ -76,7 +76,7 @@ export class ViewPRCommand extends BaseCommand<
     this.output.text(
       `${this.output.bold(`#${pr.id}`)} ${pr.title}${draftLabel} ${stateColor(`[${pr.state}]`)}`
     );
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.text(this.output.gray(this.output.symbol('─', '-').repeat(60)));
   }
 
   private renderDescription(pr: Pullrequest): void {
@@ -95,7 +95,7 @@ export class ViewPRCommand extends BaseCommand<
       | undefined;
     const sourceBranch = this.output.cyan(source?.branch?.name ?? 'unknown');
     const destBranch = this.output.cyan(destination?.branch?.name ?? 'unknown');
-    const arrow = this.output.gray(' → ');
+    const arrow = this.output.gray(this.output.symbol(' → ', ' -> '));
 
     this.output.text(
       `${this.output.dim('Branch:')}   ${sourceBranch}${arrow}${destBranch}`
@@ -143,8 +143,8 @@ export class ViewPRCommand extends BaseCommand<
     }
 
     const closeBranchIndicator = pr.close_source_branch
-      ? this.output.green('✓')
-      : this.output.gray('✗');
+      ? this.output.green(this.output.symbol('✓', 'yes'))
+      : this.output.gray(this.output.symbol('✗', 'no'));
     this.output.text(
       `${this.output.dim('Close Src:')} ${closeBranchIndicator} ${this.output.gray('(close source branch on merge)')}`
     );
@@ -183,20 +183,29 @@ export class ViewPRCommand extends BaseCommand<
     label: string;
   } {
     if (reviewer.approved) {
-      return { icon: this.output.green('✓'), label: 'approved' };
+      return {
+        icon: this.output.green(this.output.symbol('✓', '[OK]')),
+        label: 'approved',
+      };
     }
 
     if (reviewer.state === 'changes_requested') {
-      return { icon: this.output.red('✗'), label: 'changes requested' };
+      return {
+        icon: this.output.red(this.output.symbol('✗', '[X]')),
+        label: 'changes requested',
+      };
     }
 
-    return { icon: this.output.yellow('○'), label: 'pending' };
+    return {
+      icon: this.output.yellow(this.output.symbol('○', '[ ]')),
+      label: 'pending',
+    };
   }
 
   private renderFooter(pr: Pullrequest): void {
     const links = pr.links as { html?: { href?: string } } | undefined;
     this.output.text('');
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.text(this.output.gray(this.output.symbol('─', '-').repeat(60)));
     this.output.text(
       `${this.output.dim('URL:')} ${this.output.underline(this.output.blue(links?.html?.href ?? ''))}`
     );

--- a/src/commands/snippet/view.command.ts
+++ b/src/commands/snippet/view.command.ts
@@ -102,9 +102,10 @@ export class ViewSnippetCommand extends BaseCommand<
         return;
       }
       this.renderSnippet(snippet, fileNames);
+      const fileSep = this.output.symbol('──', '--');
       for (const name of fileNames) {
         this.output.text('');
-        this.output.text(this.output.bold(`── ${name} ──`));
+        this.output.text(this.output.bold(`${fileSep} ${name} ${fileSep}`));
         this.output.text(contents[name] ?? '');
       }
       return;
@@ -138,7 +139,7 @@ export class ViewSnippetCommand extends BaseCommand<
     this.output.text(
       `${this.output.bold(String(snippet.id ?? ''))}  ${snippet.title ?? 'Untitled'}  ${this.output.gray(`[${visibility}]`)}`
     );
-    this.output.text(this.output.gray('─'.repeat(60)));
+    this.output.text(this.output.gray(this.output.symbol('─', '-').repeat(60)));
 
     const creator = getUserDisplayName(snippet.creator);
     if (creator) {

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -143,6 +143,13 @@ export interface IOutputService {
    * sequence to match historical output and stay safe across terminals.
    */
   truncate(text: string, maxLength: number, suffix?: string): string;
+  /**
+   * Return `unicode` when the terminal can render Unicode glyphs, otherwise
+   * `ascii`. Lets callers keep a single inline expression for symbols
+   * (separators, arrows, status dots) that need an ASCII fallback under
+   * `--no-unicode` / `BB_NO_UNICODE`.
+   */
+  symbol(unicode: string, ascii: string): string;
   format(text: string, formatter: (text: string) => string): string;
   dim(text: string): string;
   highlight(text: string): string;

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -48,10 +48,12 @@ const WRAPPER_ARRAY_KEYS: readonly string[] = [
 
 export class OutputService implements IOutputService {
   private readonly noColor: boolean;
+  private readonly noUnicode: boolean;
   private jsonFormatOptions: JsonFormatOptions = {};
 
-  constructor(options?: { noColor?: boolean }) {
+  constructor(options?: { noColor?: boolean; noUnicode?: boolean }) {
     this.noColor = options?.noColor ?? false;
+    this.noUnicode = options?.noUnicode ?? false;
   }
 
   public setJsonFormatOptions(options: JsonFormatOptions): void {
@@ -125,23 +127,27 @@ export class OutputService implements IOutputService {
   }
 
   public success(message: string): void {
-    const symbol = this.format('✓', chalk.green);
+    const symbol = this.format(this.symbol('✓', 'OK'), chalk.green);
     console.log(`${symbol} ${stripControl(message)}`);
   }
 
   public error(message: string): void {
-    const symbol = this.format('✗', chalk.red);
+    const symbol = this.format(this.symbol('✗', 'ERR'), chalk.red);
     console.error(`${symbol} ${stripControl(message)}`);
   }
 
   public warning(message: string): void {
-    const symbol = this.format('⚠', chalk.yellow);
+    const symbol = this.format(this.symbol('⚠', '!!'), chalk.yellow);
     console.warn(`${symbol} ${stripControl(message)}`);
   }
 
   public info(message: string): void {
-    const symbol = this.format('ℹ', chalk.blue);
+    const symbol = this.format(this.symbol('ℹ', 'i'), chalk.blue);
     console.log(`${symbol} ${stripControl(message)}`);
+  }
+
+  public symbol(unicode: string, ascii: string): string {
+    return this.noUnicode ? ascii : unicode;
   }
 
   public text(message: string): void {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -43,6 +43,7 @@ export interface GlobalOptions {
   jsonFields?: string[];
   jq?: string;
   noColor?: boolean;
+  noUnicode?: boolean;
   workspace?: string;
   repo?: string;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,6 +7,7 @@ import type { Command } from 'commander';
 import {
   getCompletionParent,
   resolveNoColorSetting,
+  resolveNoUnicodeSetting,
   withGlobalOptions,
 } from '../src/cli.js';
 import { cli } from '../src/cli.js';
@@ -213,6 +214,42 @@ describe('resolveNoColorSetting', () => {
   });
 });
 
+describe('resolveNoUnicodeSetting', () => {
+  it('should disable unicode when --no-unicode is passed', () => {
+    const noUnicode = resolveNoUnicodeSetting(
+      ['node', 'bb', '--no-unicode'],
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(noUnicode).toBe(true);
+  });
+
+  it('should disable unicode when BB_NO_UNICODE env var is set', () => {
+    const noUnicode = resolveNoUnicodeSetting(['node', 'bb'], {
+      BB_NO_UNICODE: '1',
+    } as NodeJS.ProcessEnv);
+
+    expect(noUnicode).toBe(true);
+  });
+
+  it('should not disable unicode when BB_NO_UNICODE is empty', () => {
+    const noUnicode = resolveNoUnicodeSetting(['node', 'bb'], {
+      BB_NO_UNICODE: '',
+    } as NodeJS.ProcessEnv);
+
+    expect(noUnicode).toBe(false);
+  });
+
+  it('should default to false when neither flag nor env var is present', () => {
+    const noUnicode = resolveNoUnicodeSetting(
+      ['node', 'bb'],
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(noUnicode).toBe(false);
+  });
+});
+
 describe('CLI option wiring', () => {
   it('should reserve -w for global --workspace and keep pr diff --web long-only', () => {
     const workspaceOption = cli.options.find(
@@ -273,6 +310,7 @@ describe('CLI help text integration', () => {
     expect(output).toContain('BB_API_TOKEN');
     expect(output).toContain('NO_COLOR');
     expect(output).toContain('FORCE_COLOR');
+    expect(output).toContain('BB_NO_UNICODE');
     expect(output).toContain('DEBUG');
   });
 
@@ -437,6 +475,7 @@ describe('CLI command registration', () => {
     expect(hasOption(cli, '--json')).toBe(true);
     expect(hasOption(cli, '--jq')).toBe(true);
     expect(hasOption(cli, '--no-color')).toBe(true);
+    expect(hasOption(cli, '--no-unicode')).toBe(true);
     expect(hasShortOption(cli, '-w')).toBe(true);
     expect(hasShortOption(cli, '-r')).toBe(true);
   });

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -752,6 +752,72 @@ describe('ListPRsCommand', () => {
     const opts = capturedAxiosOptions as { params: Record<string, unknown> };
     expect(opts.params.q).toBeUndefined();
   });
+
+  it('should use ASCII arrow in branch column when noUnicode mode is on', async () => {
+    const prs = [
+      {
+        ...mockPullRequest,
+        id: 1,
+        source: {
+          branch: { name: 'feature' },
+        } as unknown as import('../../src/generated/api.js').PullrequestSource,
+        destination: {
+          branch: { name: 'main' },
+        } as unknown as import('../../src/generated/api.js').PullrequestDestination,
+      },
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService({ noUnicode: true });
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({}, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[3]).toBe('feature -> main');
+  });
+
+  it('should use Unicode arrow in branch column by default', async () => {
+    const prs = [
+      {
+        ...mockPullRequest,
+        id: 1,
+        source: {
+          branch: { name: 'feature' },
+        } as unknown as import('../../src/generated/api.js').PullrequestSource,
+        destination: {
+          branch: { name: 'main' },
+        } as unknown as import('../../src/generated/api.js').PullrequestDestination,
+      },
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({}, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[3]).toBe('feature → main');
+  });
 });
 
 describe('ViewPRCommand', () => {
@@ -894,6 +960,54 @@ describe('ViewPRCommand', () => {
     expect(joined).toContain('Carol Pending');
     expect(joined).toContain('pending');
     expect(joined).not.toContain('Dan Drive-by');
+  });
+
+  it('should fall back to ASCII separators, arrows, and reviewer icons under noUnicode', async () => {
+    const prs = [
+      {
+        ...mockPullRequest,
+        participants: [
+          {
+            role: 'REVIEWER',
+            approved: true,
+            user: { display_name: 'Alice Approver' },
+          },
+          {
+            role: 'REVIEWER',
+            approved: false,
+            state: 'changes_requested',
+            user: { display_name: 'Bob Blocker' },
+          },
+          {
+            role: 'REVIEWER',
+            approved: false,
+            user: { display_name: 'Carol Pending' },
+          },
+        ],
+      } as unknown as Pullrequest,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService({ noUnicode: true });
+
+    const command = new ViewPRCommand(pullrequestsApi, contextService, output);
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    const joined = output.logs.join('\n');
+    // No unicode glyphs.
+    expect(joined).not.toContain('─');
+    expect(joined).not.toContain('→');
+    expect(joined).not.toContain('○');
+    expect(joined).not.toContain('✓');
+    expect(joined).not.toContain('✗');
+    // ASCII fallbacks come through.
+    expect(joined).toContain('->');
+    expect(joined).toContain('[OK]'); // approved
+    expect(joined).toContain('[X]'); // changes requested
+    expect(joined).toContain('[ ]'); // pending
   });
 
   it('should render merge commit hash when PR is merged', async () => {

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -343,6 +343,80 @@ describe('OutputService', () => {
     });
   });
 
+  describe('noUnicode option', () => {
+    it('passes through unicode glyphs by default', () => {
+      const out = new OutputService();
+      expect(out.symbol('✓', 'OK')).toBe('✓');
+      expect(out.symbol('─', '-')).toBe('─');
+      expect(out.symbol('→', '->')).toBe('→');
+    });
+
+    it('returns the ASCII fallback when noUnicode is true', () => {
+      const out = new OutputService({ noUnicode: true });
+      expect(out.symbol('✓', 'OK')).toBe('OK');
+      expect(out.symbol('─', '-')).toBe('-');
+      expect(out.symbol('→', '->')).toBe('->');
+    });
+
+    it('substitutes ASCII fallbacks in success output', () => {
+      const out = new OutputService({ noUnicode: true });
+      out.success('done');
+
+      expect(consoleLogs[0]).toContain('OK');
+      expect(consoleLogs[0]).toContain('done');
+      expect(consoleLogs[0]).not.toContain('✓');
+    });
+
+    it('substitutes ASCII fallbacks in error output', () => {
+      const out = new OutputService({ noUnicode: true });
+      out.error('boom');
+
+      expect(consoleErrors[0]).toContain('ERR');
+      expect(consoleErrors[0]).toContain('boom');
+      expect(consoleErrors[0]).not.toContain('✗');
+    });
+
+    it('substitutes ASCII fallbacks in warning output', () => {
+      const out = new OutputService({ noUnicode: true });
+      out.warning('careful');
+
+      expect(consoleWarns[0]).toContain('!!');
+      expect(consoleWarns[0]).toContain('careful');
+      expect(consoleWarns[0]).not.toContain('⚠');
+    });
+
+    it('substitutes ASCII fallbacks in info output', () => {
+      const out = new OutputService({ noUnicode: true });
+      out.info('hello');
+
+      expect(consoleLogs[0]).toContain('hello');
+      expect(consoleLogs[0]).not.toContain('ℹ');
+    });
+
+    it('keeps Unicode glyphs in info/success/warning/error when noUnicode is false', () => {
+      const out = new OutputService({ noUnicode: false });
+      out.success('a');
+      out.error('b');
+      out.warning('c');
+      out.info('d');
+
+      expect(consoleLogs[0]).toContain('✓');
+      expect(consoleErrors[0]).toContain('✗');
+      expect(consoleWarns[0]).toContain('⚠');
+      expect(consoleLogs[1]).toContain('ℹ');
+    });
+
+    it('is independent from noColor', () => {
+      // noColor and noUnicode are orthogonal: a terminal with full color
+      // support may still have broken glyph rendering, and vice versa.
+      const colored = new OutputService({ noColor: false, noUnicode: true });
+      expect(colored.symbol('✓', 'OK')).toBe('OK');
+
+      const plain = new OutputService({ noColor: true, noUnicode: false });
+      expect(plain.symbol('✓', 'OK')).toBe('✓');
+    });
+  });
+
   describe('noColor option', () => {
     it('should strip colors when noColor is true', () => {
       const noColorOutput = new OutputService({ noColor: true });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -260,8 +260,11 @@ export function createMockContextService(
   return new ContextService(gitService, configService);
 }
 
-export function createMockOutputService(): IOutputService & { logs: string[] } {
+export function createMockOutputService(
+  options: { noUnicode?: boolean } = {}
+): IOutputService & { logs: string[] } {
   const logs: string[] = [];
+  const noUnicode = options.noUnicode ?? false;
 
   return {
     logs,
@@ -301,6 +304,9 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
         return text.slice(0, maxLength);
       }
       return text.slice(0, maxLength - suffix.length) + suffix;
+    },
+    symbol(unicode: string, ascii: string) {
+      return noUnicode ? ascii : unicode;
     },
     format(text: string, formatter: (text: string) => string) {
       return formatter(text);


### PR DESCRIPTION
## Summary

- Add a global `--no-unicode` flag and `BB_NO_UNICODE` env var that swap Unicode symbols (separators `─`, arrows `→`, status dot `○`, info/warn/error/success icons `ℹ ⚠ ✗ ✓`) for ASCII fallbacks across non-JSON output. Mirrors `gh`'s `GH_NO_UNICODE`.
- Introduce `IOutputService.symbol(unicode, ascii)` so callers compose Unicode-aware strings inline; `OutputService` accepts a new `noUnicode` constructor option, and bootstrap wires it from the resolved CLI/env setting.
- Update `pr list`, `pr view`, `snippet view`, and the root version-check banner to route through `output.symbol(...)`.

The two flags are intentionally orthogonal: a terminal can have full color support but broken glyph rendering, and vice versa. JSON output is unchanged.

Closes #226

## Test plan

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun test` — 963 passing, includes new coverage:
  - `OutputService.symbol` returns Unicode by default and ASCII when `noUnicode: true`
  - `success/error/warning/info` substitute `OK / ERR / !! / i` under noUnicode and keep `✓ ✗ ⚠ ℹ` otherwise
  - `noColor` and `noUnicode` are independent
  - `resolveNoUnicodeSetting` honors `--no-unicode` and any non-empty `BB_NO_UNICODE`
  - Root help advertises `BB_NO_UNICODE` in the env-var section and registers `--no-unicode`
  - `ListPRsCommand` renders `feature -> main` under noUnicode and `feature → main` by default
  - `ViewPRCommand` renders ASCII separators/arrows and `[OK] / [X] / [ ]` reviewer icons under noUnicode
- [ ] Manual smoke (optional): `bb --no-unicode pr list` and `BB_NO_UNICODE=1 bb pr view <id>` in a terminal that renders the original glyphs as boxes