### PR TITLE
fix: collapse newlines/CR/tabs in table cells to keep rows on one line

### DIFF
--- a/.changeset/fix-table-newline-layout.md
+++ b/.changeset/fix-table-newline-layout.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix table output breaking when a cell value contains a newline, carriage return, or tab (e.g. a repository description with a line break). Such whitespace control characters are now collapsed to a single space within table cells so every row stays on one line and columns stay aligned. Multi-line `text()` output is unaffected.

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -152,9 +152,16 @@ export class OutputService implements IOutputService {
       return;
     }
 
-    const sanitizedHeaders = headers.map(stripControl);
+    // stripControl intentionally preserves \n/\r/\t (text() relies on them for
+    // multi-line output), but inside a table cell those characters break the
+    // single-line-per-row layout and corrupt column-width math. Collapse any
+    // run of them to a single space so each row stays on one line.
+    const sanitizeCell = (cell: string): string =>
+      stripControl(cell).replace(/[\t\n\r]+/g, ' ');
+
+    const sanitizedHeaders = headers.map(sanitizeCell);
     const sanitizedRows = rows.map((row) =>
-      row.map((cell) => stripControl(cell || ''))
+      row.map((cell) => sanitizeCell(cell || ''))
     );
 
     // Calculate column widths

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -776,6 +776,42 @@ describe('OutputService', () => {
       expect(dataRow).toMatch(/^x\s+y\s*$/);
     });
 
+    it('table() neutralizes newlines/CR/tabs in cells so rows stay on one line', () => {
+      // Regression for issue #241: a repository description containing an
+      // embedded newline (real data returned by the Bitbucket API) breaks the
+      // table layout. stripControl() intentionally preserves \n/\r/\t for
+      // text(), but table() must collapse them — otherwise the tail of the
+      // cell drops to column 0 on the next visual line (the stray
+      // "To connec ..." fragment seen in the bug report) and column widths are
+      // computed from the wrong length.
+      output.table(
+        ['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'],
+        [
+          ['ws/repo-a', 'private', 'Various tools\nTo connect to the database'],
+          ['ws/repo-b', 'private', 'tab\tseparated\tdesc'],
+          ['ws/repo-c', 'private', 'carriage\r\nreturn'],
+        ]
+      );
+
+      // table() emits exactly one console.log per visual line: header,
+      // separator, then one line per row. No emitted line may contain an
+      // embedded whitespace control char, or it spans multiple terminal rows.
+      expect(consoleLogs).toHaveLength(5); // header + separator + 3 rows
+      for (const line of consoleLogs) {
+        expect(line).not.toContain('\n');
+        expect(line).not.toContain('\r');
+        expect(line).not.toContain('\t');
+      }
+
+      // The description tail must not start a new line at column 0.
+      expect(consoleLogs.some((line) => /^To connect/.test(line))).toBe(false);
+
+      // Visible words survive — only the control chars are removed/collapsed.
+      const printed = consoleLogs.join('\n');
+      expect(printed).toContain('Various tools');
+      expect(printed).toContain('To connect to the database');
+    });
+
     it('preserves chalk SGR codes embedded by callers', () => {
       // Callers commonly compose colored strings before handing them to
       // text() — e.g. `output.text(`${output.bold('#42')} ${pr.title}`)`.


### PR DESCRIPTION
## Summary

Fixes the table-rendering bug from #241: a repository description containing a newline (real data from the Bitbucket API) broke `bb repo list` output — the tail of the cell dropped to column 0 on the next terminal line (the stray `To connec ...` fragment in the report) and column widths were computed from the wrong length.

`stripControl` deliberately preserves `\n`/`\r`/`\t` so `text()` can emit legitimate multi-line output, but `table()` reused the same helper. `table()` now collapses any run of those whitespace control characters to a single space per cell — after `stripControl` — so every row stays on one line and columns stay aligned. `text()` behavior is unchanged.

This is data-driven, not platform-specific: it reproduces anywhere a cell contains one of these characters, not just on WSL/Windows.

## Changes

- `src/services/output.service.ts` — collapse `\n`/`\r`/`\t` to a single space in `table()` cells (headers and rows) before width calculation and printing.
- `tests/services/output.service.test.ts` — regression test asserting no emitted table line contains an embedded `\n`/`\r`/`\t`, and that visible text survives.
- `.changeset/fix-table-newline-layout.md` — patch bump.

## Verification

- `bun test tests/services/output.service.test.ts` → 94 pass, 0 fail
- `bun run lint` (tsc --noEmit) → clean
- Prettier check → passed

Closes #242
