### PR TITLE
feat: add global --no-truncate flag for table output

### DIFF
--- a/.changeset/global-no-truncate-flag.md
+++ b/.changeset/global-no-truncate-flag.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add a global `--no-truncate` flag that disables column truncation in table output across `bb pr list`, `bb pr activity`, `bb pr checks`, `bb pr edit`, `bb pr comments list`, `bb repo list`, and `bb snippet comments list`. The previously command-local `--no-truncate` flag on `bb pr comments list` is now subsumed by the global flag and no longer needs to be passed separately. JSON output is unaffected.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   '--version',
   '--json',
   '--no-color',
+  '--no-truncate',
   '--workspace',
   '--repo',
 ];
@@ -211,6 +212,7 @@ function createContext(program: Command): CommandContext {
       jsonFields,
       jq: jqOpt,
       noColor: opts.color === false,
+      noTruncate: opts.truncate === false,
       workspace: opts.workspace,
       repo: opts.repo,
     },
@@ -278,6 +280,10 @@ cli
     'Filter the JSON output through a jq expression — runs in-process via embedded jq, requires --json (e.g. \'.pullRequests[] | select(.state == "OPEN") | .title\')'
   )
   .option('--no-color', 'Disable color output')
+  .option(
+    '--no-truncate',
+    'Show full values in table output without truncation'
+  )
   .option('-w, --workspace <workspace>', 'Specify workspace')
   .option('-r, --repo <repo>', 'Specify repository')
   .addHelpText(
@@ -1037,7 +1043,6 @@ prCommentsCmd
   .command('list <id>')
   .description('List comments on a pull request')
   .option('--limit <number>', 'Maximum number of comments (default: 25)')
-  .option('--no-truncate', 'Show full comment content without truncation')
   .addHelpText(
     'after',
     buildHelpText({

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -122,7 +122,11 @@ export class ActivityPRCommand extends BaseCommand<
         activityType.toUpperCase(),
         this.getActorName(activity),
         this.formatActivityDate(activity),
-        this.buildActivityDetails(activity, activityType),
+        this.buildActivityDetails(
+          activity,
+          activityType,
+          context.globalOptions
+        ),
       ];
     });
 
@@ -220,20 +224,23 @@ export class ActivityPRCommand extends BaseCommand<
 
   private buildActivityDetails(
     activity: PullrequestActivity,
-    type: string
+    type: string,
+    globalOptions: GlobalOptions
   ): string {
     switch (type) {
       case 'comment': {
         const content = getRawContent(activity.comment?.content) ?? '';
         const id = activity.comment?.id ? `#${activity.comment.id}` : '';
-        const snippet = this.output.truncate(content, 80);
+        const snippet = this.truncateText(content, 80, globalOptions);
         return [id, snippet].filter(Boolean).join(' ');
       }
       case 'approval':
         return 'approved';
       case 'changes_requested': {
         const reason = activity.changes_requested?.reason;
-        return reason ? this.output.truncate(reason, 80) : 'changes requested';
+        return reason
+          ? this.truncateText(reason, 80, globalOptions)
+          : 'changes requested';
       }
       case 'merge':
         return this.formatCommitDetail(activity.merge?.commit?.hash, 'merged');
@@ -246,7 +253,7 @@ export class ActivityPRCommand extends BaseCommand<
           return `state: ${activity.update.state}`;
         }
         if (activity.update?.title) {
-          return `title: ${this.output.truncate(activity.update.title, 60)}`;
+          return `title: ${this.truncateText(activity.update.title, 60, globalOptions)}`;
         }
         if (activity.update?.description) {
           return 'description updated';

--- a/src/commands/pr/checks.command.ts
+++ b/src/commands/pr/checks.command.ts
@@ -70,7 +70,7 @@ export class ChecksPRCommand extends BaseCommand<
     }
 
     this.renderHeader(prId, statuses.length);
-    this.renderStatuses(statuses, summary);
+    this.renderStatuses(statuses, summary, context.globalOptions);
   }
 
   private formatStatusForJson(status: Commitstatus): Record<string, unknown> {
@@ -96,7 +96,8 @@ export class ChecksPRCommand extends BaseCommand<
 
   private renderStatuses(
     statuses: Commitstatus[],
-    summary: { successful: number; failed: number; pending: number }
+    summary: { successful: number; failed: number; pending: number },
+    globalOptions: GlobalOptions
   ): void {
     const rows = statuses.map((status) => {
       const stateIcon = this.getStateIcon(status.state);
@@ -107,7 +108,7 @@ export class ChecksPRCommand extends BaseCommand<
       return [
         `${stateIcon} ${stateLabel}`,
         this.output.bold(name),
-        this.output.truncate(description, 40),
+        this.truncateText(description, 40, globalOptions),
         status.updated_on ? this.output.formatDate(status.updated_on) : '-',
       ];
     });

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -21,7 +21,6 @@ import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListCommentsPROptions extends GlobalOptions {
   limit?: string;
-  truncate?: boolean;
 }
 
 export class ListCommentsPRCommand extends BaseCommand<
@@ -93,9 +92,7 @@ export class ListCommentsPRCommand extends BaseCommand<
         getUserDisplayName(comment.user) ?? 'Unknown',
         comment.deleted
           ? '[deleted]'
-          : options.truncate === false
-            ? content
-            : this.output.truncate(content, 60),
+          : this.truncateText(content, 60, context.globalOptions),
         this.output.formatDate(comment.created_on ?? ''),
       ];
     });

--- a/src/commands/pr/edit.command.ts
+++ b/src/commands/pr/edit.command.ts
@@ -144,7 +144,11 @@ export class EditPRCommand extends BaseCommand<EditPROptions, void> {
     this.output.success(`Updated pull request #${pr.id}`);
     this.output.text(`  ${this.output.dim('Title:')} ${pr.title}`);
     if (pr.description) {
-      const truncatedDesc = this.output.truncate(pr.description, 100);
+      const truncatedDesc = this.truncateText(
+        pr.description,
+        100,
+        context.globalOptions
+      );
       this.output.text(`  ${this.output.dim('Description:')} ${truncatedDesc}`);
     }
     this.output.text(`  ${this.output.dim('URL:')} ${links?.html?.href}`);

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -103,7 +103,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
         | undefined;
       return [
         `#${pr.id}`,
-        this.output.truncate(title ?? '', 50),
+        this.truncateText(title ?? '', 50, context.globalOptions),
         pr.author?.display_name ?? 'Unknown',
         `${source?.branch?.name ?? 'unknown'} → ${destination?.branch?.name ?? 'unknown'}`,
       ];

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -70,7 +70,7 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     const rows = repos.map((repo) => [
       repo.full_name ?? '',
       repo.is_private ? 'private' : 'public',
-      (repo.description || '').substring(0, 50),
+      this.truncateText(repo.description ?? '', 50, context.globalOptions),
     ]);
 
     this.output.table(['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'], rows);

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -83,7 +83,7 @@ export class ListSnippetCommentsCommand extends BaseCommand<
         String(comment.id ?? ''),
         getUserDisplayName(comment.user) ?? 'Unknown',
         this.output.formatDate(comment.created_on ?? ''),
-        this.output.truncate(content, 60),
+        this.truncateText(content, 60, context.globalOptions),
       ];
     });
 

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -165,6 +165,23 @@ export abstract class BaseCommand<
   }
 
   /**
+   * Truncate `text` for table/list rendering, honoring the global
+   * `--no-truncate` flag carried on `context.globalOptions`. Pass the
+   * `globalOptions` (or any object with `noTruncate`) so commands don't
+   * each have to thread the flag through their own helpers.
+   */
+  protected truncateText(
+    text: string,
+    maxLength: number,
+    opts: { noTruncate?: boolean } = {}
+  ): string {
+    if (opts.noTruncate) {
+      return text;
+    }
+    return this.output.truncate(text, maxLength);
+  }
+
+  /**
    * Validate a string option against a set of allowed values
    */
   protected parseEnumOption<T extends string>(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -43,6 +43,7 @@ export interface GlobalOptions {
   jsonFields?: string[];
   jq?: string;
   noColor?: boolean;
+  noTruncate?: boolean;
   workspace?: string;
   repo?: string;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -431,12 +431,13 @@ describe('CLI command registration', () => {
     ]);
   });
 
-  it('should register global --workspace, --repo, --json, --jq and --no-color options on root', () => {
+  it('should register global --workspace, --repo, --json, --jq, --no-color and --no-truncate options on root', () => {
     expect(hasOption(cli, '--workspace')).toBe(true);
     expect(hasOption(cli, '--repo')).toBe(true);
     expect(hasOption(cli, '--json')).toBe(true);
     expect(hasOption(cli, '--jq')).toBe(true);
     expect(hasOption(cli, '--no-color')).toBe(true);
+    expect(hasOption(cli, '--no-truncate')).toBe(true);
     expect(hasShortOption(cli, '-w')).toBe(true);
     expect(hasShortOption(cli, '-r')).toBe(true);
   });

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -694,6 +694,52 @@ describe('ListPRsCommand', () => {
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
 
+  it('should truncate long titles by default', async () => {
+    const longTitle = 'A'.repeat(80);
+    const prs = [{ ...mockPullRequest, id: 1, title: longTitle }];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({}, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[1]).toBe('A'.repeat(47) + '...');
+  });
+
+  it('should show full titles when noTruncate is set', async () => {
+    const longTitle = 'A'.repeat(80);
+    const prs = [{ ...mockPullRequest, id: 1, title: longTitle }];
+    const pullrequestsApi = createMockPullrequestsApi({ pullRequests: prs });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi({ uuid: '{user-uuid}' });
+
+    const command = new ListPRsCommand(
+      pullrequestsApi,
+      usersApi,
+      contextService,
+      output
+    );
+    await command.execute({}, { globalOptions: { noTruncate: true } });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[1]).toBe(longTitle);
+  });
+
   it('should include reviewer filter when --mine is set', async () => {
     let capturedAxiosOptions: unknown;
     const pullrequestsApi = createMockPullrequestsApi({
@@ -1122,6 +1168,72 @@ describe('ActivityPRCommand', () => {
     ).rejects.toThrow(/--id must be a positive integer/);
   });
 
+  it('should truncate long comment activity by default', async () => {
+    const longContent = 'D'.repeat(120);
+    const pullrequestsApi = createMockPullrequestsApi({
+      activityPages: [
+        [
+          {
+            comment: {
+              id: 99,
+              content: { raw: longContent },
+              user: mockUser,
+              created_on: '2024-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[3]).toBe('#99 ' + 'D'.repeat(77) + '...');
+  });
+
+  it('should show full comment activity when noTruncate is set', async () => {
+    const longContent = 'D'.repeat(120);
+    const pullrequestsApi = createMockPullrequestsApi({
+      activityPages: [
+        [
+          {
+            comment: {
+              id: 99,
+              content: { raw: longContent },
+              user: mockUser,
+              created_on: '2024-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ActivityPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: { noTruncate: true } });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[3]).toBe('#99 ' + longContent);
+  });
+
   it('should reject an invalid --type value', async () => {
     const pullrequestsApi = createMockPullrequestsApi();
     const contextService = createMockContextService({
@@ -1224,6 +1336,66 @@ describe('ListCommentsPRCommand', () => {
 
     const rows = getTableRows(output.logs);
     expect(rows).toHaveLength(2);
+  });
+
+  it('should truncate long comment content by default', async () => {
+    const longContent = 'B'.repeat(120);
+    const comments: PullrequestComment[] = [
+      {
+        id: 1,
+        type: 'pullrequest_comment',
+        content: { raw: longContent },
+        user: mockUser,
+        created_on: '2024-01-01T00:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ comments });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe('B'.repeat(57) + '...');
+  });
+
+  it('should show full comment content when noTruncate is set', async () => {
+    const longContent = 'B'.repeat(120);
+    const comments: PullrequestComment[] = [
+      {
+        id: 1,
+        type: 'pullrequest_comment',
+        content: { raw: longContent },
+        user: mockUser,
+        created_on: '2024-01-01T00:00:00.000Z',
+        deleted: false,
+      } as PullrequestComment,
+    ];
+    const pullrequestsApi = createMockPullrequestsApi({ comments });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: { noTruncate: true } });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe(longContent);
   });
 
   it('should include limited count in json output', async () => {
@@ -1356,6 +1528,68 @@ describe('ChecksPRCommand', () => {
         log.includes('No CI/CD checks found for this pull request')
       )
     ).toBe(true);
+  });
+
+  it('should truncate long check descriptions by default', async () => {
+    const longDescription = 'C'.repeat(80);
+    const commitStatusesApi = createMockCommitStatusesApi({
+      statuses: [
+        {
+          type: 'commit_status',
+          key: 'build',
+          name: 'Build',
+          state: 'SUCCESSFUL',
+          description: longDescription,
+          updated_on: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ChecksPRCommand(
+      commitStatusesApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe('C'.repeat(37) + '...');
+  });
+
+  it('should show full check descriptions when noTruncate is set', async () => {
+    const longDescription = 'C'.repeat(80);
+    const commitStatusesApi = createMockCommitStatusesApi({
+      statuses: [
+        {
+          type: 'commit_status',
+          key: 'build',
+          name: 'Build',
+          state: 'SUCCESSFUL',
+          description: longDescription,
+          updated_on: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ChecksPRCommand(
+      commitStatusesApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: { noTruncate: true } });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe(longDescription);
   });
 });
 

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -244,6 +244,47 @@ describe('ListReposCommand', () => {
 
     expect(output.logs.some((log) => log.startsWith('json:'))).toBe(true);
   });
+
+  it('should truncate long descriptions by default', async () => {
+    const longDescription = 'E'.repeat(80);
+    const repositoriesApi = createMockRepositoriesApi([
+      { ...mockRepository, description: longDescription },
+    ]);
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute({ workspace: 'workspace' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe('E'.repeat(47) + '...');
+  });
+
+  it('should show full descriptions when noTruncate is set', async () => {
+    const longDescription = 'E'.repeat(80);
+    const repositoriesApi = createMockRepositoriesApi([
+      { ...mockRepository, description: longDescription },
+    ]);
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace' },
+      { globalOptions: { noTruncate: true } }
+    );
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]?.[2]).toBe(longDescription);
+  });
 });
 
 describe('ViewRepoCommand', () => {

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -98,6 +98,14 @@ class TestCommandWithParseHelpers extends BaseCommand<
   ): T {
     return this.parseEnumOption(value, name, allowed);
   }
+
+  public callTruncateText(
+    text: string,
+    maxLength: number,
+    opts: { noTruncate?: boolean } = {}
+  ): string {
+    return this.truncateText(text, maxLength, opts);
+  }
 }
 
 describe('BaseCommand', () => {
@@ -500,6 +508,63 @@ describe('BaseCommand', () => {
       const command = new TestCommandWithParseHelpers(output);
 
       expect(command.callParsePositiveInt('  7  ', 'id')).toBe(7);
+    });
+  });
+
+  describe('truncateText', () => {
+    it('returns text unchanged when shorter than maxLength', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(command.callTruncateText('short', 10)).toBe('short');
+    });
+
+    it('truncates with ellipsis when text exceeds maxLength', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(command.callTruncateText('this is a longer string', 10)).toBe(
+        'this is...'
+      );
+    });
+
+    it('returns full text when noTruncate flag is set', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      const long = 'this is a longer string that would normally be cut';
+      expect(command.callTruncateText(long, 10, { noTruncate: true })).toBe(
+        long
+      );
+    });
+
+    it('truncates when noTruncate is explicitly false', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(
+        command.callTruncateText('this is a longer string', 10, {
+          noTruncate: false,
+        })
+      ).toBe('this is...');
+    });
+
+    it('treats missing options as truncating (default behavior)', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      expect(command.callTruncateText('this is a longer string', 10)).toBe(
+        'this is...'
+      );
+    });
+
+    it('accepts a GlobalOptions-shaped object so callers can pass context.globalOptions', () => {
+      const command = new TestCommandWithParseHelpers(output);
+
+      // Mimics passing context.globalOptions: extra fields are ignored.
+      const globalOptions = {
+        json: true,
+        workspace: 'ws',
+        noTruncate: true,
+      };
+      expect(
+        command.callTruncateText('this is a longer string', 10, globalOptions)
+      ).toBe('this is a longer string');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #227.

Adds a top-level `--no-truncate` flag plus a shared `BaseCommand.truncateText` helper so users can opt out of column truncation across the table-rendering commands without falling back to `--json`. The previously command-local `--no-truncate` on `bb pr comments list` is subsumed by the global flag.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Changes

- Add `--no-truncate` to the root `bb` command and propagate it as `globalOptions.noTruncate`.
- Add `BaseCommand.truncateText(text, max, opts)` that delegates to `IOutputService.truncate` and short-circuits when `noTruncate` is true.
- Wire commands that previously hard-coded truncation to honor the flag:
  - `bb pr list` (50)
  - `bb pr activity` (60/80)
  - `bb pr checks` (40)
  - `bb pr edit` (100)
  - `bb pr comments list` (60) — local `--no-truncate` removed
  - `bb repo list` (50, was a silent `substring`; now uses the shared truncate helper so users see the ellipsis)
  - `bb snippet comments list` (60)
- Add `--no-truncate` to the tab-completion list.
- Tests: BaseCommand helper unit tests + per-command tests confirming default truncation and the flag's pass-through behavior.

## Testing

- [x] `bun test` passes (964 tests)
- [x] `bun run lint` passes
- [x] `bun run format:check` passes (verified via pre-commit hook)

## Changeset

- [x] I ran `bun run changeset` and committed the file (`.changeset/global-no-truncate-flag.md`, minor)

## Checklist

- [x] Branch is named `0pilatos0/no-truncate-flag` (account-prefixed convention used in this repo)
- [x] No edits to `src/generated/`
- [x] Output uses `IOutputService` (no `console.*`)
- [x] Expected failures use `BBError` / `ErrorCode`
- [ ] Docs updated if user-facing behavior changed — _not updated; the docs site auto-derives flag listings from CLI help, but if a manual entry exists for `--no-truncate` it should be expanded to mention this is now global._