### PR TITLE
feat: add `bb api` raw passthrough command

### DIFF
--- a/.changeset/api-passthrough-command.md
+++ b/.changeset/api-passthrough-command.md
@@ -1,0 +1,26 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `bb api`, a raw authenticated passthrough to the Bitbucket Cloud 2.0 API
+(mirrors `gh api`). It is the escape hatch for endpoints not yet wrapped by a
+typed command, reusing the shared authenticated stack (Basic/Bearer auth,
+OAuth refresh, retry, redaction).
+
+- `bb api [method] <endpoint>` — method may be a leading positional verb
+  (`bb api GET /user`) or a path only (`bb api /user`); `-X/--method`
+  overrides. Defaults to `GET`, or `POST` when fields/body are present.
+- `-f/--raw-field` (string) and `-F/--field` (typed: `true`/`false`/`null`,
+  numbers, `@file`, `@-` for stdin). On `GET`/`HEAD` fields become query
+  params; otherwise a JSON body.
+- `--input <file>` reads a raw request body (`-` for stdin); mutually
+  exclusive with `-f`/`-F`.
+- `-H/--header` adds request headers; `Authorization` stays managed.
+- `--paginate` follows the cursor (`next`) and merges every page's `values`.
+- `{workspace}` and `{repo}` placeholders are filled from `--workspace`/
+  `--repo` or the current repository.
+- Global `--json [fields]` and `--jq` apply to the response; non-JSON bodies
+  (e.g. raw diffs) print verbatim. API error responses are surfaced, and
+  `APIError` JSON now carries `statusCode` and the response body.
+- Absolute URLs are restricted to `api.bitbucket.org` so credentials are
+  never sent to a foreign host.

--- a/.changeset/api-passthrough-command.md
+++ b/.changeset/api-passthrough-command.md
@@ -15,12 +15,20 @@ OAuth refresh, retry, redaction).
   params; otherwise a JSON body.
 - `--input <file>` reads a raw request body (`-` for stdin); mutually
   exclusive with `-f`/`-F`.
-- `-H/--header` adds request headers; `Authorization` stays managed.
+- `-H/--header` adds request headers; a user-supplied `Authorization` is
+  rejected since auth is managed automatically.
+- `-i/--include` prints the HTTP status line and response headers before the
+  body (text mode only).
 - `--paginate` follows the cursor (`next`) and merges every page's `values`.
 - `{workspace}` and `{repo}` placeholders are filled from `--workspace`/
   `--repo` or the current repository.
-- Global `--json [fields]` and `--jq` apply to the response; non-JSON bodies
-  (e.g. raw diffs) print verbatim. API error responses are surfaced, and
-  `APIError` JSON now carries `statusCode` and the response body.
+- `--json [fields]` and `--jq` apply to the response; because `bb api` output
+  is already JSON, `--jq` works without `--json`. Non-JSON bodies (e.g. raw
+  diffs) print verbatim; an empty body emits `{}` under `--json`. API error
+  responses are surfaced, and `APIError` JSON now carries `statusCode` and the
+  response body.
+- Ambiguous invocations fail loudly: a non-verb first positional
+  (`bb api /a /b`) and a lone verb (`bb api GET`) are rejected instead of
+  silently dropping an argument.
 - Absolute URLs are restricted to `api.bitbucket.org` so credentials are
   never sent to a foreign host.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ bb pr create --title "Add feature"
 bb pr approve 42
 bb browse 42                  # open PR #42 in your browser
 bb browse src/cli.ts:20       # open a file at a specific line
+bb api /user                  # call any Bitbucket API endpoint (escape hatch)
 bb config set defaultWorkspace myworkspace
 ```
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -98,6 +98,10 @@ export default defineConfig({
             {
               label: "Browse",
               slug: "commands/browse",
+            },
+            {
+              label: "API",
+              slug: "commands/api",
               badge: { text: "New", variant: "tip" },
             },
             { label: "Config Commands", slug: "commands/config" },

--- a/docs/src/content/docs/commands/api.mdx
+++ b/docs/src/content/docs/commands/api.mdx
@@ -34,9 +34,10 @@ bb api [method] <endpoint> [options]
 | `-X, --method <method>` | HTTP method. Overrides a positional verb. |
 | `-f, --raw-field <key=value>` | Add a string parameter. Query param on `GET`/`HEAD`, JSON body field otherwise. Repeatable. |
 | `-F, --field <key=value>` | Add a typed parameter: `true`/`false`/`null` and numbers are converted; `@file` reads a file and `@-` reads stdin. Repeatable. |
-| `--input <file>` | Read the raw request body from a file, or `-` for stdin. Mutually exclusive with `-f`/`-F`. |
-| `-H, --header <key:value>` | Add a request header. Repeatable. `Authorization` is managed automatically and cannot be overridden. |
-| `--paginate` | Follow the cursor (`next`) across pages and merge every page into a single `{ "values": [...] }` result (`GET` only). |
+| `--input <file>` | Read the raw request body from a file, or `-` for stdin. Sent as `application/json` (override with `-H 'Content-Type: ...'`). Mutually exclusive with `-f`/`-F`. |
+| `-H, --header <key:value>` | Add a request header. Repeatable. `Authorization` is managed automatically and cannot be set here. |
+| `-i, --include` | Print the HTTP status line and response headers before the body (text mode only — suppressed under `--json`). |
+| `--paginate` | Follow the cursor (`next`) across pages and merge every page into a single `{ "values": [...] }` result (`GET`/`HEAD` only). |
 
 ### Examples
 
@@ -57,13 +58,16 @@ bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3
 bb api PUT /repositories/my-ws/my-repo/pullrequests/42 --input body.json
 
 # Pipe a body in from stdin
-cat body.json | bb api POST /repositories/my-ws/my-repo/... --input -
+cat body.json | bb api POST /repositories/my-ws/my-repo/pullrequests/42/comments --input -
 
 # Force a GET with query parameters (fields normally infer POST)
 bb api GET /repositories/my-ws/my-repo/pullrequests -f state=MERGED
 
-# Project and filter the response with the global JSON flags
-bb api /repositories/my-ws --json --jq '.values[].name'
+# Filter the response with jq (no --json needed — bb api output is already JSON)
+bb api /repositories/my-ws --jq '.values[].name'
+
+# Inspect the status line and response headers
+bb api -i /user
 ```
 
 ### How fields are sent
@@ -94,7 +98,9 @@ bb api -w my-ws -r my-repo /repositories/{workspace}/{repo}/commits
 
 The response body is printed to stdout. JSON responses are pretty-printed and
 respect the global `--json [fields]` projection and `--jq` filtering; non-JSON
-responses (e.g. raw diffs) are printed verbatim.
+responses (e.g. raw diffs) are printed verbatim, and `--json`/`--jq` are inert
+on them. An empty response body (e.g. a `HEAD` or `204`) prints nothing in text
+mode, and `{}` under `--json` so a downstream `jq` never sees zero bytes.
 
 ```bash
 bb api /user
@@ -105,13 +111,14 @@ bb api /user
   "type": "user",
   "username": "my-user",
   "display_name": "My User",
-  ...
+  "account_id": "557058:..."
 }
 ```
 
 <Aside type="note">
-  `--jq` requires `--json` (a CLI-wide rule). To filter `bb api` output, pass
-  both: `bb api /repositories/my-ws --json --jq '.values[].name'`.
+  Unlike list/table commands, `bb api` output is already JSON, so `--jq` works
+  on its own — you do **not** need to pass `--json` as well:
+  `bb api /repositories/my-ws --jq '.values[].name'`.
 </Aside>
 
 ### Notes
@@ -127,8 +134,8 @@ bb api /user
   body is printed and the command exits non-zero. With `--json`, the error
   payload (including `statusCode` and `response`) is emitted as structured JSON.
 - **Retries and redaction are inherited** from the shared API client — rate
-  limits (`429`) and transient `5xx` errors are retried with backoff, and
-  sensitive values are redacted from `DEBUG` logs.
+  limits (`429`) and the transient gateway errors `502`/`503`/`504` are retried
+  with backoff, and sensitive values are redacted from `DEBUG` logs.
 
 ### Related
 

--- a/docs/src/content/docs/commands/api.mdx
+++ b/docs/src/content/docs/commands/api.mdx
@@ -1,0 +1,140 @@
+---
+title: API Command — Raw Authenticated Bitbucket API Access
+description: Call any Bitbucket Cloud 2.0 API endpoint through the CLI's authenticated stack — the escape hatch for endpoints not yet wrapped by a typed command. Mirrors gh api.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`bb api` makes an authenticated request to **any** Bitbucket Cloud 2.0 API
+endpoint, reusing the same stack as every other command: Basic/Bearer auth,
+automatic OAuth token refresh, rate-limit and transient-error retries, and
+secret redaction. It is the escape hatch for endpoints not yet wrapped by a
+typed command family, so you are never blocked. Mirrors `gh api`.
+
+Global options: `--json [fields]`, `--jq <expression>`, `--no-color`,
+`-w, --workspace`, `-r, --repo`.
+
+## `bb api`
+
+```bash
+bb api [method] <endpoint> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `method` | Optional HTTP verb (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`). When omitted, defaults to `GET`, or `POST` when fields/body are present. Both `bb api GET /user` and `bb api /user` work. |
+| `endpoint` | The API path, relative to `https://api.bitbucket.org/2.0` (a leading `/` is optional). `{workspace}` and `{repo}` placeholders are substituted from `--workspace`/`--repo` or the current repository. |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-X, --method <method>` | HTTP method. Overrides a positional verb. |
+| `-f, --raw-field <key=value>` | Add a string parameter. Query param on `GET`/`HEAD`, JSON body field otherwise. Repeatable. |
+| `-F, --field <key=value>` | Add a typed parameter: `true`/`false`/`null` and numbers are converted; `@file` reads a file and `@-` reads stdin. Repeatable. |
+| `--input <file>` | Read the raw request body from a file, or `-` for stdin. Mutually exclusive with `-f`/`-F`. |
+| `-H, --header <key:value>` | Add a request header. Repeatable. `Authorization` is managed automatically and cannot be overridden. |
+| `--paginate` | Follow the cursor (`next`) across pages and merge every page into a single `{ "values": [...] }` result (`GET` only). |
+
+### Examples
+
+```bash
+# Current user
+bb api /user
+
+# Explicit method (equivalent to the above)
+bb api GET /user
+
+# List every pull request, following pagination, using the current repo
+bb api /repositories/{workspace}/{repo}/pullrequests --paginate
+
+# Create an issue (method inferred as POST because fields are present)
+bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3
+
+# Send a JSON body from a file
+bb api PUT /repositories/my-ws/my-repo/pullrequests/42 --input body.json
+
+# Pipe a body in from stdin
+cat body.json | bb api POST /repositories/my-ws/my-repo/... --input -
+
+# Force a GET with query parameters (fields normally infer POST)
+bb api GET /repositories/my-ws/my-repo/pullrequests -f state=MERGED
+
+# Project and filter the response with the global JSON flags
+bb api /repositories/my-ws --json --jq '.values[].name'
+```
+
+### How fields are sent
+
+- **`GET` / `HEAD`** — `-f`/`-F` fields are appended as a URL query string
+  (`?key=value&...`).
+- **Other methods** — `-f`/`-F` fields are assembled into a JSON request body.
+- **`--input`** — sends the file (or stdin) contents as the raw body verbatim,
+  and cannot be combined with `-f`/`-F`.
+- Repeating the same key turns it into an array, matching `gh`.
+
+### Placeholders
+
+`{workspace}` and `{repo}` in the endpoint are filled from `--workspace` /
+`--repo` or inferred from the current git checkout. Repository context is only
+resolved when a placeholder is actually present, so `bb api /user` works
+anywhere.
+
+```bash
+# Inside a Bitbucket checkout, these resolve automatically:
+bb api /repositories/{workspace}/{repo}/commits
+
+# Or override explicitly:
+bb api -w my-ws -r my-repo /repositories/{workspace}/{repo}/commits
+```
+
+### Output
+
+The response body is printed to stdout. JSON responses are pretty-printed and
+respect the global `--json [fields]` projection and `--jq` filtering; non-JSON
+responses (e.g. raw diffs) are printed verbatim.
+
+```bash
+bb api /user
+```
+
+```json
+{
+  "type": "user",
+  "username": "my-user",
+  "display_name": "My User",
+  ...
+}
+```
+
+<Aside type="note">
+  `--jq` requires `--json` (a CLI-wide rule). To filter `bb api` output, pass
+  both: `bb api /repositories/my-ws --json --jq '.values[].name'`.
+</Aside>
+
+### Notes
+
+- **Authentication is automatic.** The same credentials as the rest of the CLI
+  are attached to every request; you cannot (and need not) set `Authorization`
+  yourself.
+- **Only the Bitbucket API host is allowed.** Absolute URLs are accepted only
+  when they point at `api.bitbucket.org`. This prevents the CLI from sending
+  your token to a foreign host. Pagination cursors (which are absolute
+  `api.bitbucket.org` URLs) are followed safely.
+- **Errors surface the API response.** On a non-2xx status, the API's error
+  body is printed and the command exits non-zero. With `--json`, the error
+  payload (including `statusCode` and `response`) is emitted as structured JSON.
+- **Retries and redaction are inherited** from the shared API client — rate
+  limits (`429`) and transient `5xx` errors are retried with backoff, and
+  sensitive values are redacted from `DEBUG` logs.
+
+### Related
+
+- [Scripting & Automation](/guides/scripting/) — combine `bb api` with `--jq`
+  to build pipelines over endpoints without a typed command.
+- [JSON Output](/reference/json-output/) — how `--json` projection and `--jq`
+  filtering work across the CLI.
+- [Authentication](/getting-started/authentication/) — the auth methods that
+  `bb api` reuses.

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -105,6 +105,7 @@ Here are the commands you'll use most often:
 | `bb repo list` | List repositories |
 | `bb browse 42` | Open PR #42 in your browser |
 | `bb browse src/cli.ts:20` | Open a file at a specific line in your browser |
+| `bb api /user` | Call any Bitbucket API endpoint (escape hatch) |
 
 ---
 
@@ -138,7 +139,7 @@ Restart your shell, then try:
 ```bash
 bb pr <Tab>      # Shows: activity, approve, checkout, create, decline, diff, list, merge, ready, view
 bb pr create -<Tab>  # Shows available flags
-bb <Tab>         # Shows: auth, repo, pr, snippet, browse, config, completion
+bb <Tab>         # Shows: auth, repo, pr, snippet, browse, api, config, completion
 ```
 
 ---

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -44,6 +44,7 @@ Pick your editor and paste the command:
     **Draft:** `bb pr create -t "WIP" --draft` → later `bb pr ready <id>`
     **Comments:** `bb pr comments list <id>` / `bb pr comments add <id> "text"`
     **Repos:** `bb repo list`, `bb repo clone workspace/repo`, `bb repo view`
+    **Raw API:** `bb api <endpoint>` — any Bitbucket 2.0 endpoint not covered above (e.g. `bb api /repositories/{workspace}/{repo}/issues`; supports `--paginate` and `--jq`)
 
     ## Tips
 
@@ -90,6 +91,9 @@ Pick your editor and paste the command:
     - `bb repo list` / `bb repo view` / `bb repo clone workspace/repo`
     - `bb repo default-reviewers list` / `add <uuid>` / `remove <uuid> --yes` - Manage repo default reviewers
 
+    **Raw API access:**
+    - `bb api <endpoint>` - Authenticated call to any Bitbucket 2.0 endpoint (escape hatch for anything without a typed command; e.g. `bb api /repositories/{workspace}/{repo}/issues`; supports `--paginate` and `--jq`)
+
     **Configuration:**
     - `bb config set defaultWorkspace myworkspace`
     - `bb auth status` - Check authentication
@@ -133,6 +137,7 @@ Pick your editor and paste the command:
     - `bb pr ready <id>` - Mark draft as ready
     - `bb pr comments add <id> "text"` - Comment on PR
     - `bb repo list/view/clone` - Repository operations
+    - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
     ## Context
@@ -162,6 +167,7 @@ Pick your editor and paste the command:
     - `bb pr ready <id>` - Mark draft as ready
     - `bb pr comments add <id> "text"` - Comment on PR
     - `bb repo list/view/clone` - Repository operations
+    - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
     **Context:** Auto-detects workspace/repo from git remotes. Use `-w`/`-r` to override.

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -90,6 +90,32 @@ bb pr list --json | jq '.pullRequests | group_by(.author.nickname // .author.dis
 
 ---
 
+## Raw API Access (Escape Hatch)
+
+When no typed command covers what you need, [`bb api`](/commands/api/) calls any
+Bitbucket Cloud 2.0 endpoint through the same authenticated stack — so scripts
+are never blocked. Its output is already JSON, so `--jq` works without `--json`.
+
+```bash
+# Any endpoint, authenticated
+bb api /user --jq '.username'
+
+# Fields become a query string on GET, a JSON body otherwise
+bb api /repositories/myworkspace/myrepo/pullrequests -X GET -f state=MERGED
+
+# Follow pagination and pull a single field across every page
+bb api /repositories/myworkspace/myrepo/pullrequests --paginate \
+  --jq '.values[].title'
+
+# Create resources that have no typed command yet
+bb api POST /repositories/myworkspace/myrepo/issues -f title="Bug report"
+```
+
+`{workspace}` and `{repo}` placeholders resolve from `-w`/`-r` or the current
+checkout. See the [API command reference](/commands/api/) for every flag.
+
+---
+
 ## Exit Codes
 
 The CLI uses a deliberately small exit-code surface:

--- a/docs/src/content/docs/help/changelog.mdx
+++ b/docs/src/content/docs/help/changelog.mdx
@@ -14,6 +14,36 @@ and is updated on every release.
   See [Configuration File](/reference/configuration/) for related settings.
 </Aside>
 
+## 1.20.0 — `bb api`
+
+A raw, authenticated passthrough to **any** Bitbucket Cloud 2.0 API endpoint —
+the escape hatch for anything not yet wrapped by a typed command. Mirrors
+`gh api`, reusing the same authenticated stack (auth, OAuth refresh, retry,
+secret redaction).
+
+- `bb api [method] <endpoint>` — method may be a leading verb (`bb api GET /user`)
+  or path-only (`bb api /user`); defaults to `GET`, or `POST` when fields/body
+  are present.
+- `-f/--raw-field` (string) and `-F/--field` (typed: `true`/`false`/`null`,
+  numbers, `@file`, `@-` stdin). On `GET`/`HEAD` fields become query params,
+  otherwise a JSON body.
+- `--input` sends a raw body from a file or stdin; `-H/--header` adds headers;
+  `-i/--include` prints the status line and response headers.
+- `--paginate` follows the `next` cursor and merges every page's `values`.
+- `{workspace}`/`{repo}` placeholders are filled from `--workspace`/`--repo` or
+  the current repo; `--json`/`--jq` filter the response (`--jq` works without
+  `--json` here). Absolute URLs are restricted to `api.bitbucket.org`.
+
+```bash
+bb api /user                                              # current user
+bb api /repositories/{workspace}/{repo}/pullrequests --paginate
+bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3
+bb api /repositories/my-ws --jq '.values[].name'          # filter with jq
+```
+
+See the [API command reference](/commands/api/) for the full flag list and
+examples.
+
 ## 1.18.0 — Pagination hints and `--all`
 
 List commands now make truncation visible and let you opt out of pagination

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -15,7 +15,7 @@ No. This is an **unofficial**, community-maintained CLI tool. It is not affiliat
 
 ### How does this compare to GitHub CLI (gh)?
 
-The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, snippets, configuration, and shell completion. Features not yet supported include issues, pipelines, and branch permissions.
+The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, snippets, configuration, and shell completion. Features without a dedicated command yet — issues, pipelines, branch permissions — can still be reached today through `bb api`, the raw API passthrough (the analog of `gh api`).
 
 ---
 
@@ -29,10 +29,11 @@ Currently supported:
 - **Snippets** - List, view (with file contents), create, edit (metadata or file upload), delete, watch/unwatch, comments (list/add/edit/delete)
 - **Configuration** - Get, set, list settings
 - **Shell Completion** - Bash, Zsh, Fish
+- **Raw API access** - `bb api` passthrough to any Bitbucket Cloud 2.0 endpoint
 
-Not yet supported:
-- Issues
-- Pipelines
+Without a dedicated command yet (but reachable today via `bb api`):
+- Issues — e.g. `bb api /repositories/{workspace}/{repo}/issues`
+- Pipelines — e.g. `bb api /repositories/{workspace}/{repo}/pipelines`
 - Branch permissions
 - Webhooks
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -104,6 +104,16 @@ bb pr list                             # list open PRs
     bb pr list --json | jq '.pullRequests[].title'
     ```
   </Card>
+
+  <Card title="Raw API Access" icon="rocket">
+    Reach any Bitbucket 2.0 endpoint not yet wrapped by a typed command.
+
+    ```bash
+    bb api /user
+    bb api /repositories/{workspace}/{repo}/pullrequests --paginate
+    bb api POST /repositories/ws/repo/issues -f title=Bug
+    ```
+  </Card>
 </CardGrid>
 
 ---

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -91,6 +91,7 @@ import { UninstallCompletionCommand } from './commands/completion/uninstall.comm
 
 // Top-level commands
 import { BrowseCommand } from './commands/browse.command.js';
+import { ApiCommand } from './commands/api.command.js';
 
 export interface BootstrapOptions {
   noColor?: boolean;
@@ -606,6 +607,26 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ServiceTokens.ContextService,
     ServiceTokens.GitService,
     ServiceTokens.UrlBuilderService,
+    ServiceTokens.OutputService,
+  ]);
+
+  // Raw API passthrough (bb api). Uses its own axios instance built from the
+  // authenticated stack, mirroring the SnippetsAxios pattern.
+  container.register(ServiceTokens.ApiAxios, () => {
+    const credentialStore = container.resolve<ConfigService>(
+      ServiceTokens.CredentialStore
+    );
+    const oauthService = container.resolve<OAuthService>(
+      ServiceTokens.OAuthService
+    );
+    const outputService = container.resolve<OutputService>(
+      ServiceTokens.OutputService
+    );
+    return createApiClient(credentialStore, outputService, oauthService);
+  });
+  registerCommand(container, ServiceTokens.ApiCommand, ApiCommand, [
+    ServiceTokens.ApiAxios,
+    ServiceTokens.ContextService,
     ServiceTokens.OutputService,
   ]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,7 @@ const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> = new Map([
   ],
   ['config', ['get', 'set', 'list']],
   ['completion', ['install', 'uninstall']],
+  ['api', ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']],
 ]);
 
 const COMMENTS_SUBCOMMANDS: readonly string[] = [
@@ -228,7 +229,10 @@ const container = bootstrap({ noColor, noUnicode, locale });
 // parsing are deferred onto `context.validationError` so they can be raised
 // inside BaseCommand.run() and rendered through the normal error path,
 // instead of escaping a Commander action handler as an unhandled rejection.
-function createContext(program: Command): CommandContext {
+export function createContext(
+  program: Command,
+  options: { allowJqWithoutJson?: boolean } = {}
+): CommandContext {
   const opts = program.opts();
   const jsonOpt = opts.json as string | boolean | undefined;
   const jqOpt = opts.jq as string | undefined;
@@ -252,7 +256,15 @@ function createContext(program: Command): CommandContext {
     }
   }
 
-  if (!validationError && jqOpt !== undefined && !json) {
+  // `--jq` normally requires `--json` to flip list/table commands out of human
+  // mode. Commands whose output is already JSON (e.g. `bb api`) opt out via
+  // `allowJqWithoutJson`, so `--jq` works standalone there.
+  if (
+    !validationError &&
+    jqOpt !== undefined &&
+    !json &&
+    !options.allowJqWithoutJson
+  ) {
     validationError = new BBError({
       code: ErrorCode.JSON_FORMAT_INVALID,
       message: '--jq requires --json',
@@ -1650,7 +1662,7 @@ cli
   )
   .option(
     '-f, --raw-field <key=value>',
-    'Add a string parameter — query param on GET, JSON body field otherwise (repeatable)',
+    'Add a string parameter — query param on GET/HEAD, JSON body field otherwise (repeatable)',
     collectRepeated,
     [] as string[]
   )
@@ -1662,17 +1674,21 @@ cli
   )
   .option(
     '--input <file>',
-    'Read the request body from a file, or - for stdin (mutually exclusive with -f/-F)'
+    'Read the request body from a file, or - for stdin (sent as application/json; mutually exclusive with -f/-F)'
   )
   .option(
     '-H, --header <key:value>',
-    'Add a request header (repeatable). Authorization is managed automatically.',
+    'Add a request header (repeatable). Authorization is managed automatically and cannot be set here.',
     collectRepeated,
     [] as string[]
   )
   .option(
+    '-i, --include',
+    'Print the HTTP status line and response headers before the body (text mode only)'
+  )
+  .option(
     '--paginate',
-    'Follow the cursor (next) and merge every page into a single {"values": [...]} result (GET only)'
+    'Follow the cursor (next) and merge every page into a single {"values": [...]} result (GET/HEAD only)'
   )
   .addHelpText(
     'before',
@@ -1688,9 +1704,10 @@ cli
         'bb api GET /user',
         'bb api /repositories/{workspace}/{repo}/pullrequests --paginate',
         'bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3',
-        'bb api PUT /repositories/my-ws/my-repo/... --input body.json',
-        'cat body.json | bb api POST /repositories/my-ws/my-repo/... --input -',
-        "bb api /repositories/my-ws --json --jq '.values[].name'",
+        'bb api PUT /repositories/my-ws/my-repo/pullrequests/42 --input body.json',
+        'cat body.json | bb api POST /repositories/my-ws/my-repo/pullrequests/42/comments --input -',
+        "bb api /repositories/my-ws --jq '.values[].name'",
+        'bb api -i /user',
       ],
       validValues: {
         'Valid methods': [
@@ -1716,7 +1733,8 @@ cli
     })
   )
   .action(async (methodOrEndpoint, endpoint, options) => {
-    const context = createContext(cli);
+    // `bb api` output is already JSON, so `--jq` works without `--json`.
+    const context = createContext(cli, { allowJqWithoutJson: true });
     await runCommand(
       ServiceTokens.ApiCommand,
       withGlobalOptions({ methodOrEndpoint, endpoint, ...options }, context),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   'pr',
   'snippet',
   'browse',
+  'api',
   'config',
   'completion',
   '--help',
@@ -1629,6 +1630,96 @@ cli
     await runCommand(
       ServiceTokens.BrowseCommand,
       withGlobalOptions({ target, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+// API passthrough command (top-level)
+const collectRepeated = (value: string, previous: string[]): string[] =>
+  previous.concat([value]);
+
+cli
+  .command('api [methodOrEndpoint] [endpoint]')
+  .description(
+    'Make an authenticated request to any Bitbucket Cloud 2.0 API endpoint'
+  )
+  .option(
+    '-X, --method <method>',
+    'HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). Defaults to GET, or POST when fields/body are present.'
+  )
+  .option(
+    '-f, --raw-field <key=value>',
+    'Add a string parameter — query param on GET, JSON body field otherwise (repeatable)',
+    collectRepeated,
+    [] as string[]
+  )
+  .option(
+    '-F, --field <key=value>',
+    'Add a typed parameter: true/false/null and numbers are converted; @file reads a file and @- reads stdin (repeatable)',
+    collectRepeated,
+    [] as string[]
+  )
+  .option(
+    '--input <file>',
+    'Read the request body from a file, or - for stdin (mutually exclusive with -f/-F)'
+  )
+  .option(
+    '-H, --header <key:value>',
+    'Add a request header (repeatable). Authorization is managed automatically.',
+    collectRepeated,
+    [] as string[]
+  )
+  .option(
+    '--paginate',
+    'Follow the cursor (next) and merge every page into a single {"values": [...]} result (GET only)'
+  )
+  .addHelpText(
+    'before',
+    '\nEscape hatch for endpoints not yet wrapped by a typed command.\n' +
+      'The path is relative to https://api.bitbucket.org/2.0; {workspace} and\n' +
+      '{repo} placeholders are filled from --workspace/--repo or the current repo.\n'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb api /user',
+        'bb api GET /user',
+        'bb api /repositories/{workspace}/{repo}/pullrequests --paginate',
+        'bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3',
+        'bb api PUT /repositories/my-ws/my-repo/... --input body.json',
+        'cat body.json | bb api POST /repositories/my-ws/my-repo/... --input -',
+        "bb api /repositories/my-ws --json --jq '.values[].name'",
+      ],
+      validValues: {
+        'Valid methods': [
+          'GET',
+          'POST',
+          'PUT',
+          'PATCH',
+          'DELETE',
+          'HEAD',
+          'OPTIONS',
+        ],
+      },
+      seeAlso: [
+        {
+          label: 'Scripting & Automation',
+          url: 'https://bitbucket-cli.paulvanderlei.com/guides/scripting/',
+        },
+        {
+          label: 'Bitbucket REST API',
+          url: 'https://developer.atlassian.com/cloud/bitbucket/rest/intro/',
+        },
+      ],
+    })
+  )
+  .action(async (methodOrEndpoint, endpoint, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ApiCommand,
+      withGlobalOptions({ methodOrEndpoint, endpoint, ...options }, context),
       cli,
       context
     );

--- a/src/commands/api.command.ts
+++ b/src/commands/api.command.ts
@@ -1,0 +1,313 @@
+/**
+ * `bb api` — raw authenticated passthrough to the Bitbucket Cloud 2.0 API.
+ *
+ * Mirrors `gh api`: it sends any request through the already-authenticated axios
+ * stack (Basic/Bearer auth, OAuth refresh, retry, redaction) so users are never
+ * blocked on an endpoint the typed command families don't cover yet.
+ */
+
+import fs from 'node:fs';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { BaseCommand } from '../core/base-command.js';
+import type { CommandContext } from '../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../core/interfaces/services.js';
+import { BBError, ErrorCode, APIError } from '../types/errors.js';
+import {
+  buildFieldObject,
+  buildRequestParts,
+  findPlaceholders,
+  getNextUrl,
+  getValues,
+  magicType,
+  normalizeEndpoint,
+  parseFieldAssignment,
+  parseHeaders,
+  resolveMethod,
+  substitutePlaceholders,
+  type FieldEntry,
+} from '../services/api-passthrough.js';
+
+export interface ApiCommandOptions {
+  /** First positional: an HTTP verb (when `endpoint` is also present) or the endpoint. */
+  methodOrEndpoint?: string;
+  /** Second positional: the endpoint, present only when a leading verb was given. */
+  endpoint?: string;
+  /** `-X/--method` override. */
+  method?: string;
+  /** `-f/--raw-field` string fields (repeatable). */
+  rawField?: string[];
+  /** `-F/--field` typed fields with magic parsing and `@file`/`@-` (repeatable). */
+  field?: string[];
+  /** `--input` raw request body from a file, or `-` for stdin. */
+  input?: string;
+  /** `-H/--header` custom request headers (repeatable). */
+  header?: string[];
+  /** `--paginate` follow the cursor `next` URL and merge `values`. */
+  paginate?: boolean;
+  workspace?: string;
+  repo?: string;
+}
+
+export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
+  public readonly name = 'api';
+  public readonly description =
+    'Make an authenticated request to the Bitbucket API';
+
+  constructor(
+    private readonly axios: AxiosInstance,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ApiCommandOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const { positionalMethod, endpointArg } = this.splitPositionals(options);
+
+    const rawFields = options.rawField ?? [];
+    const typedFields = options.field ?? [];
+    const headerArgs = options.header ?? [];
+
+    // --input is mutually exclusive with -f/-F (matches gh).
+    if (
+      options.input !== undefined &&
+      (rawFields.length > 0 || typedFields.length > 0)
+    ) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message:
+          'Cannot use --input together with -f/--raw-field or -F/--field.',
+      });
+    }
+
+    const fieldEntries = await this.collectFields(rawFields, typedFields);
+    const fields = buildFieldObject(fieldEntries);
+    const rawBody =
+      options.input !== undefined
+        ? await this.readBody(options.input)
+        : undefined;
+
+    const hasParams = fieldEntries.length > 0 || rawBody !== undefined;
+    const method = resolveMethod({
+      explicit: options.method,
+      positional: positionalMethod,
+      hasParams,
+    });
+
+    const endpoint = await this.resolveEndpoint(endpointArg, options, context);
+    const { query, data } = buildRequestParts({ method, fields, rawBody });
+    const url = query
+      ? `${endpoint}${endpoint.includes('?') ? '&' : '?'}${query}`
+      : endpoint;
+
+    const headers = parseHeaders(headerArgs);
+    const config: AxiosRequestConfig = {
+      url,
+      method,
+      ...(data !== undefined ? { data } : {}),
+      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    };
+
+    const isGetLike = method === 'GET' || method === 'HEAD';
+    try {
+      const response =
+        options.paginate && isGetLike
+          ? await this.fetchAllPages(config, headers)
+          : await this.axios.request(config);
+      await this.renderBody(response.data, context);
+    } catch (error) {
+      // Surface the API's error response body to stdout (like gh) in text mode;
+      // in JSON mode the body rides along on APIError.toJSON() via the standard
+      // error path, so avoid double-printing.
+      if (
+        error instanceof APIError &&
+        error.response !== undefined &&
+        !context.globalOptions.json
+      ) {
+        await this.renderBody(error.response, context);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Resolve the leading positionals into a possible method verb and the
+   * endpoint. With two positionals the first is the method; with one it is the
+   * endpoint.
+   */
+  private splitPositionals(options: ApiCommandOptions): {
+    positionalMethod?: string;
+    endpointArg: string;
+  } {
+    let positionalMethod: string | undefined;
+    let endpointArg: string | undefined;
+
+    if (options.endpoint !== undefined) {
+      positionalMethod = options.methodOrEndpoint;
+      endpointArg = options.endpoint;
+    } else {
+      endpointArg = options.methodOrEndpoint;
+    }
+
+    if (endpointArg === undefined || endpointArg === '') {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: this.appendHelpHint(
+          'An endpoint path is required (e.g. /user).'
+        ),
+      });
+    }
+
+    return positionalMethod !== undefined
+      ? { positionalMethod, endpointArg }
+      : { endpointArg };
+  }
+
+  /**
+   * Parse `-f` (string) and `-F` (typed) fields into ordered entries, resolving
+   * `@file` / `@-` (stdin) values for typed fields.
+   */
+  private async collectFields(
+    rawFields: readonly string[],
+    typedFields: readonly string[]
+  ): Promise<FieldEntry[]> {
+    const entries: FieldEntry[] = [];
+
+    for (const raw of rawFields) {
+      const { key, rawValue } = parseFieldAssignment(raw);
+      entries.push({ key, value: rawValue });
+    }
+
+    for (const raw of typedFields) {
+      const { key, rawValue } = parseFieldAssignment(raw);
+      if (rawValue.startsWith('@')) {
+        const source = rawValue.slice(1);
+        const value =
+          source === '-' ? await this.readStdin() : this.readFile(source);
+        entries.push({ key, value });
+      } else {
+        entries.push({ key, value: magicType(rawValue) });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Substitute `{workspace}`/`{repo}` placeholders (resolving repo context only
+   * when needed) and normalize the endpoint into a safe request URL.
+   */
+  private async resolveEndpoint(
+    endpointArg: string,
+    options: ApiCommandOptions,
+    context: CommandContext
+  ): Promise<string> {
+    const placeholders = findPlaceholders(endpointArg);
+    let substituted = endpointArg;
+
+    if (placeholders.repo) {
+      const repoContext = await this.contextService.requireRepoContextFor(
+        options,
+        context
+      );
+      substituted = substitutePlaceholders(endpointArg, {
+        workspace: repoContext.workspace,
+        repo: repoContext.repoSlug,
+      });
+    } else if (placeholders.workspace) {
+      const workspace = await this.contextService.requireWorkspace(
+        options.workspace
+      );
+      substituted = substitutePlaceholders(endpointArg, { workspace });
+    }
+
+    return normalizeEndpoint(substituted);
+  }
+
+  /**
+   * Follow the Bitbucket cursor (`next`) across pages, merging every `values`
+   * array into a single `{ values: [...] }` payload.
+   */
+  private async fetchAllPages(
+    config: AxiosRequestConfig,
+    headers: Record<string, string>
+  ): Promise<AxiosResponse> {
+    const first = await this.axios.request(config);
+    const firstValues = getValues(first.data);
+
+    if (firstValues === undefined) {
+      if (!this.output.isJsonMode()) {
+        this.output.warning(
+          '--paginate: response has no "values" array; returning the first page only.'
+        );
+      }
+      return first;
+    }
+
+    const collected: unknown[] = [...firstValues];
+    let next = getNextUrl(first.data);
+
+    while (next) {
+      // Defensive: ensure the server-provided cursor stays on the API host.
+      const nextUrl = normalizeEndpoint(next);
+      const response = await this.axios.request({
+        url: nextUrl,
+        method: 'GET',
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
+      });
+      const values = getValues(response.data) ?? [];
+      collected.push(...values);
+      next = getNextUrl(response.data);
+    }
+
+    return { ...first, data: { values: collected } };
+  }
+
+  /**
+   * Render a response (or error) body. JSON payloads route through
+   * `output.json()` so `--json` field projection and `--jq` apply; non-JSON
+   * (string) bodies pass through verbatim.
+   */
+  private async renderBody(
+    data: unknown,
+    _context: CommandContext
+  ): Promise<void> {
+    if (typeof data === 'string') {
+      if (data.length > 0) {
+        this.output.text(data);
+      }
+      return;
+    }
+    if (data === undefined || data === null || data === '') {
+      return;
+    }
+    await this.output.json(data);
+  }
+
+  private async readBody(input: string): Promise<string> {
+    return input === '-' ? this.readStdin() : this.readFile(input);
+  }
+
+  protected readFile(filePath: string): string {
+    try {
+      return fs.readFileSync(filePath, 'utf8');
+    } catch (error) {
+      throw new BBError({
+        code: ErrorCode.FILE_NOT_FOUND,
+        message: `Could not read file '${filePath}'.`,
+        cause: error instanceof Error ? error : undefined,
+        context: { path: filePath },
+      });
+    }
+  }
+
+  protected async readStdin(): Promise<string> {
+    return Bun.stdin.text();
+  }
+}

--- a/src/commands/api.command.ts
+++ b/src/commands/api.command.ts
@@ -21,6 +21,8 @@ import {
   findPlaceholders,
   getNextUrl,
   getValues,
+  HTTP_METHODS,
+  isHttpMethod,
   magicType,
   normalizeEndpoint,
   parseFieldAssignment,
@@ -45,6 +47,8 @@ export interface ApiCommandOptions {
   input?: string;
   /** `-H/--header` custom request headers (repeatable). */
   header?: string[];
+  /** `-i/--include` print the HTTP status line and response headers before the body. */
+  include?: boolean;
   /** `--paginate` follow the cursor `next` URL and merge `values`. */
   paginate?: boolean;
   workspace?: string;
@@ -86,6 +90,20 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
       });
     }
 
+    const headers = parseHeaders(headerArgs);
+    // Auth is attached by the request interceptor and would override any
+    // user-supplied Authorization anyway; reject it up front so the documented
+    // "managed automatically" guarantee fails loudly instead of silently.
+    for (const name of Object.keys(headers)) {
+      if (name.toLowerCase() === 'authorization') {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message:
+            'Authorization is managed automatically and cannot be set with -H. Run `bb auth login` to change credentials.',
+        });
+      }
+    }
+
     const fieldEntries = await this.collectFields(rawFields, typedFields);
     const fields = buildFieldObject(fieldEntries);
     const rawBody =
@@ -106,7 +124,6 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
       ? `${endpoint}${endpoint.includes('?') ? '&' : '?'}${query}`
       : endpoint;
 
-    const headers = parseHeaders(headerArgs);
     const config: AxiosRequestConfig = {
       url,
       method,
@@ -115,12 +132,25 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
     };
 
     const isGetLike = method === 'GET' || method === 'HEAD';
+    if (options.paginate && !isGetLike && !context.globalOptions.json) {
+      this.output.warning(
+        '--paginate only applies to GET/HEAD requests; ignoring it.'
+      );
+    }
+
     try {
       const response =
         options.paginate && isGetLike
           ? await this.fetchAllPages(config, headers)
           : await this.axios.request(config);
-      await this.renderBody(response.data, context);
+      if (options.include && !context.globalOptions.json) {
+        this.printResponseMeta(response);
+      }
+      await this.renderBody(
+        response.data,
+        context,
+        this.getContentType(response)
+      );
     } catch (error) {
       // Surface the API's error response body to stdout (like gh) in text mode;
       // in JSON mode the body rides along on APIError.toJSON() via the standard
@@ -138,8 +168,10 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
 
   /**
    * Resolve the leading positionals into a possible method verb and the
-   * endpoint. With two positionals the first is the method; with one it is the
-   * endpoint.
+   * endpoint. With two positionals the first must be an HTTP verb; with one it
+   * is the endpoint. Both ambiguous shapes (`bb api <path> <path>` and
+   * `bb api GET` with no endpoint) are rejected loudly rather than silently
+   * dropping an argument or requesting `/GET`.
    */
   private splitPositionals(options: ApiCommandOptions): {
     positionalMethod?: string;
@@ -151,6 +183,14 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
     if (options.endpoint !== undefined) {
       positionalMethod = options.methodOrEndpoint;
       endpointArg = options.endpoint;
+      if (positionalMethod !== undefined && !isHttpMethod(positionalMethod)) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: this.appendHelpHint(
+            `'${positionalMethod}' is not a valid HTTP method. Expected one of: ${HTTP_METHODS.join(', ')}.`
+          ),
+        });
+      }
     } else {
       endpointArg = options.methodOrEndpoint;
     }
@@ -160,6 +200,16 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
         code: ErrorCode.VALIDATION_REQUIRED,
         message: this.appendHelpHint(
           'An endpoint path is required (e.g. /user).'
+        ),
+      });
+    }
+
+    // A lone HTTP verb (`bb api GET`) is a missing endpoint, not a path.
+    if (positionalMethod === undefined && isHttpMethod(endpointArg)) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: this.appendHelpHint(
+          `An endpoint path is required after the method (e.g. bb api ${endpointArg.toUpperCase()} /user).`
         ),
       });
     }
@@ -266,27 +316,63 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
       next = getNextUrl(response.data);
     }
 
+    // first.status/headers are preserved, so -i/--include reflects the first
+    // page's status line and headers in --paginate mode.
     return { ...first, data: { values: collected } };
   }
 
   /**
+   * Print the HTTP status line and response headers (`-i/--include`), followed
+   * by a blank line, ahead of the body. Text mode only — callers guard on
+   * `!json` so the structured stream is never corrupted.
+   */
+  private printResponseMeta(response: AxiosResponse): void {
+    const statusText = response.statusText ? ` ${response.statusText}` : '';
+    this.output.text(`HTTP/1.1 ${response.status}${statusText}`);
+    const headers = (response.headers ?? {}) as Record<string, unknown>;
+    for (const [name, value] of Object.entries(headers)) {
+      this.output.text(`${name}: ${String(value)}`);
+    }
+    this.output.text('');
+  }
+
+  private getContentType(response: AxiosResponse): string | undefined {
+    const raw = (response.headers as Record<string, unknown> | undefined)?.[
+      'content-type'
+    ];
+    return typeof raw === 'string' ? raw : undefined;
+  }
+
+  /**
    * Render a response (or error) body. JSON payloads route through
-   * `output.json()` so `--json` field projection and `--jq` apply; non-JSON
-   * (string) bodies pass through verbatim.
+   * `output.json()` so `--json` field projection and `--jq` apply; genuinely
+   * non-JSON (string) bodies pass through verbatim. An empty body still emits
+   * `{}` in JSON mode so a downstream `jq` never receives zero bytes.
    */
   private async renderBody(
     data: unknown,
-    _context: CommandContext
+    context: CommandContext,
+    contentType?: string
   ): Promise<void> {
+    if (data === undefined || data === null || data === '') {
+      if (context.globalOptions.json) {
+        await this.output.json({});
+      }
+      return;
+    }
+
     if (typeof data === 'string') {
-      if (data.length > 0) {
+      // A string body with a JSON content-type is a JSON scalar (e.g. "hi") or
+      // an unparsed payload — quote it through json(). Missing/unknown
+      // content-types default to verbatim so raw diffs/patches print as-is.
+      if (contentType !== undefined && /\bjson\b/i.test(contentType)) {
+        await this.output.json(data);
+      } else {
         this.output.text(data);
       }
       return;
     }
-    if (data === undefined || data === null || data === '') {
-      return;
-    }
+
     await this.output.json(data);
   }
 
@@ -298,9 +384,12 @@ export class ApiCommand extends BaseCommand<ApiCommandOptions, void> {
     try {
       return fs.readFileSync(filePath, 'utf8');
     } catch (error) {
+      // Append the underlying reason (e.g. EACCES/EISDIR) that handleError
+      // would otherwise drop, so permission/dir mistakes are diagnosable.
+      const reason = error instanceof Error ? `: ${error.message}` : '';
       throw new BBError({
         code: ErrorCode.FILE_NOT_FOUND,
-        message: `Could not read file '${filePath}'.`,
+        message: `Could not read file '${filePath}'${reason}`,
         cause: error instanceof Error ? error : undefined,
         context: { path: filePath },
       });

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -160,8 +160,12 @@ export const ServiceTokens = {
   // Services - URL builder (Bitbucket web URL construction)
   UrlBuilderService: 'UrlBuilderService',
 
+  // Raw API passthrough (bb api)
+  ApiAxios: 'ApiAxios',
+
   // Commands - Top level
   BrowseCommand: 'BrowseCommand',
+  ApiCommand: 'ApiCommand',
 
   // Commands - PR
   CreatePRCommand: 'CreatePRCommand',

--- a/src/services/api-passthrough.ts
+++ b/src/services/api-passthrough.ts
@@ -1,0 +1,343 @@
+/**
+ * Pure helpers for the `bb api` raw passthrough command. Kept HTTP-free so the
+ * method resolution, field parsing, query/body distribution, placeholder
+ * substitution, endpoint host validation, and pagination accessors can be unit
+ * tested without an axios instance. The command in
+ * `src/commands/api.command.ts` wires these to the authenticated axios stack.
+ */
+
+import { BBError, ErrorCode } from '../types/errors.js';
+
+export const API_HOST = 'api.bitbucket.org';
+export const API_BASE_URL = 'https://api.bitbucket.org/2.0';
+
+export const HTTP_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+/**
+ * Whether `token` names an HTTP verb (case-insensitive). Used by the CLI to
+ * decide whether a leading positional is a method or the endpoint, so both
+ * `bb api GET /user` and `bb api /user` parse correctly.
+ */
+export function isHttpMethod(token: string): boolean {
+  return (HTTP_METHODS as readonly string[]).includes(token.toUpperCase());
+}
+
+/**
+ * Normalize a method string to a canonical `HttpMethod`, or `undefined` when it
+ * is not a supported verb.
+ */
+export function normalizeMethod(value: string): HttpMethod | undefined {
+  const upper = value.toUpperCase();
+  return (HTTP_METHODS as readonly string[]).includes(upper)
+    ? (upper as HttpMethod)
+    : undefined;
+}
+
+/**
+ * Resolve the effective HTTP method. Precedence mirrors `gh api`:
+ * explicit `-X/--method` > leading positional verb > inferred (`POST` when any
+ * field/body is present, otherwise `GET`).
+ */
+export function resolveMethod(opts: {
+  explicit?: string;
+  positional?: string;
+  hasParams: boolean;
+}): HttpMethod {
+  if (opts.explicit !== undefined) {
+    const method = normalizeMethod(opts.explicit);
+    if (!method) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `--method must be one of: ${HTTP_METHODS.join(', ')}`,
+        context: { method: opts.explicit },
+      });
+    }
+    return method;
+  }
+
+  if (opts.positional !== undefined) {
+    const method = normalizeMethod(opts.positional);
+    if (method) {
+      return method;
+    }
+  }
+
+  return opts.hasParams ? 'POST' : 'GET';
+}
+
+/**
+ * Split a `key=value` assignment used by `-f`/`-F`. Throws on a missing `=`.
+ */
+export function parseFieldAssignment(raw: string): {
+  key: string;
+  rawValue: string;
+} {
+  const idx = raw.indexOf('=');
+  if (idx <= 0) {
+    throw new BBError({
+      code: ErrorCode.VALIDATION_INVALID,
+      message: `Invalid field '${raw}'. Expected key=value.`,
+      context: { field: raw },
+    });
+  }
+  return { key: raw.slice(0, idx), rawValue: raw.slice(idx + 1) };
+}
+
+/**
+ * Apply `gh`-style magic typing to a typed-field (`-F`) value: `true`/`false`/
+ * `null` become their literals, integer/float strings become numbers, and
+ * everything else stays a string. File (`@file`) and stdin values are resolved
+ * by the command before reaching here and are passed through unchanged.
+ */
+export function magicType(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value === 'null') return null;
+  if (/^-?\d+$/.test(value)) {
+    const parsed = Number.parseInt(value, 10);
+    // Guard against precision loss on very large integers: if the round-trip
+    // doesn't match, keep the original string rather than a lossy number.
+    if (String(parsed) === value) {
+      return parsed;
+    }
+  }
+  if (/^-?\d*\.\d+$/.test(value)) {
+    return Number.parseFloat(value);
+  }
+  return value;
+}
+
+export interface FieldEntry {
+  key: string;
+  value: unknown;
+}
+
+/**
+ * Assemble field entries into an object. Repeated keys collapse into an array,
+ * matching `gh`'s behavior for multiple `-f`/`-F` with the same name.
+ */
+export function buildFieldObject(
+  entries: readonly FieldEntry[]
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const { key, value } of entries) {
+    if (Object.prototype.hasOwnProperty.call(result, key)) {
+      const existing = result[key];
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        result[key] = [existing, value];
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function stringifyScalar(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return '';
+  return String(value);
+}
+
+/**
+ * Serialize a field object into a `key=value&key=value` query string, repeating
+ * the key for array values and percent-encoding both sides.
+ */
+export function serializeQueryParams(params: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(params)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      parts.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(stringifyScalar(item))}`
+      );
+    }
+  }
+  return parts.join('&');
+}
+
+/**
+ * Decide where assembled fields / a raw body belong on the request. For GET and
+ * HEAD, fields become a query string; for other methods they become a JSON
+ * body. A raw `--input` body always wins (callers reject combining it with
+ * fields beforehand).
+ */
+export function buildRequestParts(input: {
+  method: HttpMethod;
+  fields: Record<string, unknown>;
+  rawBody?: string;
+}): { query?: string; data?: unknown } {
+  if (input.rawBody !== undefined) {
+    return { data: input.rawBody };
+  }
+
+  const keys = Object.keys(input.fields);
+  if (keys.length === 0) {
+    return {};
+  }
+
+  const isGetLike = input.method === 'GET' || input.method === 'HEAD';
+  if (isGetLike) {
+    return { query: serializeQueryParams(input.fields) };
+  }
+  return { data: input.fields };
+}
+
+export interface EndpointPlaceholders {
+  workspace: boolean;
+  repo: boolean;
+}
+
+/**
+ * Report which of `{workspace}` / `{repo}` appear in the endpoint, so the
+ * command only resolves repository context when it is actually needed.
+ */
+export function findPlaceholders(endpoint: string): EndpointPlaceholders {
+  return {
+    workspace: endpoint.includes('{workspace}'),
+    repo: endpoint.includes('{repo}'),
+  };
+}
+
+/**
+ * Substitute `{workspace}` and `{repo}` placeholders. Throws if a placeholder is
+ * present but no value was resolved.
+ */
+export function substitutePlaceholders(
+  endpoint: string,
+  values: { workspace?: string; repo?: string }
+): string {
+  let result = endpoint;
+  if (result.includes('{workspace}')) {
+    if (!values.workspace) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_WORKSPACE_NOT_FOUND,
+        message:
+          'Endpoint uses {workspace} but no workspace could be resolved. Pass --workspace or run inside a Bitbucket repo.',
+      });
+    }
+    result = result.replaceAll('{workspace}', values.workspace);
+  }
+  if (result.includes('{repo}')) {
+    if (!values.repo) {
+      throw new BBError({
+        code: ErrorCode.CONTEXT_REPO_NOT_FOUND,
+        message:
+          'Endpoint uses {repo} but no repository could be resolved. Pass --repo or run inside a Bitbucket repo.',
+      });
+    }
+    result = result.replaceAll('{repo}', values.repo);
+  }
+  return result;
+}
+
+/**
+ * Normalize a user-supplied endpoint into a request URL for the authenticated
+ * axios instance (whose baseURL is {@link API_BASE_URL}).
+ *
+ * - Absolute URLs are allowed ONLY for the Bitbucket API host. This is a
+ *   security boundary: the request interceptor attaches the user's Bitbucket
+ *   token to every call, so an arbitrary absolute URL would leak credentials to
+ *   a foreign host.
+ * - Relative paths get a leading slash; a redundant leading `2.0/` (the API
+ *   version already in the baseURL) is stripped so `/2.0/user` and `/user`
+ *   behave identically.
+ */
+export function normalizeEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+  if (trimmed === '') {
+    throw new BBError({
+      code: ErrorCode.VALIDATION_INVALID,
+      message: 'An endpoint path is required (e.g. /user).',
+    });
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url: URL;
+    try {
+      url = new URL(trimmed);
+    } catch {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `Invalid URL: ${trimmed}`,
+      });
+    }
+    if (url.host !== API_HOST) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `bb api only supports the Bitbucket API host (${API_HOST}); refusing to send credentials to ${url.host}.`,
+        context: { host: url.host },
+      });
+    }
+    return trimmed;
+  }
+
+  let path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  path = path.replace(/^\/2\.0(?=\/|$)/, '');
+  return path === '' ? '/' : path;
+}
+
+/**
+ * Pull the cursor `next` URL from a Bitbucket paginated payload, if present.
+ */
+export function getNextUrl(page: unknown): string | undefined {
+  if (page && typeof page === 'object' && !Array.isArray(page)) {
+    const next = (page as Record<string, unknown>).next;
+    if (typeof next === 'string' && next.length > 0) {
+      return next;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pull the `values` array from a Bitbucket paginated payload, if present.
+ */
+export function getValues(page: unknown): unknown[] | undefined {
+  if (page && typeof page === 'object' && !Array.isArray(page)) {
+    const values = (page as Record<string, unknown>).values;
+    if (Array.isArray(values)) {
+      return values;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Split a raw `Name: value` header. Throws on a missing colon.
+ */
+export function parseHeader(raw: string): { name: string; value: string } {
+  const idx = raw.indexOf(':');
+  if (idx <= 0) {
+    throw new BBError({
+      code: ErrorCode.VALIDATION_INVALID,
+      message: `Invalid header '${raw}'. Expected 'Name: value'.`,
+      context: { header: raw },
+    });
+  }
+  return { name: raw.slice(0, idx).trim(), value: raw.slice(idx + 1).trim() };
+}
+
+/**
+ * Parse repeated `-H` values into a header object. Later duplicates win.
+ */
+export function parseHeaders(raws: readonly string[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const raw of raws) {
+    const { name, value } = parseHeader(raw);
+    headers[name] = value;
+  }
+  return headers;
+}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -108,6 +108,16 @@ export class APIError extends BBError {
     this.response = response;
   }
 
+  public toJSON(): Record<string, unknown> {
+    return {
+      ...super.toJSON(),
+      statusCode: this.statusCode,
+      ...(this.response !== undefined && this.response !== null
+        ? { response: this.response }
+        : {}),
+    };
+  }
+
   private static statusToErrorCode(status: number): ErrorCode {
     switch (status) {
       case 401:

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -498,6 +498,7 @@ describe('CLI command registration', () => {
   it('should register all top-level commands', () => {
     const names = cli.commands.map((command) => command.name()).sort();
     expect(names).toEqual([
+      'api',
       'auth',
       'browse',
       'completion',

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'bun:test';
 import type { Command } from 'commander';
 import {
+  createContext,
   extractLocaleArg,
   getCompletionParent,
   resolveNoColorSetting,
@@ -13,6 +14,25 @@ import {
 } from '../src/cli.js';
 import { cli } from '../src/cli.js';
 import type { CommandContext } from '../src/core/interfaces/commands.js';
+
+describe('createContext --jq / --json validation', () => {
+  const fakeProgram = (opts: Record<string, unknown>): Command =>
+    ({ opts: () => opts }) as unknown as Command;
+
+  it('rejects --jq without --json by default', () => {
+    const context = createContext(fakeProgram({ jq: '.x' }));
+    expect(context.validationError).toBeDefined();
+    expect(context.validationError?.message).toContain('--jq requires --json');
+  });
+
+  it('allows --jq without --json when allowJqWithoutJson is set (bb api)', () => {
+    const context = createContext(fakeProgram({ jq: '.x' }), {
+      allowJqWithoutJson: true,
+    });
+    expect(context.validationError).toBeUndefined();
+    expect(context.globalOptions.jq).toBe('.x');
+  });
+});
 
 describe('withGlobalOptions', () => {
   it('should use global workspace when local is not provided', () => {

--- a/tests/commands/api.test.ts
+++ b/tests/commands/api.test.ts
@@ -238,4 +238,99 @@ describe('ApiCommand', () => {
 
     expect(output.logs.some((l) => l.startsWith('json:'))).toBe(false);
   });
+
+  it('rejects two positionals when the first is not an HTTP verb', async () => {
+    const { command, axios } = makeCommand(() => ({ data: {} }));
+
+    await expect(
+      command.execute(
+        { methodOrEndpoint: '/repositories/a', endpoint: '/repositories/b' },
+        ctx
+      )
+    ).rejects.toThrow(BBError);
+    expect(axios.calls).toHaveLength(0);
+  });
+
+  it('rejects a lone HTTP verb with no endpoint', async () => {
+    const { command } = makeCommand(() => ({ data: {} }));
+
+    await expect(
+      command.execute({ methodOrEndpoint: 'GET' }, ctx)
+    ).rejects.toThrow(BBError);
+    await expect(
+      command.execute({ methodOrEndpoint: 'delete' }, ctx)
+    ).rejects.toThrow(BBError);
+  });
+
+  it('rejects a user-supplied Authorization header', async () => {
+    const { command, axios } = makeCommand(() => ({ data: {} }));
+
+    await expect(
+      command.execute(
+        { methodOrEndpoint: '/user', header: ['Authorization: Bearer x'] },
+        ctx
+      )
+    ).rejects.toThrow(BBError);
+    expect(axios.calls).toHaveLength(0);
+  });
+
+  it('warns when --paginate is used on a non-GET method', async () => {
+    const { command, axios, output } = makeCommand(() => ({ data: { id: 1 } }));
+
+    await command.execute(
+      { methodOrEndpoint: '/x', method: 'POST', paginate: true },
+      ctx
+    );
+
+    expect(axios.calls).toHaveLength(1);
+    expect(axios.calls[0]!.method).toBe('POST');
+    expect(
+      output.logs.some(
+        (l) => l.startsWith('warning:') && l.includes('--paginate')
+      )
+    ).toBe(true);
+  });
+
+  it('emits {} for an empty body in JSON mode', async () => {
+    const { command, output } = makeCommand(() => ({ data: '' }));
+
+    await command.execute({ methodOrEndpoint: '/x' }, jsonCtx);
+
+    expect(output.logs).toContain('json:{}');
+  });
+
+  it('prints nothing for an empty body in text mode', async () => {
+    const { command, output } = makeCommand(() => ({ data: '' }));
+
+    await command.execute({ methodOrEndpoint: '/x' }, ctx);
+
+    expect(output.logs.some((l) => l.startsWith('json:'))).toBe(false);
+    expect(output.logs.some((l) => l.startsWith('text:'))).toBe(false);
+  });
+
+  it('prints the status line and headers with -i/--include', async () => {
+    const { command, output } = makeCommand(() => ({
+      data: { ok: true },
+      status: 200,
+      headers: { 'content-type': 'application/json', 'x-test': '1' },
+    }));
+
+    await command.execute({ methodOrEndpoint: '/user', include: true }, ctx);
+
+    expect(output.logs).toContain('text:HTTP/1.1 200 OK');
+    expect(output.logs).toContain('text:x-test: 1');
+    expect(output.logs).toContain('json:{"ok":true}');
+  });
+
+  it('quotes a JSON-string body when content-type is application/json', async () => {
+    const { command, output } = makeCommand(() => ({
+      data: 'hello',
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    await command.execute({ methodOrEndpoint: '/x' }, ctx);
+
+    expect(output.logs).toContain('json:"hello"');
+    expect(output.logs.some((l) => l.startsWith('text:'))).toBe(false);
+  });
 });

--- a/tests/commands/api.test.ts
+++ b/tests/commands/api.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the `bb api` raw passthrough command.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { ApiCommand } from '../../src/commands/api.command.js';
+import type { CommandContext } from '../../src/core/interfaces/commands.js';
+import { APIError, BBError } from '../../src/types/errors.js';
+import { createMockContextService, createMockOutputService } from '../setup.js';
+
+interface MockAxios {
+  instance: AxiosInstance;
+  calls: AxiosRequestConfig[];
+}
+
+type Responder = (
+  config: AxiosRequestConfig,
+  callIndex: number
+) => { data: unknown; status?: number; headers?: Record<string, string> };
+
+function createMockAxios(responder: Responder): MockAxios {
+  const calls: AxiosRequestConfig[] = [];
+  const instance = {
+    async request(config: AxiosRequestConfig) {
+      calls.push(config);
+      const result = responder(config, calls.length);
+      return {
+        data: result.data,
+        status: result.status ?? 200,
+        statusText: 'OK',
+        headers: result.headers ?? {},
+        config,
+      };
+    },
+  } as unknown as AxiosInstance;
+  return { instance, calls };
+}
+
+const ctx: CommandContext = { globalOptions: {} };
+const jsonCtx: CommandContext = { globalOptions: { json: true } };
+
+function makeCommand(responder: Responder) {
+  const axios = createMockAxios(responder);
+  const output = createMockOutputService();
+  const context = createMockContextService({
+    workspace: 'ws',
+    repoSlug: 'repo',
+  });
+  const command = new ApiCommand(axios.instance, context, output);
+  return { command, axios, output };
+}
+
+describe('ApiCommand', () => {
+  it('performs a GET by default and prints JSON', async () => {
+    const { command, axios, output } = makeCommand(() => ({
+      data: { username: 'me' },
+    }));
+
+    await command.execute({ methodOrEndpoint: '/user' }, ctx);
+
+    expect(axios.calls).toHaveLength(1);
+    expect(axios.calls[0]!.method).toBe('GET');
+    expect(axios.calls[0]!.url).toBe('/user');
+    expect(axios.calls[0]!.data).toBeUndefined();
+    expect(output.logs).toContain('json:{"username":"me"}');
+  });
+
+  it('accepts a leading positional method', async () => {
+    const { command, axios } = makeCommand(() => ({ data: {} }));
+
+    await command.execute({ methodOrEndpoint: 'GET', endpoint: '/user' }, ctx);
+
+    expect(axios.calls[0]!.method).toBe('GET');
+    expect(axios.calls[0]!.url).toBe('/user');
+  });
+
+  it('infers POST and sends a JSON body when fields are present', async () => {
+    const { command, axios } = makeCommand(() => ({ data: { id: 1 } }));
+
+    await command.execute(
+      {
+        methodOrEndpoint: '/repositories/ws/repo/issues',
+        rawField: ['title=Bug'],
+        field: ['priority=3', 'confidential=true'],
+      },
+      ctx
+    );
+
+    expect(axios.calls[0]!.method).toBe('POST');
+    expect(axios.calls[0]!.data).toEqual({
+      title: 'Bug',
+      priority: 3,
+      confidential: true,
+    });
+  });
+
+  it('sends fields as a query string on an explicit GET', async () => {
+    const { command, axios } = makeCommand(() => ({ data: {} }));
+
+    await command.execute(
+      { methodOrEndpoint: '/search', method: 'GET', rawField: ['q=foo bar'] },
+      ctx
+    );
+
+    expect(axios.calls[0]!.method).toBe('GET');
+    expect(axios.calls[0]!.url).toBe('/search?q=foo%20bar');
+    expect(axios.calls[0]!.data).toBeUndefined();
+  });
+
+  it('rejects --input combined with fields', async () => {
+    const { command } = makeCommand(() => ({ data: {} }));
+
+    await expect(
+      command.execute(
+        { methodOrEndpoint: '/x', input: 'body.json', rawField: ['a=b'] },
+        ctx
+      )
+    ).rejects.toThrow(BBError);
+  });
+
+  it('substitutes {workspace}/{repo} from context', async () => {
+    const { command, axios } = makeCommand(() => ({ data: { values: [] } }));
+
+    await command.execute(
+      { methodOrEndpoint: '/repositories/{workspace}/{repo}/pullrequests' },
+      ctx
+    );
+
+    expect(axios.calls[0]!.url).toBe('/repositories/ws/repo/pullrequests');
+  });
+
+  it('follows pagination and merges values', async () => {
+    const { command, axios, output } = makeCommand((config, index) => {
+      if (index === 1) {
+        return {
+          data: {
+            values: [{ id: 1 }, { id: 2 }],
+            next: 'https://api.bitbucket.org/2.0/repositories/ws?page=2',
+          },
+        };
+      }
+      return { data: { values: [{ id: 3 }] } };
+    });
+
+    await command.execute(
+      { methodOrEndpoint: '/repositories/ws', paginate: true },
+      ctx
+    );
+
+    expect(axios.calls).toHaveLength(2);
+    expect(axios.calls[1]!.url).toBe(
+      'https://api.bitbucket.org/2.0/repositories/ws?page=2'
+    );
+    expect(output.logs).toContain(
+      'json:{"values":[{"id":1},{"id":2},{"id":3}]}'
+    );
+  });
+
+  it('warns and returns the first page when --paginate hits a non-list', async () => {
+    const { command, axios, output } = makeCommand(() => ({
+      data: { username: 'me' },
+    }));
+
+    await command.execute({ methodOrEndpoint: '/user', paginate: true }, ctx);
+
+    expect(axios.calls).toHaveLength(1);
+    expect(output.logs).toContain('json:{"username":"me"}');
+    expect(output.logs.some((l) => l.startsWith('warning:'))).toBe(true);
+  });
+
+  it('passes custom headers through', async () => {
+    const { command, axios } = makeCommand(() => ({ data: {} }));
+
+    await command.execute(
+      { methodOrEndpoint: '/user', header: ['Accept: application/json'] },
+      ctx
+    );
+
+    expect(axios.calls[0]!.headers).toEqual({ Accept: 'application/json' });
+  });
+
+  it('prints a non-JSON (string) response verbatim', async () => {
+    const { command, output } = makeCommand(() => ({
+      data: 'diff --git a/x b/x',
+    }));
+
+    await command.execute(
+      { methodOrEndpoint: '/repositories/ws/repo/diff' },
+      ctx
+    );
+
+    expect(output.logs).toContain('text:diff --git a/x b/x');
+    expect(output.logs.some((l) => l.startsWith('json:'))).toBe(false);
+  });
+
+  it('requires an endpoint', async () => {
+    const { command } = makeCommand(() => ({ data: {} }));
+
+    await expect(command.execute({}, ctx)).rejects.toThrow(BBError);
+  });
+
+  it('rejects an absolute URL to a foreign host', async () => {
+    const { command } = makeCommand(() => ({ data: {} }));
+
+    await expect(
+      command.execute({ methodOrEndpoint: 'https://evil.example.com/x' }, ctx)
+    ).rejects.toThrow(BBError);
+  });
+
+  it('surfaces the API error body to stdout in text mode, then rethrows', async () => {
+    const { command, output } = makeCommand(() => {
+      throw new APIError('Not found', 404, {
+        type: 'error',
+        error: { message: 'Repository not found' },
+      });
+    });
+
+    await expect(
+      command.execute({ methodOrEndpoint: '/repositories/ws/missing' }, ctx)
+    ).rejects.toThrow(APIError);
+
+    expect(
+      output.logs.some(
+        (l) => l.startsWith('json:') && l.includes('Repository not found')
+      )
+    ).toBe(true);
+  });
+
+  it('does not pre-print the error body in JSON mode', async () => {
+    const { command, output } = makeCommand(() => {
+      throw new APIError('Not found', 404, { error: { message: 'nope' } });
+    });
+
+    await expect(
+      command.execute({ methodOrEndpoint: '/repositories/ws/missing' }, jsonCtx)
+    ).rejects.toThrow(APIError);
+
+    expect(output.logs.some((l) => l.startsWith('json:'))).toBe(false);
+  });
+});

--- a/tests/services/api-passthrough.test.ts
+++ b/tests/services/api-passthrough.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the pure `bb api` passthrough helpers.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  buildFieldObject,
+  buildRequestParts,
+  findPlaceholders,
+  getNextUrl,
+  getValues,
+  isHttpMethod,
+  magicType,
+  normalizeEndpoint,
+  normalizeMethod,
+  parseFieldAssignment,
+  parseHeader,
+  parseHeaders,
+  resolveMethod,
+  serializeQueryParams,
+  substitutePlaceholders,
+} from '../../src/services/api-passthrough.js';
+import { BBError } from '../../src/types/errors.js';
+
+describe('method helpers', () => {
+  it('detects HTTP verbs case-insensitively', () => {
+    expect(isHttpMethod('get')).toBe(true);
+    expect(isHttpMethod('POST')).toBe(true);
+    expect(isHttpMethod('/user')).toBe(false);
+    expect(isHttpMethod('repositories')).toBe(false);
+  });
+
+  it('normalizes valid verbs and rejects others', () => {
+    expect(normalizeMethod('patch')).toBe('PATCH');
+    expect(normalizeMethod('frobnicate')).toBeUndefined();
+  });
+
+  it('honors precedence: explicit > positional > inferred', () => {
+    expect(
+      resolveMethod({ explicit: 'delete', positional: 'GET', hasParams: true })
+    ).toBe('DELETE');
+    expect(resolveMethod({ positional: 'PUT', hasParams: false })).toBe('PUT');
+    expect(resolveMethod({ hasParams: true })).toBe('POST');
+    expect(resolveMethod({ hasParams: false })).toBe('GET');
+  });
+
+  it('throws on an invalid explicit method', () => {
+    expect(() => resolveMethod({ explicit: 'nope', hasParams: false })).toThrow(
+      BBError
+    );
+  });
+});
+
+describe('field parsing', () => {
+  it('splits key=value and rejects missing =', () => {
+    expect(parseFieldAssignment('title=Bug')).toEqual({
+      key: 'title',
+      rawValue: 'Bug',
+    });
+    expect(parseFieldAssignment('a=b=c')).toEqual({
+      key: 'a',
+      rawValue: 'b=c',
+    });
+    expect(() => parseFieldAssignment('noequals')).toThrow(BBError);
+    expect(() => parseFieldAssignment('=novalue')).toThrow(BBError);
+  });
+
+  it('applies gh-style magic typing', () => {
+    expect(magicType('true')).toBe(true);
+    expect(magicType('false')).toBe(false);
+    expect(magicType('null')).toBeNull();
+    expect(magicType('42')).toBe(42);
+    expect(magicType('-7')).toBe(-7);
+    expect(magicType('3.14')).toBe(3.14);
+    expect(magicType('hello')).toBe('hello');
+  });
+
+  it('keeps oversized integers as strings to avoid precision loss', () => {
+    const big = '123456789012345678901234567890';
+    expect(magicType(big)).toBe(big);
+  });
+
+  it('collapses repeated keys into arrays', () => {
+    const obj = buildFieldObject([
+      { key: 'label', value: 'a' },
+      { key: 'label', value: 'b' },
+      { key: 'title', value: 'x' },
+    ]);
+    expect(obj).toEqual({ label: ['a', 'b'], title: 'x' });
+  });
+});
+
+describe('query / body distribution', () => {
+  it('serializes query params with repeated keys', () => {
+    expect(serializeQueryParams({ q: 'a b', n: 2 })).toBe('q=a%20b&n=2');
+    expect(serializeQueryParams({ k: ['a', 'b'] })).toBe('k=a&k=b');
+    expect(serializeQueryParams({ k: null })).toBe('k=null');
+  });
+
+  it('routes fields to query for GET and to body otherwise', () => {
+    expect(buildRequestParts({ method: 'GET', fields: { q: 'x' } })).toEqual({
+      query: 'q=x',
+    });
+    expect(
+      buildRequestParts({ method: 'POST', fields: { title: 'x' } })
+    ).toEqual({ data: { title: 'x' } });
+  });
+
+  it('prefers a raw body over fields', () => {
+    expect(
+      buildRequestParts({ method: 'PUT', fields: {}, rawBody: '{"a":1}' })
+    ).toEqual({ data: '{"a":1}' });
+  });
+
+  it('returns nothing when there are no fields or body', () => {
+    expect(buildRequestParts({ method: 'GET', fields: {} })).toEqual({});
+  });
+});
+
+describe('endpoint handling', () => {
+  it('adds a leading slash to relative paths', () => {
+    expect(normalizeEndpoint('user')).toBe('/user');
+    expect(normalizeEndpoint('/user')).toBe('/user');
+  });
+
+  it('strips a redundant leading /2.0', () => {
+    expect(normalizeEndpoint('/2.0/user')).toBe('/user');
+    expect(normalizeEndpoint('2.0/repositories')).toBe('/repositories');
+  });
+
+  it('allows absolute URLs only for the Bitbucket API host', () => {
+    expect(normalizeEndpoint('https://api.bitbucket.org/2.0/user')).toBe(
+      'https://api.bitbucket.org/2.0/user'
+    );
+    expect(() => normalizeEndpoint('https://evil.example.com/x')).toThrow(
+      BBError
+    );
+  });
+
+  it('rejects an empty endpoint', () => {
+    expect(() => normalizeEndpoint('   ')).toThrow(BBError);
+  });
+
+  it('finds and substitutes placeholders', () => {
+    expect(findPlaceholders('/repositories/{workspace}/{repo}')).toEqual({
+      workspace: true,
+      repo: true,
+    });
+    expect(
+      substitutePlaceholders('/repositories/{workspace}/{repo}/pullrequests', {
+        workspace: 'ws',
+        repo: 'r',
+      })
+    ).toBe('/repositories/ws/r/pullrequests');
+  });
+
+  it('throws when a placeholder cannot be resolved', () => {
+    expect(() =>
+      substitutePlaceholders('/repositories/{workspace}', {})
+    ).toThrow(BBError);
+    expect(() =>
+      substitutePlaceholders('/repositories/{workspace}/{repo}', {
+        workspace: 'ws',
+      })
+    ).toThrow(BBError);
+  });
+});
+
+describe('pagination accessors', () => {
+  it('reads next and values from a page', () => {
+    const page = {
+      values: [1, 2],
+      next: 'https://api.bitbucket.org/2.0/x?page=2',
+    };
+    expect(getValues(page)).toEqual([1, 2]);
+    expect(getNextUrl(page)).toBe('https://api.bitbucket.org/2.0/x?page=2');
+  });
+
+  it('returns undefined for non-paginated payloads', () => {
+    expect(getValues({ username: 'x' })).toBeUndefined();
+    expect(getNextUrl({ username: 'x' })).toBeUndefined();
+    expect(getValues([1, 2])).toBeUndefined();
+    expect(getNextUrl('not an object')).toBeUndefined();
+  });
+});
+
+describe('header parsing', () => {
+  it('splits Name: value and trims', () => {
+    expect(parseHeader('Accept: text/plain')).toEqual({
+      name: 'Accept',
+      value: 'text/plain',
+    });
+    expect(() => parseHeader('no-colon')).toThrow(BBError);
+  });
+
+  it('builds a header object with later duplicates winning', () => {
+    expect(parseHeaders(['Accept: a', 'Accept: b', 'X-Test: 1'])).toEqual({
+      Accept: 'b',
+      'X-Test': '1',
+    });
+  });
+});

--- a/tests/types/errors.test.ts
+++ b/tests/types/errors.test.ts
@@ -285,10 +285,17 @@ describe('APIError.statusToErrorCode mapping', () => {
     expect(json.code).toBe(ErrorCode.API_SERVER_ERROR);
     expect(json.message).toBe('boom');
     expect(json.context).toEqual({ url: '/x' });
-    // The raw response and statusCode are intentionally not in toJSON() —
-    // pin that behavior so a future change is deliberate.
-    expect(json).not.toHaveProperty('statusCode');
+    // toJSON() includes statusCode so `--json` error output (notably from
+    // `bb api`) carries the HTTP status. A null response is omitted.
+    expect(json.statusCode).toBe(500);
     expect(json).not.toHaveProperty('response');
+  });
+
+  it('includes the response payload in toJSON when present', () => {
+    const payload = { error: { message: 'Not found' } };
+    const json = new APIError('Not found', 404, payload).toJSON();
+    expect(json.statusCode).toBe(404);
+    expect(json.response).toEqual(payload);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `bb api`, a raw authenticated passthrough to the Bitbucket Cloud 2.0 API — the escape hatch for endpoints not yet wrapped by a typed command. It reuses the existing authenticated axios stack (`createApiClient`): Basic/Bearer auth, proactive + reactive OAuth refresh, 429/5xx retry with backoff, and secret redaction. Mirrors `gh api`.

Closes #248.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Changes

- **`bb api [method] <endpoint>`** — method may be a leading positional verb (`bb api GET /user`) or path-only (`bb api /user`); `-X/--method` overrides. Defaults to `GET`, or `POST` when fields/body are present. Ambiguous shapes (`bb api /a /b`, lone `bb api GET`) are rejected loudly.
- **`-f/--raw-field`** (string) and **`-F/--field`** (typed: `true`/`false`/`null`, numbers, `@file`, `@-` for stdin). On `GET`/`HEAD` fields become query params; otherwise a JSON body. Repeated keys collapse into arrays.
- **`--input <file>`** reads a raw request body (`-` for stdin), sent as `application/json`; mutually exclusive with `-f`/`-F`.
- **`-H/--header`** adds request headers; a user-supplied `Authorization` is rejected since auth is managed.
- **`-i/--include`** prints the HTTP status line and response headers before the body (text mode only).
- **`--paginate`** follows the cursor (`next`) and merges every page's `values` into a single `{ "values": [...] }`; warns if used on a non-GET method.
- **`{workspace}`/`{repo}`** placeholders are filled from `--workspace`/`--repo` or the current repo (context resolved only when a placeholder is present).
- **`--json [fields]`** and **`--jq`** apply to the response; because `bb api` output is already JSON, `--jq` works **without** `--json`. Non-JSON bodies (e.g. raw diffs) print verbatim; an empty body emits `{}` under `--json`. API error responses are surfaced; `APIError.toJSON()` now carries `statusCode` and the response body.
- **Security:** absolute URLs are restricted to `api.bitbucket.org` so the auth token is never sent to a foreign host (pagination cursors validated the same way).
- New DI tokens `ApiAxios` + `ApiCommand` (mirrors the `SnippetsAxios` pattern); `api` added to shell completions with verb completion.
- **Docs:** new `commands/api.mdx` reference + sidebar entry, and `bb api` surfaced across changelog, FAQ, quickstart, index, scripting guide, AI-agents cheat sheets, and README.

## Testing

- [x] `bun test` passes (**1125 pass / 0 fail**; new tests across `tests/services/api-passthrough.test.ts`, `tests/commands/api.test.ts`, `tests/cli.test.ts`)
- [x] `bun run lint` passes
- [x] `bun run format:check` passes (pre-commit hook)
- [x] `bun run docs:build` passes (38 pages)
- [x] Manually exercised `bb api --help` and the validation/error paths

## Changeset

- [x] I ran the changeset workflow and committed the file (`minor`)

## Checklist

- [x] Branch is named `feat/...`
- [x] No edits to `src/generated/`
- [x] Output uses `IOutputService` (no `console.*`)
- [x] Expected failures use `BBError` / `ErrorCode`
- [x] Docs updated (`commands/api.mdx` + ecosystem)

## Implementation notes

- Pure, HTTP-free helpers live in `src/services/api-passthrough.ts` (method resolution, field parsing, query/body split, placeholder substitution, endpoint host validation, pagination accessors) and are unit-tested directly; `ApiCommand` wires them to the authenticated axios instance.
- The first commit adds the feature; the second applies UX + docs polish from an adversarial multi-agent audit (see the PR comment for the breakdown and the items deliberately left out).
