### PR TITLE
feat: indicate truncated list output and add --all flag

### DIFF
--- a/.changeset/list-truncation-hint.md
+++ b/.changeset/list-truncation-hint.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+List commands now indicate when output was capped by `--limit` and add an `--all` flag to fetch every page. When more results exist than were shown, `repo list`, `pr list`, `pr activity`, `pr comments list`, `snippet list`, and `snippet comments list` print a dimmed footer such as `Showing 25 repositories. Use --limit <n> or --all to see more.` (suppressed in `--json` mode). Pass `--all` to retrieve all results regardless of `--limit`.

--- a/docs/src/content/docs/commands/pr/activity-and-checks.mdx
+++ b/docs/src/content/docs/commands/pr/activity-and-checks.mdx
@@ -28,6 +28,7 @@ bb pr activity <id> [options]
 | Option | Description |
 |--------|-------------|
 | `--limit <number>` | Maximum number of activity entries (default: 25) |
+| `--all` | Show all activity entries (overrides `--limit`) |
 | `--type <types>` | Filter by activity type (comma-separated): `comment`, `approval`, `changes_requested`, `merge`, `decline`, `commit`, `update` |
 | `-w, --workspace <workspace>` | Workspace |
 | `-r, --repo <repo>` | Repository |
@@ -45,6 +46,9 @@ bb pr activity 42 --type comment,approval
 # Limit results
 bb pr activity 42 --limit 10
 
+# Show the full activity history
+bb pr activity 42 --all
+
 # Get activity as JSON
 bb pr activity 42 --json
 ```
@@ -52,6 +56,7 @@ bb pr activity 42 --json
 ### Notes
 
 - `--limit` is enforced across paginated activity responses
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
 - Valid `--type` values: `comment`, `approval`, `changes_requested`, `merge`, `decline`, `commit`, `update`
 - Multiple types can be combined: `--type comment,approval`
 

--- a/docs/src/content/docs/commands/pr/comments.mdx
+++ b/docs/src/content/docs/commands/pr/comments.mdx
@@ -46,6 +46,7 @@ bb pr comments list <id>
 | `-w, --workspace <workspace>` | Workspace |
 | `-r, --repo <repo>` | Repository |
 | `--limit <number>` | Maximum number of comments (default: 25) |
+| `--all` | List all comments (overrides `--limit`) |
 | `--no-truncate` | Show full comment content without truncation |
 | `--json` | Output as JSON |
 
@@ -57,6 +58,9 @@ bb pr comments list 42
 
 # List more comments
 bb pr comments list 42 --limit 50
+
+# List every comment
+bb pr comments list 42 --all
 
 # Show full comment content (not truncated)
 bb pr comments list 42 --no-truncate
@@ -73,6 +77,7 @@ bb pr comments list 42 --json
 - By default, comment content is truncated to 60 characters in the table view
 - Use `--no-truncate` to display the full comment text
 - `--limit` is enforced across paginated comment responses
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
 
 ---
 

--- a/docs/src/content/docs/commands/pr/index.mdx
+++ b/docs/src/content/docs/commands/pr/index.mdx
@@ -62,6 +62,7 @@ Global options available on all PR commands: `--json [fields]`, `--jq <expressio
 | Create a PR | `bb pr create -t "Add feature"` |
 | Create a PR with the repo's default reviewers | `bb pr create -t "Add feature" --default-reviewers` |
 | List open PRs | `bb pr list` |
+| List all PRs (ignore the default limit) | `bb pr list --all` |
 | List PRs where you are a reviewer | `bb pr list --mine` |
 | View PR details | `bb pr view 42` |
 | View checks | `bb pr checks 42` |

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -97,6 +97,7 @@ bb repo list [options]
 |--------|-------------|
 | `-w, --workspace <workspace>` | Workspace to list repositories from |
 | `--limit <number>` | Maximum number of repositories (default: 25) |
+| `--all` | List all repositories (overrides `--limit`) |
 | `--json` | Output as JSON |
 
 ### Examples
@@ -107,6 +108,9 @@ bb repo list -w myworkspace
 
 # List more repositories
 bb repo list -w myworkspace --limit 50
+
+# List every repository in the workspace
+bb repo list -w myworkspace --all
 
 # List with JSON output for scripting
 bb repo list -w myworkspace --json
@@ -121,6 +125,7 @@ bb repo list -w myworkspace --json --jq '.repositories[] | select(.is_private ==
 ### Notes
 
 - `--limit` is enforced across paginated repository responses
+- When the result is capped by `--limit`, a hint is printed showing how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
 
 ---
 

--- a/docs/src/content/docs/commands/snippet.mdx
+++ b/docs/src/content/docs/commands/snippet.mdx
@@ -28,6 +28,7 @@ bb snippet list [options]
 | `-w, --workspace <workspace>` | Workspace |
 | `--role <role>` | Filter by authenticated user's role: `owner`, `contributor`, or `member` |
 | `--limit <number>` | Maximum number of snippets (default: 25) |
+| `--all` | List all snippets (overrides `--limit`) |
 | `--json` | Output as JSON |
 
 ### Examples
@@ -36,6 +37,7 @@ bb snippet list [options]
 bb snippet list
 bb snippet list --role owner
 bb snippet list --limit 50 --json
+bb snippet list --all
 
 # Project to specific fields (returns a flat array)
 bb snippet list --json id,title,is_private
@@ -47,6 +49,7 @@ bb snippet list --json --jq '.snippets[] | select(.is_private == false) | .title
 ### Notes
 
 - `--limit` is enforced across paginated responses.
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
 
 ---
 
@@ -220,12 +223,14 @@ bb snippet comments list <id> [options]
 |--------|-------------|
 | `-w, --workspace <workspace>` | Workspace |
 | `--limit <number>` | Maximum number of comments (default: 25) |
+| `--all` | List all comments (overrides `--limit`) |
 | `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
 bb snippet comments list kypj
+bb snippet comments list kypj --all
 bb snippet comments list kypj --limit 50 --json
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -574,12 +574,14 @@ repoCmd
   .command('list')
   .description('List repositories')
   .option('--limit <number>', 'Maximum number of repositories to list', '25')
+  .option('--all', 'List all repositories (overrides --limit)')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb repo list',
         'bb repo list --limit 50',
+        'bb repo list --all',
         'bb repo list --json',
       ],
       defaults: { limit: '25' },
@@ -795,6 +797,7 @@ prCmd
     'OPEN'
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
+  .option('--all', 'List all pull requests (overrides --limit)')
   .option(
     '--mine',
     'Show only PRs where you are a reviewer (not authored by you)'
@@ -805,6 +808,7 @@ prCmd
       examples: [
         'bb pr list',
         'bb pr list -s MERGED --limit 10',
+        'bb pr list --all',
         'bb pr list --mine',
         'bb pr list --json',
       ],
@@ -857,6 +861,7 @@ prCmd
   .command('activity <id>')
   .description('Show pull request activity log')
   .option('--limit <number>', 'Maximum number of activity entries', '25')
+  .option('--all', 'Show all activity entries (overrides --limit)')
   .option('--type <types>', 'Filter activity by type (comma-separated)')
   .addHelpText(
     'after',
@@ -864,6 +869,7 @@ prCmd
       examples: [
         'bb pr activity 42',
         'bb pr activity 42 --type comment,approval',
+        'bb pr activity 42 --all',
         'bb pr activity 42 --limit 10 --json',
       ],
       validValues: {
@@ -1108,12 +1114,14 @@ prCommentsCmd
   .command('list <id>')
   .description('List comments on a pull request')
   .option('--limit <number>', 'Maximum number of comments (default: 25)')
+  .option('--all', 'List all comments (overrides --limit)')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb pr comments list 42',
         'bb pr comments list 42 --no-truncate',
+        'bb pr comments list 42 --all',
         'bb pr comments list 42 --limit 50 --json',
       ],
       defaults: { limit: '25' },
@@ -1282,12 +1290,14 @@ snippetCmd
   .description('List snippets in a workspace')
   .option('--role <role>', 'Filter by role (owner, contributor, member)')
   .option('--limit <number>', 'Maximum number of snippets to list', '25')
+  .option('--all', 'List all snippets (overrides --limit)')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb snippet list',
         'bb snippet list --role owner',
+        'bb snippet list --all',
         'bb snippet list --limit 50 --json',
       ],
       validValues: {
@@ -1464,11 +1474,13 @@ snippetCommentsCmd
   .command('list <id>')
   .description('List comments on a snippet')
   .option('--limit <number>', 'Maximum number of comments', '25')
+  .option('--all', 'List all comments (overrides --limit)')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb snippet comments list kypj',
+        'bb snippet comments list kypj --all',
         'bb snippet comments list kypj --limit 50 --json',
       ],
       defaults: { limit: '25' },

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -9,7 +9,10 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 import {
   getRawContent,
   getUserDisplayName,
@@ -33,6 +36,7 @@ type ActivityType = (typeof VALID_ACTIVITY_TYPES)[number];
 
 export interface ActivityPROptions extends GlobalOptions {
   limit?: string;
+  all?: boolean;
   type?: string;
 }
 
@@ -62,36 +66,37 @@ export class ActivityPRCommand extends BaseCommand<
 
     const prId = this.parsePositiveInt(options.id, 'id');
     const filterTypes = this.parseTypeFilter(options.type);
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
 
-    const activities = await collectPages<PullrequestActivity>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response =
-          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
-            {
-              workspace: repoContext.workspace,
-              repoSlug: repoContext.repoSlug,
-              pullRequestId: prId,
-            },
-            {
-              params: { page, pagelen },
-            }
+    const { items: activities, hasMore } =
+      await collectPagesWithMeta<PullrequestActivity>({
+        limit,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+                pullRequestId: prId,
+              },
+              {
+                params: { page, pagelen },
+              }
+            );
+
+          // The generated API types say this returns void, but it actually returns paginated activity.
+          return parsePullrequestActivitiesPage(response.data);
+        },
+        shouldInclude: (activity) => {
+          if (filterTypes.length === 0) {
+            return true;
+          }
+
+          return (filterTypes as readonly string[]).includes(
+            this.getActivityType(activity)
           );
-
-        // The generated API types say this returns void, but it actually returns paginated activity.
-        return parsePullrequestActivitiesPage(response.data);
-      },
-      shouldInclude: (activity) => {
-        if (filterTypes.length === 0) {
-          return true;
-        }
-
-        return (filterTypes as readonly string[]).includes(
-          this.getActivityType(activity)
-        );
-      },
-    });
+        },
+      });
 
     if (context.globalOptions.json) {
       await this.output.json({
@@ -131,6 +136,7 @@ export class ActivityPRCommand extends BaseCommand<
     });
 
     this.output.table(['TYPE', 'ACTOR', 'DATE', 'DETAILS'], rows);
+    this.printMoreHint(activities.length, hasMore, 'activity entries');
   }
 
   private parseTypeFilter(typeOption?: string): ActivityType[] {

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -12,7 +12,10 @@ import type {
   PullrequestComment,
   PullrequestsApi,
 } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 import {
   getRawContent,
   getUserDisplayName,
@@ -21,6 +24,7 @@ import type { GlobalOptions } from '../../types/config.js';
 
 export interface ListCommentsPROptions extends GlobalOptions {
   limit?: string;
+  all?: boolean;
 }
 
 export class ListCommentsPRCommand extends BaseCommand<
@@ -48,26 +52,27 @@ export class ListCommentsPRCommand extends BaseCommand<
     );
 
     const prId = this.parsePositiveInt(options.id, 'id');
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
 
-    const values = await collectPages<PullrequestComment>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response =
-          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
-            {
-              workspace: repoContext.workspace,
-              repoSlug: repoContext.repoSlug,
-              pullRequestId: prId,
-            },
-            {
-              params: { page, pagelen },
-            }
-          );
+    const { items: values, hasMore } =
+      await collectPagesWithMeta<PullrequestComment>({
+        limit,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+                pullRequestId: prId,
+              },
+              {
+                params: { page, pagelen },
+              }
+            );
 
-        return response.data;
-      },
-    });
+          return response.data;
+        },
+      });
 
     if (context.globalOptions.json) {
       await this.output.json({
@@ -98,5 +103,6 @@ export class ListCommentsPRCommand extends BaseCommand<
     });
 
     this.output.table(['ID', 'Author', 'Content', 'Date'], rows);
+    this.printMoreHint(values.length, hasMore, 'comments');
   }
 }

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -13,13 +13,17 @@ import type {
   Pullrequest,
   UsersApi,
 } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { PR_STATES } from '../../types/pr.js';
 
 export interface ListPRsOptions extends GlobalOptions {
   state?: string;
   limit?: string;
+  all?: boolean;
   mine?: boolean;
 }
 
@@ -48,12 +52,12 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     const state = options.state
       ? this.parseEnumOption(options.state, 'state', PR_STATES)
       : 'OPEN';
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
     const reviewerQuery = options.mine
       ? await this.buildMineFilter()
       : undefined;
 
-    const values = await collectPages<Pullrequest>({
+    const { items: values, hasMore } = await collectPagesWithMeta<Pullrequest>({
       limit,
       fetchPage: async (page, pagelen) => {
         const response =
@@ -111,6 +115,7 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     });
 
     this.output.table(['ID', 'TITLE', 'AUTHOR', 'BRANCHES'], rows);
+    this.printMoreHint(values.length, hasMore, 'pull requests');
   }
 
   private async buildMineFilter(): Promise<string | undefined> {

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -9,11 +9,15 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi, Repository } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 
 export interface ListReposOptions {
   workspace?: string;
   limit?: string;
+  all?: boolean;
 }
 
 export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
@@ -35,9 +39,9 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
 
-    const repos = await collectPages<Repository>({
+    const { items: repos, hasMore } = await collectPagesWithMeta<Repository>({
       limit,
       fetchPage: async (page, pagelen) => {
         const response = await this.repositoriesApi.repositoriesWorkspaceGet(
@@ -74,5 +78,6 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     ]);
 
     this.output.table(['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'], rows);
+    this.printMoreHint(repos.length, hasMore, 'repositories');
   }
 }

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -9,7 +9,10 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 import {
   getRawContent,
   getUserDisplayName,
@@ -18,6 +21,7 @@ import {
 export interface ListSnippetCommentsOptions {
   workspace?: string;
   limit?: string;
+  all?: boolean;
 }
 
 export class ListSnippetCommentsCommand extends BaseCommand<
@@ -42,25 +46,26 @@ export class ListSnippetCommentsCommand extends BaseCommand<
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
 
-    const comments = await collectPages<SnippetComment>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response =
-          await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsGet(
-            {
-              workspace,
-              encodedId: options.id,
-            },
-            {
-              params: { page, pagelen },
-            }
-          );
+    const { items: comments, hasMore } =
+      await collectPagesWithMeta<SnippetComment>({
+        limit,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsGet(
+              {
+                workspace,
+                encodedId: options.id,
+              },
+              {
+                params: { page, pagelen },
+              }
+            );
 
-        return response.data;
-      },
-    });
+          return response.data;
+        },
+      });
 
     if (context.globalOptions.json) {
       await this.output.json({
@@ -88,5 +93,6 @@ export class ListSnippetCommentsCommand extends BaseCommand<
     });
 
     this.output.table(['ID', 'AUTHOR', 'DATE', 'CONTENT'], rows);
+    this.printMoreHint(comments.length, hasMore, 'comments');
   }
 }

--- a/src/commands/snippet/list.command.ts
+++ b/src/commands/snippet/list.command.ts
@@ -10,7 +10,10 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { Snippet, SnippetsApi } from '../../generated/api.js';
 import { SnippetsWorkspaceGetRoleEnum } from '../../generated/api.js';
-import { collectPages, parseLimit } from '../../services/pagination.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+} from '../../services/pagination.js';
 import { getUserDisplayName } from '../../services/response-parsers.js';
 
 const VALID_ROLES = Object.values(SnippetsWorkspaceGetRoleEnum) as readonly (
@@ -23,6 +26,7 @@ export interface ListSnippetsOptions {
   workspace?: string;
   role?: string;
   limit?: string;
+  all?: boolean;
 }
 
 export class ListSnippetsCommand extends BaseCommand<
@@ -47,13 +51,13 @@ export class ListSnippetsCommand extends BaseCommand<
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = parseLimit(options.limit);
+    const limit = resolveLimit(options);
 
     const role = options.role
       ? this.parseEnumOption(options.role, 'role', VALID_ROLES)
       : undefined;
 
-    const snippets = await collectPages<Snippet>({
+    const { items: snippets, hasMore } = await collectPagesWithMeta<Snippet>({
       limit,
       fetchPage: async (page, pagelen) => {
         const response = await this.snippetsApi.snippetsWorkspaceGet(
@@ -96,5 +100,6 @@ export class ListSnippetsCommand extends BaseCommand<
       ['ID', 'TITLE', 'VISIBILITY', 'CREATOR', 'UPDATED'],
       rows
     );
+    this.printMoreHint(snippets.length, hasMore, 'snippets');
   }
 }

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -183,6 +183,25 @@ export abstract class BaseCommand<
   }
 
   /**
+   * Print a dimmed footer after a list table when the output was capped by
+   * `--limit` and more results exist on the server. No-op when nothing was
+   * truncated. Callers omit this in JSON mode by returning before rendering
+   * the table (JSON payloads carry their own `count`).
+   */
+  protected printMoreHint(
+    shown: number,
+    hasMore: boolean,
+    noun = 'results'
+  ): void {
+    if (!hasMore) return;
+    this.output.text(
+      this.output.dim(
+        `Showing ${shown} ${noun}. Use --limit <n> or --all to see more.`
+      )
+    );
+  }
+
+  /**
    * Gate a destructive action on an explicit confirmation flag (typically
    * `--yes`). Throws a standard `BBError` so the warning and the
    * "Use --yes to confirm." instruction stay consistent across commands.

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -19,6 +19,17 @@ export interface CollectPagesOptions<T> {
 export const DEFAULT_LIMIT = 25;
 export const MAX_PAGE_LENGTH = 50;
 
+/**
+ * Result of {@link collectPagesWithMeta}: the collected items plus whether the
+ * collection was cut short by the limit (i.e. more results exist on the server
+ * than were returned). `hasMore` lets callers print a "use --limit/--all to see
+ * more" hint without a second request.
+ */
+export interface CollectPagesResult<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
 export function parseLimit(
   limit?: string,
   fallback: number = DEFAULT_LIMIT
@@ -38,16 +49,35 @@ export function parseLimit(
   return parsed;
 }
 
-export async function collectPages<T>(
+/**
+ * Resolve the effective item limit for a list command. `--all` requests every
+ * page (represented as `Infinity`); otherwise the `--limit` value is parsed,
+ * falling back to {@link DEFAULT_LIMIT}.
+ */
+export function resolveLimit(options: {
+  all?: boolean;
+  limit?: string;
+}): number {
+  return options.all ? Number.POSITIVE_INFINITY : parseLimit(options.limit);
+}
+
+/**
+ * Collect items across paginated pages, stopping at `limit`, and report whether
+ * more results remain on the server. Pass `limit = Infinity` to fetch every
+ * page (`--all`).
+ */
+export async function collectPagesWithMeta<T>(
   options: CollectPagesOptions<T>
-): Promise<T[]> {
+): Promise<CollectPagesResult<T>> {
   const { fetchPage, shouldInclude } = options;
   const limit = Math.max(0, options.limit);
 
   if (limit === 0) {
-    return [];
+    return { items: [], hasMore: false };
   }
 
+  // pageSize is unbounded for --all (Infinity); clamp to the API's max so each
+  // request stays valid while we loop until the server runs out of pages.
   const requestedPageSize = options.pageSize ?? limit;
   const pagelen = Math.max(1, Math.min(requestedPageSize, MAX_PAGE_LENGTH));
 
@@ -62,14 +92,20 @@ export async function collectPages<T>(
       break;
     }
 
-    for (const value of pageValues) {
+    for (let i = 0; i < pageValues.length; i += 1) {
+      const value = pageValues[i]!;
       if (shouldInclude && !shouldInclude(value)) {
         continue;
       }
 
       items.push(value);
       if (items.length >= limit) {
-        return items;
+        // We hit the cap. More results exist if any later value on this page
+        // would have been included, or another page follows.
+        const moreOnThisPage = pageValues
+          .slice(i + 1)
+          .some((rest) => !shouldInclude || shouldInclude(rest));
+        return { items, hasMore: moreOnThisPage || Boolean(data.next) };
       }
     }
 
@@ -80,5 +116,11 @@ export async function collectPages<T>(
     page += 1;
   }
 
-  return items;
+  return { items, hasMore: false };
+}
+
+export async function collectPages<T>(
+  options: CollectPagesOptions<T>
+): Promise<T[]> {
+  return (await collectPagesWithMeta(options)).items;
 }

--- a/tests/commands/repo.test.ts
+++ b/tests/commands/repo.test.ts
@@ -210,6 +210,117 @@ describe('ListReposCommand', () => {
     expect(requestedPages).toEqual([1, 2]);
   });
 
+  it('prints a "see more" hint when results are capped by the limit', async () => {
+    const repos = Array.from({ length: 5 }, (_, index) => ({
+      ...mockRepository,
+      slug: `repo-${index + 1}`,
+      full_name: `workspace/repo-${index + 1}`,
+    }));
+    const repositoriesApi = createMockRepositoriesApi(repos);
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace', limit: '2' },
+      { globalOptions: {} }
+    );
+
+    expect(
+      output.logs.some(
+        (log) =>
+          log.startsWith('text:Showing 2 repositories') && log.includes('--all')
+      )
+    ).toBe(true);
+  });
+
+  it('does not print the hint when all repositories are shown', async () => {
+    const repos = [
+      { ...mockRepository, slug: 'repo1', full_name: 'workspace/repo1' },
+      { ...mockRepository, slug: 'repo2', full_name: 'workspace/repo2' },
+    ];
+    const repositoriesApi = createMockRepositoriesApi(repos);
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace', limit: '25' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs.some((log) => log.startsWith('text:Showing'))).toBe(
+      false
+    );
+  });
+
+  it('--all fetches every page and prints no hint', async () => {
+    const repos = Array.from({ length: 120 }, (_, index) => ({
+      ...mockRepository,
+      slug: `repo-${index + 1}`,
+      full_name: `workspace/repo-${index + 1}`,
+    }));
+    const requestedPages: number[] = [];
+    const repositoriesApi = createMockRepositoriesApi(repos, {
+      onListCall: (_request, axiosOptions) => {
+        requestedPages.push(extractPaginationParams(axiosOptions).page);
+      },
+    });
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace', all: true },
+      { globalOptions: {} }
+    );
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(120);
+    // 120 repos at the 50-item max page size => 3 pages.
+    expect(requestedPages).toEqual([1, 2, 3]);
+    expect(output.logs.some((log) => log.startsWith('text:Showing'))).toBe(
+      false
+    );
+  });
+
+  it('does not print the hint in JSON mode even when capped', async () => {
+    const repos = Array.from({ length: 5 }, (_, index) => ({
+      ...mockRepository,
+      slug: `repo-${index + 1}`,
+      full_name: `workspace/repo-${index + 1}`,
+    }));
+    const repositoriesApi = createMockRepositoriesApi(repos);
+    const contextService = createMockContextService();
+    const output = createMockOutputService();
+
+    const command = new ListReposCommand(
+      repositoriesApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { workspace: 'workspace', limit: '2' },
+      { globalOptions: { json: true } }
+    );
+
+    expect(output.logs.some((log) => log.startsWith('text:Showing'))).toBe(
+      false
+    );
+  });
+
   it('should show message when no repositories found', async () => {
     const repositoriesApi = createMockRepositoriesApi([]);
     const contextService = createMockContextService();

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -5,8 +5,10 @@
 import { describe, expect, it } from 'bun:test';
 import {
   collectPages,
+  collectPagesWithMeta,
   DEFAULT_LIMIT,
   parseLimit,
+  resolveLimit,
   type PaginatedCollection,
 } from '../../src/services/pagination.js';
 import { BBError, ErrorCode } from '../../src/types/errors.js';
@@ -135,5 +137,107 @@ describe('collectPages', () => {
     });
 
     expect(result).toEqual([2, 4]);
+  });
+});
+
+describe('resolveLimit', () => {
+  it('returns Infinity when --all is set, ignoring --limit', () => {
+    expect(resolveLimit({ all: true, limit: '10' })).toBe(
+      Number.POSITIVE_INFINITY
+    );
+  });
+
+  it('parses --limit when --all is not set', () => {
+    expect(resolveLimit({ limit: '10' })).toBe(10);
+  });
+
+  it('falls back to the default limit when neither is set', () => {
+    expect(resolveLimit({})).toBe(DEFAULT_LIMIT);
+  });
+});
+
+describe('collectPagesWithMeta', () => {
+  it('reports hasMore=false when everything fits under the limit', async () => {
+    const result = await collectPagesWithMeta<number>({
+      limit: 10,
+      fetchPage: async () => ({ values: [1, 2, 3] }),
+    });
+
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('reports hasMore=true when more items remain on the capped page', async () => {
+    const result = await collectPagesWithMeta<number>({
+      limit: 2,
+      pageSize: 5,
+      fetchPage: async () => ({ values: [1, 2, 3, 4, 5] }),
+    });
+
+    expect(result.items).toEqual([1, 2]);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('reports hasMore=true when the limit ends a page but another follows', async () => {
+    const pages: Array<PaginatedCollection<number>> = [
+      { values: [1, 2, 3], next: 'page2' },
+      { values: [4, 5, 6] },
+    ];
+
+    const result = await collectPagesWithMeta<number>({
+      limit: 3,
+      pageSize: 3,
+      fetchPage: async (page) => pages[page - 1] ?? { values: [] },
+    });
+
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('reports hasMore=false when the limit ends the final page exactly', async () => {
+    const result = await collectPagesWithMeta<number>({
+      limit: 3,
+      pageSize: 3,
+      fetchPage: async () => ({ values: [1, 2, 3] }),
+    });
+
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('collects every page when limit is Infinity (--all)', async () => {
+    const pages: Array<PaginatedCollection<number>> = [
+      { values: [1, 2], next: 'page2' },
+      { values: [3, 4], next: 'page3' },
+      { values: [5] },
+    ];
+    const calls: number[] = [];
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      fetchPage: async (page) => {
+        calls.push(page);
+        return pages[page - 1] ?? { values: [] };
+      },
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5]);
+    expect(result.hasMore).toBe(false);
+    expect(calls).toEqual([1, 2, 3]);
+  });
+
+  it('ignores filtered-out trailing values when computing hasMore', async () => {
+    // Only even values are included; after collecting [2] at the cap, the
+    // remaining page values (3) are filtered out and there is no next page,
+    // so nothing more would actually be shown.
+    const result = await collectPagesWithMeta<number>({
+      limit: 1,
+      pageSize: 3,
+      fetchPage: async () => ({ values: [1, 2, 3] }),
+      shouldInclude: (value) => value % 2 === 0,
+    });
+
+    expect(result.items).toEqual([2]);
+    expect(result.hasMore).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements #243: paginated list commands silently capped results at `--limit` (default 25) with no indication that more existed, and offered no way to fetch everything. This is what made the reporter in #241 think repositories were missing.

Two improvements, applied consistently across all six list commands:

1. **Truncation hint** — when the output is capped by `--limit` and more results exist on the server, a dimmed footer is printed, e.g.:

   ```
   Showing 25 repositories. Use --limit <n> or --all to see more.
   ```

   It only appears when results were actually truncated, and is suppressed in `--json` mode (JSON payloads already carry `count`).

2. **`--all` flag** — fetches every page regardless of `--limit`.

## How it works

- `collectPagesWithMeta()` returns `{ items, hasMore }`. `hasMore` is computed precisely at the cap point — true only if a not-yet-consumed value remains on the current page or another page follows — so the hint never fires when the total happens to equal the limit. `collectPages()` remains as a thin wrapper, so callers that don't need the flag (`default-reviewer.service`, `pr edit`, `pr diff`) are untouched.
- `resolveLimit({ all, limit })` maps `--all` to an unbounded (`Infinity`) fetch; the existing page-size clamp (`MAX_PAGE_LENGTH`) keeps each request valid while looping until the server runs out of pages. `--limit 0` still errors as before.
- `BaseCommand.printMoreHint()` centralizes the footer wording and the no-op/JSON gating.

## Commands updated

`repo list`, `pr list`, `pr activity`, `pr comments list`, `snippet list`, `snippet comments list` — each gains `--all` and the hint.

## Changes

- `src/services/pagination.ts` — `collectPagesWithMeta`, `resolveLimit`, `CollectPagesResult`.
- `src/core/base-command.ts` — `printMoreHint`.
- 6 list commands + `src/cli.ts` (`--all` flag + examples).
- Docs: `--all` and the hint documented across the command reference pages.
- Tests: pagination (`hasMore` semantics, `--all`/Infinity, `resolveLimit`) and repo command (hint shown/hidden, `--json` suppression, `--all` fetches all pages).
- Changeset: minor.

## Verification

- `bun test` → 1071 pass, 0 fail
- `bun run lint` (tsc --noEmit) → clean
- `bun run format:check` → clean

Closes #243
