### PR TITLE
feat: dependency automation + `auth login --with-token` stdin flow

### DIFF
--- a/.changeset/auth-login-with-token.md
+++ b/.changeset/auth-login-with-token.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `bb auth login --with-token` to read an API token from stdin, so secrets never appear in shell history or `ps` output the way `-p, --password` does. Pipe the token in, e.g. `echo "$BB_API_TOKEN" | bb auth login -u myuser --with-token` — it pairs well with secret managers. Combining `--with-token` with `--password` is rejected, and an empty stdin produces a clear error. Docs also now note that OAuth requires a loopback browser (`http://localhost:19872/callback`) with no device-code flow, so headless users know to use token auth.

--- a/docs/src/content/docs/commands/auth.mdx
+++ b/docs/src/content/docs/commands/auth.mdx
@@ -21,6 +21,7 @@ bb auth login [options]
 |--------|-------------|
 | `-u, --username <username>` | Bitbucket username (implies API token auth) |
 | `-p, --password <password>` | Bitbucket API token (implies API token auth) |
+| `--with-token` | Read the API token from stdin so it never appears in shell history or process args (implies API token auth) |
 | `--app-password` | Use API token authentication instead of OAuth (legacy flag name — uses API tokens, not app passwords) |
 | `--client-id <clientId>` | Custom OAuth consumer client ID |
 | `--client-secret <clientSecret>` | Custom OAuth consumer client secret |
@@ -38,11 +39,21 @@ bb auth login --client-id YOUR_KEY --client-secret YOUR_SECRET
 # Login with API token
 bb auth login -u myuser -p your-api-token
 
+# Login by piping the token via stdin (keeps it out of shell history and `ps`)
+echo "$BB_API_TOKEN" | bb auth login -u myuser --with-token
+
 # Login using environment variables (API token)
 export BB_USERNAME=myuser
 export BB_API_TOKEN=your-api-token
 bb auth login
 ```
+
+:::tip
+`--with-token` is the safest way to pass a token. Unlike `-p`, the token is
+read from stdin, so it never lands in your shell history or in process-listing
+tools like `ps`. It pairs well with secret managers, e.g.
+`my-secret-tool get bb-token | bb auth login -u myuser --with-token`.
+:::
 
 ### How It Works
 
@@ -55,9 +66,17 @@ bb auth login
 5. Tokens are stored in your config file
 6. Access tokens expire after 2 hours and are refreshed automatically
 
-**API token flow (with `-u`/`-p` or `--app-password`):**
+:::note
+The OAuth flow needs a browser that can reach a loopback callback server on
+`http://localhost:19872/callback`. There is **no device-code flow**, so on
+headless hosts (SSH sessions, containers, CI) use API token auth — ideally
+`--with-token` — instead.
+:::
 
-1. You provide your Bitbucket username and API token
+**API token flow (with `-u`/`-p`, `--with-token`, or `--app-password`):**
+
+1. You provide your Bitbucket username and API token (token via `-p`, piped to
+   stdin with `--with-token`, or the `BB_API_TOKEN` environment variable)
 2. The CLI stores the credentials in your config file
 3. The CLI verifies the credentials by fetching your user information
 4. If verification fails, credentials are not saved
@@ -70,6 +89,7 @@ The CLI determines which flow to use based on flags:
 |-----------|------------|
 | No flags | OAuth |
 | `-u` or `-p` provided | API Token |
+| `--with-token` flag | API Token (read from stdin) |
 | `--app-password` flag | API Token |
 | `BB_API_TOKEN` env var set | API Token |
 

--- a/docs/src/content/docs/getting-started/authentication.mdx
+++ b/docs/src/content/docs/getting-started/authentication.mdx
@@ -21,6 +21,10 @@ This opens your browser where you authorize the CLI with your Bitbucket account.
 OAuth tokens expire after 2 hours but are refreshed automatically — you won't be interrupted.
 </Aside>
 
+<Aside type="caution">
+OAuth needs a browser that can reach a loopback callback server on `http://localhost:19872/callback`. There is **no device-code flow**, so if you're on a headless host (SSH session, container, CI runner) where no browser is available, use an [API token](#api-token-for-cicd-and-headless-environments) instead.
+</Aside>
+
 ### Using a Custom OAuth Consumer
 
 Organizations can use their own OAuth consumer instead of the built-in default:
@@ -72,6 +76,13 @@ Use API tokens when a browser is not available (SSH sessions, Docker containers,
    bb auth login -u your-username -p your-api-token
    ```
 
+   Or pipe the token via stdin so it never lands in your shell history or
+   `ps` output (recommended, and great with secret managers):
+
+   ```bash
+   echo "$BB_API_TOKEN" | bb auth login -u your-username --with-token
+   ```
+
    Or using environment variables:
 
    ```bash
@@ -81,6 +92,10 @@ Use API tokens when a browser is not available (SSH sessions, Docker containers,
    ```
 
 </Steps>
+
+<Aside type="tip">
+Prefer `--with-token` or `BB_API_TOKEN` over `-p` in scripts and CI. Passing a secret as a command-line argument leaves it visible in shell history and to anyone who can list processes (`ps`).
+</Aside>
 
 See [Environment Variables Reference](/reference/environment-variables/) for more details on using environment variables in scripts and CI/CD.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Automated dependency updates for the Bitbucket CLI. Renovate is used instead of Dependabot because it understands Bun's `bun.lock` and updates the manifest + lockfile together. It auto-discovers both package manifests (root and docs/), keeps the SHA-pinned GitHub Actions current, and bumps the pinned Bun runtime used across the CI workflows.",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Europe/Brussels",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 8,
+  "prHourlyLimit": 3,
+  "lockFileMaintenance": {
+    "description": "Refresh transitive dependencies in bun.lock (root + docs/) once a month.",
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  },
+  "vulnerabilityAlerts": {
+    "description": "Security fixes bypass the weekly schedule so they land as soon as they are available.",
+    "labels": ["dependencies", "security"],
+    "schedule": ["at any time"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the pinned `BUN_VERSION` used by every GitHub Actions workflow against Bun's GitHub releases.",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": ["BUN_VERSION:\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "oven-sh/bun",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^bun-v(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Batch all non-major npm updates (root + docs/) into a single low-risk PR; existing CI gates them.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "description": "Major npm updates each get their own labelled PR so breaking changes are reviewed deliberately.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-update"]
+    },
+    {
+      "description": "Keep the SHA-pinned GitHub Actions current in their own grouped PR.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "semanticCommitType": "ci",
+      "addLabels": ["github-actions"]
+    },
+    {
+      "description": "Surface the Bun runtime bump on its own PR — it changes the CI/test matrix and warrants a deliberate look.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["oven-sh/bun"],
+      "groupName": "bun runtime",
+      "semanticCommitType": "ci",
+      "addLabels": ["bun"]
+    }
+  ]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -464,6 +464,10 @@ authCmd
     '--app-password',
     'Use API token authentication (instead of OAuth). App passwords are deprecated; use API tokens.'
   )
+  .option(
+    '--with-token',
+    'Read the API token from stdin (keeps it out of shell history and process args)'
+  )
   .option('--client-id <clientId>', 'Custom OAuth consumer client ID')
   .option(
     '--client-secret <clientSecret>',
@@ -473,6 +477,9 @@ authCmd
     'before',
     '\nDefault: OAuth (browser-based, recommended).\n' +
       'For CI/CD: API token via --app-password or BB_API_TOKEN env var.\n' +
+      'For headless/secret-safe: pipe the token in with --with-token.\n' +
+      'OAuth needs a loopback browser (http://localhost:19872/callback); there\n' +
+      'is no device-code flow, so use token auth on headless hosts.\n' +
       'Note: Bitbucket app passwords are deprecated; use OAuth or an API token.\n'
   )
   .addHelpText(
@@ -481,6 +488,7 @@ authCmd
       examples: [
         'bb auth login',
         'bb auth login --app-password -u myuser -p mytoken',
+        'echo "$BB_API_TOKEN" | bb auth login -u myuser --with-token',
         'bb auth login --client-id <id>',
         'BB_USERNAME=myuser BB_API_TOKEN=mytoken bb auth login',
       ],

--- a/src/commands/auth/login.command.ts
+++ b/src/commands/auth/login.command.ts
@@ -16,6 +16,7 @@ export interface LoginOptions {
   username?: string;
   password?: string;
   appPassword?: boolean;
+  withToken?: boolean;
   clientId?: string;
   clientSecret?: string;
 }
@@ -39,6 +40,7 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
   ): Promise<void> {
     const useAppPassword =
       options.appPassword ||
+      options.withToken ||
       options.username !== undefined ||
       options.password !== undefined ||
       process.env.BB_API_TOKEN !== undefined;
@@ -89,7 +91,6 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
     context: CommandContext
   ): Promise<void> {
     const username = options.username || process.env.BB_USERNAME;
-    const apiToken = options.password || process.env.BB_API_TOKEN;
 
     if (!username) {
       throw new BBError({
@@ -98,6 +99,8 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
           'Username is required. Use --username option or set BB_USERNAME environment variable.',
       });
     }
+
+    const apiToken = await this.resolveApiToken(options);
 
     if (!apiToken) {
       throw new BBError({
@@ -135,6 +138,48 @@ export class LoginCommand extends BaseCommand<LoginOptions, void> {
       await this.credentialStore.clearCredentials();
       throw this.wrapLoginError(error);
     }
+  }
+
+  /**
+   * Resolve the API token for the app-password flow. With `--with-token` the
+   * token is read from stdin so it never appears in shell history, `ps`
+   * output, or process args; otherwise it comes from `--password` or the
+   * `BB_API_TOKEN` environment variable.
+   */
+  private async resolveApiToken(
+    options: LoginOptions
+  ): Promise<string | undefined> {
+    if (!options.withToken) {
+      return options.password || process.env.BB_API_TOKEN;
+    }
+
+    if (options.password !== undefined) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message:
+          'Cannot combine --password with --with-token. With --with-token the API token is read from stdin.',
+      });
+    }
+
+    const token = (await this.readTokenFromStdin()).trim();
+
+    if (!token) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message:
+          'No API token found on stdin. Pipe a token, e.g. `echo "$BB_API_TOKEN" | bb auth login -u <username> --with-token`.',
+      });
+    }
+
+    return token;
+  }
+
+  /**
+   * Read the API token from stdin. Extracted into its own method so tests can
+   * stub stdin without a real pipe; mirrors the stdin read in `api.command.ts`.
+   */
+  protected async readTokenFromStdin(): Promise<string> {
+    return Bun.stdin.text();
   }
 
   private wrapLoginError(error: unknown): BBError {

--- a/tests/commands/auth.test.ts
+++ b/tests/commands/auth.test.ts
@@ -41,6 +41,14 @@ function restoreEnv(key: string, original: string | undefined): void {
   }
 }
 
+// Stub the protected stdin read used by the `--with-token` flow so tests can
+// feed a token without a real pipe.
+function stubStdin(command: LoginCommand, token: string): void {
+  (
+    command as unknown as { readTokenFromStdin: () => Promise<string> }
+  ).readTokenFromStdin = async () => token;
+}
+
 function createMockOAuthService(): OAuthService {
   return {
     authorize: async () => ({
@@ -369,6 +377,117 @@ describe('LoginCommand', () => {
     const jsonLog = output.logs.find((l) => l.startsWith('json:'));
     const parsed = JSON.parse(jsonLog!.replace('json:', ''));
     expect(parsed.method).toBe('api_token');
+  });
+
+  it('should read the API token from stdin with --with-token', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi();
+    const oauthService = createMockOAuthService();
+
+    const command = new LoginCommand(
+      configService,
+      usersApi,
+      oauthService,
+      output
+    );
+    stubStdin(command, 'piped-token');
+
+    await command.execute(
+      { username: 'testuser', withToken: true },
+      { globalOptions: {} }
+    );
+
+    const creds = await configService.getCredentials();
+    expect(creds.username).toBe('testuser');
+    expect(creds.apiToken).toBe('piped-token');
+  });
+
+  it('should trim surrounding whitespace from the stdin token', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi();
+    const oauthService = createMockOAuthService();
+
+    const command = new LoginCommand(
+      configService,
+      usersApi,
+      oauthService,
+      output
+    );
+    // A piped token typically arrives with a trailing newline from `echo`.
+    stubStdin(command, '  piped-token\n');
+
+    await command.execute(
+      { username: 'testuser', withToken: true },
+      { globalOptions: {} }
+    );
+
+    const creds = await configService.getCredentials();
+    expect(creds.apiToken).toBe('piped-token');
+  });
+
+  it('should fail when stdin is empty for --with-token', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi();
+    const oauthService = createMockOAuthService();
+
+    const command = new LoginCommand(
+      configService,
+      usersApi,
+      oauthService,
+      output
+    );
+    stubStdin(command, '\n');
+
+    await expect(
+      command.execute(
+        { username: 'testuser', withToken: true },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('No API token found on stdin');
+  });
+
+  it('should reject combining --password with --with-token', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi();
+    const oauthService = createMockOAuthService();
+
+    const command = new LoginCommand(
+      configService,
+      usersApi,
+      oauthService,
+      output
+    );
+    stubStdin(command, 'piped-token');
+
+    await expect(
+      command.execute(
+        { username: 'testuser', password: 'inline', withToken: true },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('Cannot combine --password with --with-token');
+  });
+
+  it('should still require a username for --with-token', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+    const usersApi = createMockUsersApi();
+    const oauthService = createMockOAuthService();
+
+    const command = new LoginCommand(
+      configService,
+      usersApi,
+      oauthService,
+      output
+    );
+    stubStdin(command, 'piped-token');
+
+    await expect(
+      command.execute({ withToken: true }, { globalOptions: {} })
+    ).rejects.toThrow('Username is required');
   });
 
   it('should pass clientId and clientSecret to OAuth service', async () => {


### PR DESCRIPTION
## Summary

Knocks out two roadmap items from the **Now — next release** milestone:

- **Closes #251** — adds Renovate dependency-update automation
- **Closes #253** — adds `bb auth login --with-token` stdin flow

Both are low-risk, self-contained changes; CI gates the dependency PRs Renovate will open.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / build / tooling
- [x] Documentation only

## Changes

**#251 — Dependency automation (`renovate.json`)**

- Renovate over Dependabot for first-class Bun `bun.lock` support; auto-discovers both manifests (root + `docs/`)
- Non-major npm updates batched into one low-risk PR; majors get their own labelled PR
- Keeps the SHA-pinned GitHub Actions current with readable `# vX` semver comments (`helpers:pinGitHubActionDigestsToSemver`), grouped on a `ci`-typed PR
- Custom regex manager tracks the pinned `BUN_VERSION` across all workflows against Bun's GitHub releases
- Monthly `bun.lock` maintenance, immediate security-fix fast path, weekly schedule + PR limits to keep noise low
- No changeset (CI/tooling only, no user-facing impact)

**#253 — `auth login --with-token`**

- New `--with-token` flag reads the API token from **stdin**, so secrets never appear in shell history or `ps` output the way `-p, --password` does (mirrors `gh auth login --with-token`)
- Implies API-token auth, trims surrounding whitespace; rejects `--with-token` + `--password`; clear error on empty stdin
- Token resolution extracted to `resolveApiToken`; stdin read isolated in a `protected readTokenFromStdin()` for testability
- Docs note OAuth requires a loopback browser (`http://localhost:19872/callback`) with **no device-code flow**, so headless users use token auth
- `minor` changeset added

## Testing

- [x] `bun test` passes (auth suite 41/41; new `--with-token` cases included)
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run lint:docs` passes
- [x] `bun run build` passes
- [x] `renovate.json` validated with `renovate-config-validator --strict`

> Note: 6 `GitService` tests fail only in the sandbox used to author this (its `git commit` hits a commit-signing hook returning HTTP 400). They're the non-hermetic git tests tracked in #269, unrelated to these changes, and pass in CI.

## Changeset

- [x] I ran `bun run changeset` and committed the file (for #253), **and**
- [x] The #251 portion does not affect users (CI/tooling only)

## Checklist

- [x] No edits to `src/generated/`
- [x] Output uses `IOutputService` (no `console.*`)
- [x] Expected failures use `BBError` / `ErrorCode`
- [x] Docs updated for user-facing behavior

## Post-merge action (#251)

`renovate.json` is inert until the [Renovate GitHub App](https://github.com/apps/renovate) is installed on the repo/org. Once installed, Renovate opens an onboarding PR and a Dependency Dashboard issue.

https://claude.ai/code/session_01ES9GsvQnBAWo4c6KJTAaZD