### PR TITLE
feat: add spinner progress indicators for long-running operations

### DIFF
--- a/.changeset/spinner-progress-indicators.md
+++ b/.changeset/spinner-progress-indicators.md
@@ -1,0 +1,31 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add a spinner progress indicator for long-running operations.
+
+`IOutputService` now exposes a `spinner(text)` factory returning an
+`ISpinner` handle (`start` / `stop` / `succeed` / `fail` / `setText`). The
+spinner auto-disables in JSON mode (would corrupt machine-readable output),
+non-TTY streams (pipes, redirects, CI), and tests — every method is a safe
+no-op there, so callers can instrument commands without branching on the
+runtime environment.
+
+`OutputService` tracks the active spinner and stops it before any other
+write (`success`, `error`, `warning`, `info`, `text`, `table`, `json`,
+`jsonError`), so a forgotten spinner can never interleave with regular
+output. Two concurrent spinners cannot fight over the same line either —
+creating a new spinner stops the previous one.
+
+Instrumented the high-priority long-running commands listed in the
+proposal:
+
+- `bb pr create` — "Creating pull request..."
+- `bb pr merge` — "Merging pull request #{id}..."
+- `bb repo clone` — "Cloning {repo}..."
+
+Implementation is dependency-free (no `ora`); the `Spinner` class lives in
+`src/services/spinner.ts` and renders 10-frame braille animation with
+ANSI cursor hide/show and line-clear sequences. Cursor restore is wired
+to `SIGINT`, `SIGTERM`, and `exit` so an interrupted CLI doesn't leave
+the cursor hidden.

--- a/src/commands/pr/create.command.ts
+++ b/src/commands/pr/create.command.ts
@@ -114,14 +114,21 @@ export class CreatePRCommand extends BaseCommand<CreatePROptions, void> {
       );
     }
 
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPost({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pullrequest: request,
-      });
-
-    const pr = response.data;
+    const spinner = this.output.spinner('Creating pull request...').start();
+    let pr;
+    try {
+      const response =
+        await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPost(
+          {
+            workspace: repoContext.workspace,
+            repoSlug: repoContext.repoSlug,
+            pullrequest: request,
+          }
+        );
+      pr = response.data;
+    } finally {
+      spinner.stop();
+    }
     const links = pr.links as { html?: { href?: string } } | undefined;
 
     if (context.globalOptions.json) {

--- a/src/commands/pr/merge.command.ts
+++ b/src/commands/pr/merge.command.ts
@@ -75,17 +75,24 @@ export class MergePRCommand extends BaseCommand<
       );
     }
 
-    const response =
-      await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdMergePost(
-        {
-          workspace: repoContext.workspace,
-          repoSlug: repoContext.repoSlug,
-          pullRequestId: prId,
-          pullrequestMergeParameters: request,
-        }
-      );
-
-    const pr = response.data;
+    const spinner = this.output
+      .spinner(`Merging pull request #${prId}...`)
+      .start();
+    let pr;
+    try {
+      const response =
+        await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdMergePost(
+          {
+            workspace: repoContext.workspace,
+            repoSlug: repoContext.repoSlug,
+            pullRequestId: prId,
+            pullrequestMergeParameters: request,
+          }
+        );
+      pr = response.data;
+    } finally {
+      spinner.stop();
+    }
 
     if (context.globalOptions.json) {
       await this.output.json({

--- a/src/commands/repo/clone.command.ts
+++ b/src/commands/repo/clone.command.ts
@@ -37,7 +37,12 @@ export class CloneCommand extends BaseCommand<
     const { repository, directory } = options;
 
     const repoUrl = await this.resolveRepositoryUrl(repository);
-    await this.gitService.clone(repoUrl, directory);
+    const spinner = this.output.spinner(`Cloning ${repository}...`).start();
+    try {
+      await this.gitService.clone(repoUrl, directory);
+    } finally {
+      spinner.stop();
+    }
 
     const targetDir = directory || this.extractRepoName(repository);
 

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -28,6 +28,7 @@ export abstract class BaseCommand<
     context: CommandContext
   ): Promise<TResult> {
     this.output.setJsonFormatOptions({
+      json: !!context.globalOptions.json,
       fields: context.globalOptions.jsonFields,
       jq: context.globalOptions.jq,
     });

--- a/src/core/interfaces/services.ts
+++ b/src/core/interfaces/services.ts
@@ -119,8 +119,36 @@ export interface ISnippetFilesService {
  * Pushed by BaseCommand.run() from CommandContext.globalOptions.
  */
 export interface JsonFormatOptions {
+  /**
+   * Whether the active command was invoked with `--json`. Drives the spinner
+   * suppression logic — animations on stdout would corrupt JSON output.
+   */
+  json?: boolean;
   fields?: string[];
   jq?: string;
+}
+
+/**
+ * Animated progress indicator handle returned by `IOutputService.spinner()`.
+ *
+ * Implementations must auto-disable in environments that cannot animate
+ * cleanly (non-TTY streams, JSON mode, tests). Disabled spinners turn every
+ * method into a safe no-op, so callers can instrument commands without
+ * branching on the runtime environment.
+ *
+ * Methods return `this` to support fluent calls.
+ */
+export interface ISpinner {
+  /** Begin the animation. Idempotent. */
+  start(): ISpinner;
+  /** Stop the animation and restore the cursor. Idempotent. */
+  stop(): ISpinner;
+  /** Stop the animation; print an optional success line if enabled. */
+  succeed(message?: string): ISpinner;
+  /** Stop the animation; print an optional failure line if enabled. */
+  fail(message?: string): ISpinner;
+  /** Update the text shown next to the spinner. */
+  setText(text: string): ISpinner;
 }
 
 /**
@@ -130,6 +158,12 @@ export interface IOutputService {
   json(data: unknown): Promise<void>;
   jsonError(data: unknown): void;
   setJsonFormatOptions(options: JsonFormatOptions): void;
+  /**
+   * Create a progress spinner with the given initial text. Returns a handle
+   * the caller is responsible for stopping. Implementations must auto-disable
+   * the animation in JSON mode, non-TTY streams, and tests.
+   */
+  spinner(text: string): ISpinner;
   table(headers: string[], rows: string[][]): void;
   success(message: string): void;
   error(message: string): void;

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -5,10 +5,12 @@
 import chalk from 'chalk';
 import type {
   IOutputService,
+  ISpinner,
   JsonFormatOptions,
 } from '../core/interfaces/services.js';
 import { BBError, ErrorCode } from '../types/errors.js';
 import { projectFields } from './output.project.js';
+import { Spinner, createNoopSpinner } from './spinner.js';
 
 // Strip dangerous terminal control sequences from text before printing so
 // attacker-controlled API data (PR titles, descriptions, branch names,
@@ -49,6 +51,7 @@ const WRAPPER_ARRAY_KEYS: readonly string[] = [
 export class OutputService implements IOutputService {
   private readonly noColor: boolean;
   private jsonFormatOptions: JsonFormatOptions = {};
+  private activeSpinner: ISpinner | null = null;
 
   constructor(options?: { noColor?: boolean }) {
     this.noColor = options?.noColor ?? false;
@@ -58,7 +61,41 @@ export class OutputService implements IOutputService {
     this.jsonFormatOptions = { ...options };
   }
 
+  public spinner(text: string): ISpinner {
+    // Disabled in JSON mode (would corrupt stdout), non-TTY streams (no point
+    // animating into a pipe), and tests (deterministic output, no escape
+    // sequences leaking into snapshots). The disabled path returns a real
+    // Spinner with `enabled: false` so callers see a uniform handle.
+    const enabled =
+      !this.jsonFormatOptions.json &&
+      !!process.stdout.isTTY &&
+      process.env.NODE_ENV !== 'test';
+
+    if (!enabled) {
+      return createNoopSpinner();
+    }
+
+    // Stop any prior spinner so two concurrent animations don't fight over
+    // the same line. Commands that nest spinners are responsible for ordering;
+    // this guard simply prevents corruption.
+    this.activeSpinner?.stop();
+
+    const spinner: ISpinner = new Spinner(text, {
+      enabled: true,
+      noColor: this.noColor,
+      stream: process.stdout,
+      onStop: () => {
+        if (this.activeSpinner === spinner) {
+          this.activeSpinner = null;
+        }
+      },
+    });
+    this.activeSpinner = spinner;
+    return spinner;
+  }
+
   public async json(data: unknown): Promise<void> {
+    this.stopActiveSpinner();
     const { fields, jq } = this.jsonFormatOptions;
 
     let result: unknown = data;
@@ -84,10 +121,12 @@ export class OutputService implements IOutputService {
   }
 
   public jsonError(data: unknown): void {
+    this.stopActiveSpinner();
     console.error(JSON.stringify(data));
   }
 
   public table(headers: string[], rows: string[][]): void {
+    this.stopActiveSpinner();
     if (rows.length === 0) {
       return;
     }
@@ -125,27 +164,45 @@ export class OutputService implements IOutputService {
   }
 
   public success(message: string): void {
+    this.stopActiveSpinner();
     const symbol = this.format('✓', chalk.green);
     console.log(`${symbol} ${stripControl(message)}`);
   }
 
   public error(message: string): void {
+    this.stopActiveSpinner();
     const symbol = this.format('✗', chalk.red);
     console.error(`${symbol} ${stripControl(message)}`);
   }
 
   public warning(message: string): void {
+    this.stopActiveSpinner();
     const symbol = this.format('⚠', chalk.yellow);
     console.warn(`${symbol} ${stripControl(message)}`);
   }
 
   public info(message: string): void {
+    this.stopActiveSpinner();
     const symbol = this.format('ℹ', chalk.blue);
     console.log(`${symbol} ${stripControl(message)}`);
   }
 
   public text(message: string): void {
+    this.stopActiveSpinner();
     console.log(stripControl(message));
+  }
+
+  /**
+   * Stop and forget the currently active spinner, if any. Called by every
+   * write-emitting method so a forgotten spinner can never interleave with
+   * regular output. Safe to call when no spinner is active.
+   */
+  private stopActiveSpinner(): void {
+    if (this.activeSpinner) {
+      const spinner = this.activeSpinner;
+      this.activeSpinner = null;
+      spinner.stop();
+    }
   }
 
   public truncate(text: string, maxLength: number, suffix = '...'): string {

--- a/src/services/spinner.ts
+++ b/src/services/spinner.ts
@@ -1,0 +1,165 @@
+/**
+ * Lightweight terminal spinner for long-running operations.
+ *
+ * Auto-disables when output cannot animate cleanly: non-TTY streams (pipes,
+ * redirects, CI), `--json` mode (would corrupt machine-readable output), and
+ * during tests. All public methods are safe no-ops in those modes so callers
+ * can instrument commands without branching on environment.
+ */
+
+import type { ISpinner } from '../core/interfaces/services.js';
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const FRAME_INTERVAL_MS = 80;
+
+const ESC = '\x1b';
+const CLEAR_LINE = `\r${ESC}[2K`;
+const HIDE_CURSOR = `${ESC}[?25l`;
+const SHOW_CURSOR = `${ESC}[?25h`;
+const COLOR_CYAN = `${ESC}[36m`;
+const COLOR_GREEN = `${ESC}[32m`;
+const COLOR_RED = `${ESC}[31m`;
+const COLOR_RESET = `${ESC}[0m`;
+
+export interface SpinnerOptions {
+  /** When false, every method is a no-op. */
+  enabled: boolean;
+  noColor: boolean;
+  stream: NodeJS.WriteStream;
+  /** Notifies the owner that the spinner has stopped (used to clear refs). */
+  onStop?: () => void;
+}
+
+export class Spinner implements ISpinner {
+  private text: string;
+  private readonly enabled: boolean;
+  private readonly noColor: boolean;
+  private readonly stream: NodeJS.WriteStream;
+  private onStop?: () => void;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private frameIndex = 0;
+  private active = false;
+  private exitHandler: (() => void) | null = null;
+
+  constructor(text: string, options: SpinnerOptions) {
+    this.text = text;
+    this.enabled = options.enabled;
+    this.noColor = options.noColor;
+    this.stream = options.stream;
+    this.onStop = options.onStop;
+  }
+
+  public start(): this {
+    if (!this.enabled || this.active) {
+      return this;
+    }
+    this.active = true;
+    this.stream.write(HIDE_CURSOR);
+    this.render();
+    this.timer = setInterval(() => {
+      this.frameIndex = (this.frameIndex + 1) % FRAMES.length;
+      this.render();
+    }, FRAME_INTERVAL_MS);
+    // Don't keep the event loop alive for the spinner alone.
+    this.timer.unref?.();
+
+    // Best-effort cursor restore if the process is interrupted while spinning.
+    this.exitHandler = () => {
+      if (this.active) {
+        this.active = false;
+        if (this.timer) {
+          clearInterval(this.timer);
+          this.timer = null;
+        }
+        this.stream.write(`${CLEAR_LINE}${SHOW_CURSOR}`);
+      }
+    };
+    process.once('SIGINT', this.exitHandler);
+    process.once('SIGTERM', this.exitHandler);
+    process.once('exit', this.exitHandler);
+    return this;
+  }
+
+  public stop(): this {
+    if (!this.active) {
+      return this.detach();
+    }
+    this.active = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.stream.write(`${CLEAR_LINE}${SHOW_CURSOR}`);
+    return this.detach();
+  }
+
+  public succeed(message?: string): this {
+    this.stop();
+    if (this.enabled && message) {
+      const symbol = this.colorize('✓', COLOR_GREEN);
+      this.stream.write(`${symbol} ${message}\n`);
+    }
+    return this;
+  }
+
+  public fail(message?: string): this {
+    this.stop();
+    if (this.enabled && message) {
+      const symbol = this.colorize('✗', COLOR_RED);
+      this.stream.write(`${symbol} ${message}\n`);
+    }
+    return this;
+  }
+
+  public setText(text: string): this {
+    this.text = text;
+    if (this.active) {
+      this.render();
+    }
+    return this;
+  }
+
+  private render(): void {
+    if (!this.active) return;
+    const frame = FRAMES[this.frameIndex] ?? FRAMES[0]!;
+    const symbol = this.colorize(frame, COLOR_CYAN);
+    this.stream.write(`${CLEAR_LINE}${symbol} ${this.text}`);
+  }
+
+  private colorize(text: string, color: string): string {
+    return this.noColor ? text : `${color}${text}${COLOR_RESET}`;
+  }
+
+  private detach(): this {
+    if (this.exitHandler) {
+      process.removeListener('SIGINT', this.exitHandler);
+      process.removeListener('SIGTERM', this.exitHandler);
+      process.removeListener('exit', this.exitHandler);
+      this.exitHandler = null;
+    }
+    if (this.onStop) {
+      const cb = this.onStop;
+      // Clear before invoking to keep onStop idempotent across repeated stop() calls.
+      this.onStop = undefined;
+      cb();
+    }
+    return this;
+  }
+}
+
+/**
+ * Create a no-op spinner. Useful as a default and for environments where
+ * animation is undesirable. All methods short-circuit and never write to the
+ * stream.
+ */
+export function createNoopSpinner(): ISpinner {
+  const noop: ISpinner = {
+    start: () => noop,
+    stop: () => noop,
+    succeed: () => noop,
+    fail: () => noop,
+    setText: () => noop,
+  };
+  return noop;
+}

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1392,6 +1392,7 @@ interface CreatePRHarnessOptions {
   authorUuid?: string;
   config?: Parameters<typeof createMockConfigService>[0];
   capturedBodyRef?: { body?: import('../../src/generated/api.js').Pullrequest };
+  createPRThrows?: boolean;
 }
 
 function buildCreatePRCommand(options: CreatePRHarnessOptions = {}): {
@@ -1422,6 +1423,9 @@ function buildCreatePRCommand(options: CreatePRHarnessOptions = {}): {
     params
   ) => {
     captured.body = params.pullrequest;
+    if (options.createPRThrows) {
+      throw new Error('PR creation failed');
+    }
     return originalPost(params);
   };
 
@@ -1660,6 +1664,38 @@ describe('CreatePRCommand', () => {
     ).toBe(true);
     expect(output.logs.some((log) => log.includes('success:'))).toBe(true);
   });
+
+  it('should run a spinner for the duration of the API call', async () => {
+    const { command, output } = buildCreatePRCommand();
+    await command.execute({ title: 'My PR' }, { globalOptions: {} });
+
+    const startIdx = output.logs.findIndex((log) =>
+      log.startsWith('spinner-start:Creating pull request')
+    );
+    const stopIdx = output.logs.findIndex((log) => log === 'spinner-stop');
+    const successIdx = output.logs.findIndex((log) =>
+      log.startsWith('success:')
+    );
+
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeGreaterThan(startIdx);
+    expect(successIdx).toBeGreaterThan(stopIdx);
+  });
+
+  it('should stop the spinner even when the API call fails', async () => {
+    const { command, output } = buildCreatePRCommand({
+      createPRThrows: true,
+    });
+
+    await expect(
+      command.execute({ title: 'My PR' }, { globalOptions: {} })
+    ).rejects.toThrow();
+
+    expect(output.logs.some((log) => log.startsWith('spinner-start:'))).toBe(
+      true
+    );
+    expect(output.logs.some((log) => log === 'spinner-stop')).toBe(true);
+  });
 });
 
 describe('MergePRCommand', () => {
@@ -1738,6 +1774,25 @@ describe('MergePRCommand', () => {
     await expect(
       command.execute({ id: 'abc' }, { globalOptions: {} })
     ).rejects.toThrow(/--id must be a positive integer/);
+  });
+
+  it('should run a spinner labeled with the PR id', async () => {
+    const pullrequestsApi = createMockPullrequestsApi();
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new MergePRCommand(pullrequestsApi, contextService, output);
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('spinner-start:Merging pull request #1')
+      )
+    ).toBe(true);
+    expect(output.logs.some((log) => log === 'spinner-stop')).toBe(true);
   });
 });
 

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -618,4 +618,44 @@ describe('CloneCommand', () => {
       command.execute({ repository: 'myrepo' }, { globalOptions: {} })
     ).rejects.toThrow();
   });
+
+  it('should run a spinner around the git clone call', async () => {
+    const gitService = createMockGitService();
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new CloneCommand(gitService, contextService, output);
+    await command.execute(
+      { repository: 'workspace/repo' },
+      { globalOptions: {} }
+    );
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('spinner-start:Cloning workspace/repo')
+      )
+    ).toBe(true);
+    expect(output.logs.some((log) => log === 'spinner-stop')).toBe(true);
+  });
+
+  it('should stop the spinner when the git clone call fails', async () => {
+    const gitService = createMockGitService();
+    gitService.clone = async () => {
+      throw new Error('clone failed');
+    };
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new CloneCommand(gitService, contextService, output);
+    await expect(
+      command.execute({ repository: 'workspace/repo' }, { globalOptions: {} })
+    ).rejects.toThrow('clone failed');
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('spinner-start:Cloning workspace/repo')
+      )
+    ).toBe(true);
+    expect(output.logs.some((log) => log === 'spinner-stop')).toBe(true);
+  });
 });

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -383,10 +383,15 @@ describe('BaseCommand', () => {
     });
 
     it('should push and clear json format options around execute()', async () => {
-      const calls: Array<{ fields?: string[]; jq?: string }> = [];
+      const calls: Array<{ json?: boolean; fields?: string[]; jq?: string }> =
+        [];
       const spyOutput = {
         ...output,
-        setJsonFormatOptions(opts: { fields?: string[]; jq?: string }) {
+        setJsonFormatOptions(opts: {
+          json?: boolean;
+          fields?: string[];
+          jq?: string;
+        }) {
           calls.push({ ...opts });
         },
       };
@@ -404,14 +409,22 @@ describe('BaseCommand', () => {
       );
 
       // First call sets the options, finally{} resets to {}.
-      expect(calls).toEqual([{ fields: ['id', 'title'], jq: '.[] | .id' }, {}]);
+      expect(calls).toEqual([
+        { json: true, fields: ['id', 'title'], jq: '.[] | .id' },
+        {},
+      ]);
     });
 
     it('should reset json format options even when execute throws', async () => {
-      const calls: Array<{ fields?: string[]; jq?: string }> = [];
+      const calls: Array<{ json?: boolean; fields?: string[]; jq?: string }> =
+        [];
       const spyOutput = {
         ...output,
-        setJsonFormatOptions(opts: { fields?: string[]; jq?: string }) {
+        setJsonFormatOptions(opts: {
+          json?: boolean;
+          fields?: string[];
+          jq?: string;
+        }) {
           calls.push({ ...opts });
         },
       };
@@ -421,7 +434,10 @@ describe('BaseCommand', () => {
         command.run({}, { globalOptions: { json: true, jsonFields: ['id'] } })
       ).rejects.toThrow('Test error');
 
-      expect(calls).toEqual([{ fields: ['id'], jq: undefined }, {}]);
+      expect(calls).toEqual([
+        { json: true, fields: ['id'], jq: undefined },
+        {},
+      ]);
     });
   });
 

--- a/tests/services/spinner.test.ts
+++ b/tests/services/spinner.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Spinner unit tests.
+ *
+ * Cover the standalone Spinner class plus its integration into OutputService:
+ * enabled/disabled gating (TTY, JSON mode, NODE_ENV=test), animation lifecycle,
+ * idempotent stop semantics, color output, and the auto-stop behavior that
+ * prevents a forgotten spinner from interleaving with regular output.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Spinner, createNoopSpinner } from '../../src/services/spinner.js';
+import { OutputService } from '../../src/services/output.service.js';
+
+class FakeStream {
+  public chunks: string[] = [];
+  public isTTY = true;
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    return true;
+  }
+
+  joined(): string {
+    return this.chunks.join('');
+  }
+
+  reset(): void {
+    this.chunks = [];
+  }
+}
+
+function makeSpinner(
+  text: string,
+  overrides: Partial<{ enabled: boolean; noColor: boolean }> = {}
+): { spinner: Spinner; stream: FakeStream } {
+  const stream = new FakeStream();
+  const spinner = new Spinner(text, {
+    enabled: overrides.enabled ?? true,
+    noColor: overrides.noColor ?? false,
+    stream: stream as unknown as NodeJS.WriteStream,
+  });
+  return { spinner, stream };
+}
+
+describe('Spinner', () => {
+  describe('disabled mode', () => {
+    it('writes nothing when start/stop/succeed/fail/setText are called', () => {
+      const { spinner, stream } = makeSpinner('working', { enabled: false });
+
+      spinner.start();
+      spinner.setText('still working');
+      spinner.succeed('done');
+      spinner.fail('nope');
+      spinner.stop();
+
+      expect(stream.chunks).toEqual([]);
+    });
+
+    it('returns the spinner from every method (fluent)', () => {
+      const { spinner } = makeSpinner('working', { enabled: false });
+
+      expect(spinner.start()).toBe(spinner);
+      expect(spinner.setText('x')).toBe(spinner);
+      expect(spinner.succeed('y')).toBe(spinner);
+      expect(spinner.fail('z')).toBe(spinner);
+      expect(spinner.stop()).toBe(spinner);
+    });
+  });
+
+  describe('enabled mode', () => {
+    it('hides the cursor and renders the first frame on start', () => {
+      const { spinner, stream } = makeSpinner('loading', { noColor: true });
+
+      spinner.start();
+      const output = stream.joined();
+      expect(output).toContain('\x1b[?25l'); // hide cursor
+      expect(output).toContain('loading');
+
+      spinner.stop();
+    });
+
+    it('clears the line and shows the cursor on stop', () => {
+      const { spinner, stream } = makeSpinner('loading', { noColor: true });
+      spinner.start();
+      stream.reset();
+
+      spinner.stop();
+
+      const output = stream.joined();
+      expect(output).toContain('\r\x1b[2K'); // clear line
+      expect(output).toContain('\x1b[?25h'); // show cursor
+    });
+
+    it('is idempotent on repeated stop calls', () => {
+      const { spinner, stream } = makeSpinner('loading');
+
+      spinner.start();
+      stream.reset();
+      spinner.stop();
+      const afterFirstStop = stream.chunks.length;
+      spinner.stop();
+      spinner.stop();
+
+      expect(stream.chunks.length).toBe(afterFirstStop);
+    });
+
+    it('does nothing on a second start call', () => {
+      const { spinner, stream } = makeSpinner('loading');
+
+      spinner.start();
+      const sizeAfterFirstStart = stream.chunks.length;
+      spinner.start();
+
+      expect(stream.chunks.length).toBe(sizeAfterFirstStart);
+      spinner.stop();
+    });
+
+    it('emits an updated frame when setText is called while active', () => {
+      const { spinner, stream } = makeSpinner('initial', { noColor: true });
+
+      spinner.start();
+      stream.reset();
+      spinner.setText('updated');
+
+      expect(stream.joined()).toContain('updated');
+      spinner.stop();
+    });
+
+    it('does not emit when setText is called before start', () => {
+      const { spinner, stream } = makeSpinner('initial', { noColor: true });
+
+      spinner.setText('updated');
+
+      expect(stream.chunks).toEqual([]);
+    });
+
+    it('writes a green check on succeed when message is provided', () => {
+      const { spinner, stream } = makeSpinner('working', { noColor: false });
+      spinner.start();
+      stream.reset();
+
+      spinner.succeed('all done');
+
+      const output = stream.joined();
+      expect(output).toContain('\x1b[32m'); // green
+      expect(output).toContain('✓');
+      expect(output).toContain('all done\n');
+    });
+
+    it('writes a plain check on succeed when noColor is true', () => {
+      const { spinner, stream } = makeSpinner('working', { noColor: true });
+      spinner.start();
+      stream.reset();
+
+      spinner.succeed('all done');
+
+      const output = stream.joined();
+      expect(output).not.toContain('\x1b[32m');
+      expect(output).toContain('✓ all done\n');
+    });
+
+    it('writes only the cleanup sequences on succeed without message', () => {
+      const { spinner, stream } = makeSpinner('working', { noColor: true });
+      spinner.start();
+      stream.reset();
+
+      spinner.succeed();
+
+      // No success line — just the line-clear / cursor-restore from stop().
+      const output = stream.joined();
+      expect(output).not.toContain('✓');
+      expect(output).toContain('\r\x1b[2K');
+      expect(output).toContain('\x1b[?25h');
+    });
+
+    it('writes a red cross on fail when message is provided', () => {
+      const { spinner, stream } = makeSpinner('working', { noColor: false });
+      spinner.start();
+      stream.reset();
+
+      spinner.fail('boom');
+
+      const output = stream.joined();
+      expect(output).toContain('\x1b[31m'); // red
+      expect(output).toContain('✗');
+      expect(output).toContain('boom\n');
+    });
+
+    it('invokes onStop exactly once across repeated stop/succeed calls', () => {
+      const stream = new FakeStream();
+      let callCount = 0;
+      const spinner = new Spinner('working', {
+        enabled: true,
+        noColor: true,
+        stream: stream as unknown as NodeJS.WriteStream,
+        onStop: () => {
+          callCount += 1;
+        },
+      });
+
+      spinner.start();
+      spinner.stop();
+      spinner.succeed('done');
+      spinner.fail('boom');
+
+      expect(callCount).toBe(1);
+    });
+  });
+});
+
+describe('createNoopSpinner', () => {
+  it('returns a chainable handle whose methods are no-ops', () => {
+    const noop = createNoopSpinner();
+
+    expect(noop.start()).toBe(noop);
+    expect(noop.setText('x')).toBe(noop);
+    expect(noop.succeed('y')).toBe(noop);
+    expect(noop.fail('z')).toBe(noop);
+    expect(noop.stop()).toBe(noop);
+  });
+});
+
+describe('OutputService.spinner gating', () => {
+  let originalIsTTY: boolean | undefined;
+  let originalNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY;
+    originalNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('returns a no-op spinner when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test';
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    const output = new OutputService();
+
+    const spinner = output.spinner('hello');
+    spinner.start().setText('updated').succeed('done').fail('boom').stop();
+
+    // The no-op spinner does not write. Calling any method in any order
+    // must not throw — that is the contract.
+    expect(typeof spinner.start).toBe('function');
+  });
+
+  it('returns a no-op spinner when stdout is not a TTY', () => {
+    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    const output = new OutputService();
+
+    const spinner = output.spinner('hello');
+    spinner.start().stop();
+    expect(typeof spinner.start).toBe('function');
+  });
+
+  it('returns a no-op spinner when JSON mode is active', () => {
+    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    const output = new OutputService();
+    output.setJsonFormatOptions({ json: true });
+
+    const spinner = output.spinner('hello');
+    spinner.start().succeed('done').stop();
+    expect(typeof spinner.start).toBe('function');
+  });
+});
+
+describe('OutputService.spinner enabled path', () => {
+  // To exercise the real Spinner via OutputService we need NODE_ENV != 'test'
+  // and stdout.isTTY = true. Restore both after each test.
+
+  let originalIsTTY: boolean | undefined;
+  let originalNodeEnv: string | undefined;
+  let originalWrite: typeof process.stdout.write;
+  let writes: string[];
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let logs: string[];
+
+  beforeEach(() => {
+    originalIsTTY = process.stdout.isTTY;
+    originalNodeEnv = process.env.NODE_ENV;
+    originalWrite = process.stdout.write.bind(process.stdout);
+    originalLog = console.log;
+    originalError = console.error;
+    writes = [];
+    logs = [];
+
+    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    process.stdout.write = ((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    console.log = (...args: unknown[]) => {
+      logs.push(`log:${args.map(String).join(' ')}`);
+    };
+    console.error = (...args: unknown[]) => {
+      logs.push(`err:${args.map(String).join(' ')}`);
+    };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  it('returns a real Spinner that writes animation frames', () => {
+    const output = new OutputService();
+    const spinner = output.spinner('working');
+
+    spinner.start();
+    spinner.stop();
+
+    const out = writes.join('');
+    expect(out).toContain('\x1b[?25l'); // hide cursor
+    expect(out).toContain('working');
+    expect(out).toContain('\x1b[?25h'); // show cursor
+  });
+
+  it('auto-stops the active spinner before printing success()', () => {
+    const output = new OutputService();
+    const spinner = output.spinner('working');
+
+    spinner.start();
+    writes.length = 0;
+
+    output.success('done');
+
+    // Stop chunk emitted before console.log success line.
+    expect(writes.some((w) => w.includes('\x1b[?25h'))).toBe(true);
+    expect(logs.some((l) => l.startsWith('log:') && l.includes('done'))).toBe(
+      true
+    );
+  });
+
+  it('auto-stops the active spinner before printing error()', () => {
+    const output = new OutputService();
+    const spinner = output.spinner('working');
+
+    spinner.start();
+    writes.length = 0;
+
+    output.error('something broke');
+
+    expect(writes.some((w) => w.includes('\x1b[?25h'))).toBe(true);
+    expect(
+      logs.some((l) => l.startsWith('err:') && l.includes('something broke'))
+    ).toBe(true);
+  });
+
+  it('auto-stops the active spinner before printing JSON', async () => {
+    const output = new OutputService();
+    const spinner = output.spinner('working');
+
+    spinner.start();
+    writes.length = 0;
+
+    await output.json({ ok: true });
+
+    expect(writes.some((w) => w.includes('\x1b[?25h'))).toBe(true);
+    expect(logs.some((l) => l.startsWith('log:') && l.includes('"ok"'))).toBe(
+      true
+    );
+  });
+
+  it('replaces the active spinner when a second one is requested', () => {
+    const output = new OutputService();
+    const first = output.spinner('first');
+    first.start();
+    writes.length = 0;
+
+    const second = output.spinner('second');
+    second.start();
+
+    // The first spinner should have been stopped (cursor restore emitted)
+    // before the second one starts (cursor hide emitted again).
+    const out = writes.join('');
+    expect(out).toContain('\x1b[?25h'); // first stopped
+    expect(out).toContain('\x1b[?25l'); // second started
+    expect(out).toContain('second');
+
+    second.stop();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,6 +11,7 @@ import type {
   IGitService,
   IContextService,
   IOutputService,
+  ISpinner,
 } from '../src/core/interfaces/services.js';
 import type { BBError } from '../src/types/errors.js';
 import type {
@@ -273,6 +274,35 @@ export function createMockOutputService(): IOutputService & { logs: string[] } {
     },
     setJsonFormatOptions() {
       // No-op in tests; commands log raw payloads via `json:` prefix.
+    },
+    spinner(text: string) {
+      // Records lifecycle events but never animates. Tests can assert on the
+      // captured prefixes (`spinner-start:`, `spinner-stop:`,
+      // `spinner-succeed:`, `spinner-fail:`, `spinner-text:`).
+      const spinner: ISpinner = {
+        start() {
+          logs.push(`spinner-start:${text}`);
+          return spinner;
+        },
+        stop() {
+          logs.push('spinner-stop');
+          return spinner;
+        },
+        succeed(message?: string) {
+          logs.push(`spinner-succeed:${message ?? ''}`);
+          return spinner;
+        },
+        fail(message?: string) {
+          logs.push(`spinner-fail:${message ?? ''}`);
+          return spinner;
+        },
+        setText(next: string) {
+          text = next;
+          logs.push(`spinner-text:${next}`);
+          return spinner;
+        },
+      };
+      return spinner;
     },
     table(headers: string[], rows: string[][]) {
       logs.push(`table:${headers.join(',')}`);


### PR DESCRIPTION
Closes #225.

## Summary

- Add `spinner(text)` to `IOutputService`, returning an `ISpinner` handle (`start` / `stop` / `succeed` / `fail` / `setText`). Dependency-free implementation lives in `src/services/spinner.ts` (10-frame braille animation, ANSI cursor hide/show, line-clear).
- Auto-disable in JSON mode (would corrupt machine-readable output), non-TTY streams (pipes, redirects, CI), and tests — every method is a safe no-op there, so commands don't branch on environment.
- `OutputService` tracks the active spinner and stops it before any write method (`success`, `error`, `warning`, `info`, `text`, `table`, `json`, `jsonError`). A forgotten spinner can never interleave with regular output, and two concurrent spinners cannot fight over the same line.
- `SIGINT` / `SIGTERM` / `exit` handlers restore the cursor on interruption.
- Instrument the High-priority commands listed in the issue: `bb pr create`, `bb pr merge`, `bb repo clone`. Medium/Low priority commands intentionally deferred to a follow-up PR to keep this one reviewable.

## Why dependency-free instead of `ora`?

- The project ships with only six runtime deps and stripping control characters is already a security concern in `OutputService`. A homegrown spinner under 150 LoC keeps the dep audit surface unchanged and gives full control over JSON-mode / TTY / no-color / test behavior. `ora` would have worked too — the issue explicitly allowed either path.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun test` — 975 pass / 0 fail (29 new tests added)
- [x] New `tests/services/spinner.test.ts` covers: disabled mode is silent; enabled mode hides/shows cursor, idempotent stop, fluent API, succeed/fail with and without messages, `onStop` invoked exactly once, `setText` re-renders only when active.
- [x] `OutputService` gating tests: NODE_ENV=test → no-op, non-TTY → no-op, JSON mode → no-op.
- [x] `OutputService` enabled-path tests (with mocked `process.stdout`): emits animation, auto-stops before `success` / `error` / `json`, replaces prior spinner on a second `spinner()` call.
- [x] Per-command tests verify the spinner lifecycle:
  - `pr create`: spinner starts → stops → success line, in that order; spinner stops on API error
  - `pr merge`: spinner text contains the PR id
  - `repo clone`: spinner text contains the repo; stops cleanly on git failure
- [x] Manual: `bb pr list --json` (and any `--json` invocation) produces valid JSON with no spinner interleaving — verified by the auto-disable contract.
- [x] Changeset added (`.changeset/spinner-progress-indicators.md`, minor bump).