### PR TITLE
feat: milestone polish — command-path hint, update-check hook, coverage gate

### DIFF
--- a/.changeset/command-path-help-hint.md
+++ b/.changeset/command-path-help-hint.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Fix the `bb <command> --help` hint shown on validation errors to point at the exact command path. It previously sliced `process.argv` and guessed the first two tokens, which was wrong for top-level commands like `bb browse` and deeply nested ones like `bb pr comments add`. The hint now uses the resolved command path threaded through the command context.

--- a/.changeset/update-check-after-every-command.md
+++ b/.changeset/update-check-after-every-command.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Run the update-available check after every command instead of only when `bb` is invoked with no subcommand, so users who always run real subcommands see update notices. The notice now prints to stderr and only when stderr is an interactive TTY, output is not `--json`, and not in CI; it continues to honor `skipVersionCheck` and `versionCheckInterval`. This keeps `--json` and piped stdout byte-clean.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,14 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test
+        if: matrix.os != 'ubuntu-latest'
         run: bun test
+
+      # Linux leg measures coverage and fails the build under the bunfig.toml
+      # threshold (the hard gate). Kept Linux-only to keep the matrix fast.
+      - name: Test (coverage)
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run test:coverage
 
       - name: Build
         run: bun run build
@@ -84,3 +91,14 @@ jobs:
       - name: Verify build output
         shell: bash
         run: test -f dist/index.js || (echo "Build output missing" && exit 1)
+
+      # Reporting only — the Bun threshold above is the gate. Non-blocking so a
+      # missing CODECOV_TOKEN never fails CI (add it as a repo secret to enable).
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Common scripts (full list in [AGENTS.md](AGENTS.md#commands)):
 
 ```bash
 bun test              # run all tests
+bun run test:coverage # run tests with coverage (gated in CI on Linux)
 bun run lint          # type-check
 bun run format:check  # required by the pre-commit hook
 ```
@@ -81,6 +82,20 @@ Commit the generated file in `.changeset/` alongside your code changes.
 - Fill in the PR template
 - Link related issues
 - Wait for CI to pass
+
+## Dependency Updates
+
+Dependency maintenance is automated with [Renovate](https://docs.renovatebot.com/)
+(`renovate.json`), so you generally **don't bump these by hand**:
+
+- npm dependencies for both the root package and `docs/`.
+- GitHub Action versions, kept pinned to commit SHAs with a `# vX` comment.
+- The pinned `BUN_VERSION` used across the CI workflows.
+
+Renovate batches non-major updates into a single PR on a weekly schedule, opens
+separate labelled PRs for major upgrades, and fast-tracks security fixes. It runs
+on a weekly schedule with monthly `bun.lock` maintenance. We use Renovate rather
+than Dependabot for its Bun lockfile support.
 
 ## Release Process
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,20 @@
+[test]
+# Coverage is opt-in via the --coverage flag (see the `test:coverage` script in
+# package.json). We deliberately do NOT set `coverage = true` here so that a
+# plain `bun test` (local dev + the macOS/Windows CI legs) stays fast.
+coverageReporter = ["text", "lcov"]
+coverageDir = "coverage"
+
+# Exclude code that can't be meaningfully unit-covered:
+# - src/generated/**: auto-generated API client (never edited by hand).
+# - src/index.ts: the runtime-guard entrypoint.
+# - src/cli.ts: Commander wiring; its ~50 action callbacks are exercised
+#   end-to-end, not unit-tested, so its per-file function coverage is low.
+# Glob (**) form is required — a plain prefix is not matched by Bun 1.3.x.
+coveragePathIgnorePatterns = ["src/generated/**", "src/index.ts", "src/cli.ts"]
+
+# Per-file floor enforced by Bun's exit code (the hard CI gate). Use the SCALAR
+# form: the object form ([test.coverageThreshold]) is not enforced on Bun 1.3.x.
+# Measured per-file floor is ~80% functions / ~90% lines; 0.75 leaves margin for
+# the pinned Bun 1.3.6 in CI. Ratchet upward toward 0.80 as coverage improves.
+coverageThreshold = 0.75

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+## Codecov is reporting-only — the hard coverage gate is Bun's per-file
+## threshold in bunfig.toml. Statuses are informational so Codecov never
+## blocks a merge, and generated/build/test code is excluded from the UI.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - 'src/generated/**'
+  - 'tests/**'
+  - 'dist/**'

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -171,7 +171,7 @@ Some configuration keys cannot be set directly:
 
 ## Update Notifications
 
-The CLI automatically checks for updates when you run the bare `bb` command (without any subcommands). This helps you stay current with the latest features and bug fixes.
+The CLI opportunistically checks for updates after any command, so you stay current with the latest features and bug fixes without it getting in the way of scripts.
 
 ### How It Works
 
@@ -179,6 +179,7 @@ The CLI automatically checks for updates when you run the bare `bb` command (wit
 - Compares with your installed version
 - Shows a notification if an update is available
 - Caches the check result for 24 hours (configurable)
+- Prints the notice to **stderr**, and only in an interactive terminal — so `--json` and piped output stay clean
 - Skips checks in CI environments automatically
 
 ### Example Notification
@@ -233,6 +234,10 @@ When determining workspace and repository, the CLI checks sources in this order:
    ```
 
 See [Understanding Repository Context](/guides/repository-context/) for detailed examples.
+
+<Aside type="note">
+Some runtime behavior is tuned with environment variables rather than config-file keys — for example `BB_HTTP_TIMEOUT` for the API request timeout. See [Environment Variables](/reference/environment-variables/).
+</Aside>
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "bun run src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun --sourcemap --external tabtab",
     "test": "bun test",
+    "test:coverage": "bun test --coverage",
     "lint": "tsc --noEmit",
     "lint:docs": "bun scripts/check-error-codes-docs.ts && bun scripts/check-env-vars-docs.ts",
     "format": "prettier --write .",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import type { BaseCommand } from './core/base-command.js';
 import type { CommandContext } from './core/interfaces/commands.js';
 import type { IOutputService } from './core/interfaces/services.js';
 import type { VersionService } from './services/version.service.js';
+import type { VersionCheckResult } from './types/version.js';
 import type { IConfigService } from './core/interfaces/services.js';
 import { PR_STATES } from './types/pr.js';
 import { BBError, ErrorCode } from './types/errors.js';
@@ -225,6 +226,25 @@ const locale = resolveLocale({
 
 const container = bootstrap({ noColor, noUnicode, locale });
 
+// Exact path of the command currently executing (e.g. `pr comments add`),
+// derived from Commander's command tree by the root `preAction` hook below and
+// read by `createContext`. A module-level value is safe because the CLI runs
+// exactly one command per process invocation.
+let activeCommandPath = '';
+
+// Walk up Commander's command tree to build the space-joined path, excluding
+// the root program (`bb`, whose `.parent` is null). Yields `browse` for a
+// top-level command and `pr comments add` for a nested one.
+export function buildCommandPath(command: Command): string {
+  const parts: string[] = [];
+  let current: Command | null = command;
+  while (current && current.parent) {
+    parts.unshift(current.name());
+    current = current.parent;
+  }
+  return parts.join(' ');
+}
+
 // Helper to create command context. Validation errors from --json/--jq
 // parsing are deferred onto `context.validationError` so they can be raised
 // inside BaseCommand.run() and rendered through the normal error path,
@@ -283,6 +303,7 @@ export function createContext(
       repo: opts.repo,
     },
     validationError,
+    commandPath: activeCommandPath || undefined,
   };
 }
 
@@ -328,6 +349,53 @@ export function withGlobalOptions<T extends Record<string, unknown>>(
       context.globalOptions.workspace,
     repo: (options.repo as string | undefined) ?? context.globalOptions.repo,
   } as T & { workspace?: string; repo?: string };
+}
+
+// Build the update-available banner. Pure string-building so it is trivially
+// unit-testable; the caller supplies the separator so it can honor --no-unicode.
+export function formatUpdateNotice(
+  result: VersionCheckResult,
+  installCommand: string,
+  separator: string
+): string {
+  return [
+    '',
+    separator,
+    `A new version is available: ${result.latestVersion} (you have ${result.currentVersion})`,
+    `  Run '${installCommand}' to update`,
+    `  Or disable with 'bb config set skipVersionCheck true'`,
+    separator,
+    '',
+  ].join('\n');
+}
+
+// Print the update-available notice to stderr, gated so it never pollutes
+// machine-readable output. CI / skip / throttle gating lives inside
+// VersionService.checkForUpdate(); here we add the presentation gates: skip in
+// JSON mode and when stderr is not an interactive TTY, and route the banner to
+// stderr so piped stdout (e.g. `--json`) stays byte-clean.
+export async function maybePrintUpdateNotice(
+  versionService: VersionService,
+  opts: { json?: boolean; noUnicode?: boolean }
+): Promise<void> {
+  if (opts.json) return;
+  if (process.stderr.isTTY !== true) return;
+
+  try {
+    const result = await versionService.checkForUpdate();
+    if (result?.updateAvailable) {
+      const separator = (opts.noUnicode ? '-' : '─').repeat(50);
+      process.stderr.write(
+        formatUpdateNotice(
+          result,
+          versionService.getInstallCommand(),
+          separator
+        ) + '\n'
+      );
+    }
+  } catch {
+    // The version check is opportunistic — never block or surface errors.
+  }
 }
 
 // Create CLI
@@ -399,29 +467,11 @@ cli
     // Show help when no subcommand is provided
     cli.outputHelp();
 
-    // Check for updates after showing help
-    const versionService = container.resolve<VersionService>(
-      ServiceTokens.VersionService
-    );
+    // The update-available check runs in the root `postAction` hook so it fires
+    // after every command, not just the bare `bb` invocation handled here.
     const output = container.resolve<IOutputService>(
       ServiceTokens.OutputService
     );
-
-    try {
-      const result = await versionService.checkForUpdate();
-      if (result?.updateAvailable) {
-        output.text('');
-        output.separator(50);
-        output.warning(
-          `A new version is available: ${result.latestVersion} (you have ${result.currentVersion})\n` +
-            `  Run '${versionService.getInstallCommand()}' to update\n` +
-            `  Or disable with 'bb config set skipVersionCheck true'`
-        );
-        output.separator(50);
-      }
-    } catch {
-      // Silently ignore version check errors
-    }
 
     // Nudge unauthenticated users toward `bb auth login`. First-run users hit
     // this path immediately after install, so it's the right moment to point
@@ -445,6 +495,27 @@ cli
       // Don't let an unreadable config disrupt the help screen.
     }
   });
+
+// Capture the exact path of the command about to run so `createContext` can
+// stamp it onto the context and `BaseCommand.appendHelpHint()` can build an
+// accurate `bb <path> --help` footer. Inherited by every subcommand.
+cli.hook('preAction', (_thisCommand, actionCommand) => {
+  activeCommandPath = buildCommandPath(actionCommand);
+});
+
+// Surface an update-available notice after every command (like `gh`). The
+// notice prints to stderr and only in interactive, non-JSON, non-CI sessions;
+// throttling and the skip flag are enforced inside VersionService. Runs because
+// runCommand() and the root action swallow all errors, so no action ever throws
+// out to Commander and skips its postAction hooks.
+cli.hook('postAction', async (thisCommand) => {
+  const versionService = container.resolve<VersionService>(
+    ServiceTokens.VersionService
+  );
+  const jsonOpt = thisCommand.opts().json;
+  const json = jsonOpt !== undefined && jsonOpt !== false;
+  await maybePrintUpdateNotice(versionService, { json, noUnicode });
+});
 
 // Auth commands
 const authCmd = new Command('auth').description('Authenticate with Bitbucket');

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -13,6 +13,13 @@ export abstract class BaseCommand<
   public abstract readonly name: string;
   public abstract readonly description: string;
 
+  /**
+   * Exact command path (e.g. `pr comments add`) captured from the context in
+   * `run()` and used by `appendHelpHint()`. Safe as instance state because the
+   * CLI resolves and runs exactly one command per process invocation.
+   */
+  private commandPath?: string;
+
   constructor(protected readonly output: IOutputService) {}
 
   public abstract execute(
@@ -27,6 +34,7 @@ export abstract class BaseCommand<
     options: TOptions,
     context: CommandContext
   ): Promise<TResult> {
+    this.commandPath = context.commandPath;
     this.output.setJsonFormatOptions({
       json: !!context.globalOptions.json,
       fields: context.globalOptions.jsonFields,
@@ -114,20 +122,7 @@ export abstract class BaseCommand<
   }
 
   private getCommandPath(): string {
-    const argv = process.argv.slice(2);
-    const tokens: string[] = [];
-    for (const arg of argv) {
-      if (arg.startsWith('-')) break;
-      tokens.push(arg);
-    }
-    // The trailing token is typically a positional argument value (e.g. PR id);
-    // include only the leading subcommands. The simplest reliable signal is to
-    // stop once we have the first two tokens, matching the `bb <group> <cmd>`
-    // shape used throughout the CLI. Fall back to whatever we have.
-    if (tokens.length >= 2) {
-      return `${tokens[0]} ${tokens[1]}`;
-    }
-    return tokens.join(' ');
+    return this.commandPath ?? '';
   }
 
   /**

--- a/src/core/interfaces/commands.ts
+++ b/src/core/interfaces/commands.ts
@@ -17,6 +17,14 @@ export interface CommandContext {
    * Commander action handler as an unhandled rejection.
    */
   validationError?: BBError;
+  /**
+   * Exact resolved command path (e.g. `pr comments add` or the top-level
+   * `browse`), derived from Commander's executing command and stamped onto
+   * the context in `cli.ts`. Consumed by `BaseCommand.appendHelpHint()` to
+   * build the `bb <path> --help` footer. Optional so unit tests may omit it,
+   * in which case the hint falls back to `bb --help`.
+   */
+  commandPath?: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,6 @@ if (typeof Bun === 'undefined') {
 
 import { cli } from './cli.js';
 
-cli.parse(process.argv);
+// parseAsync (not parse) so Commander awaits async action handlers and the
+// postAction update-check hook before the process exits.
+await cli.parseAsync(process.argv);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,15 +5,20 @@
 import { describe, it, expect } from 'bun:test';
 import type { Command } from 'commander';
 import {
+  buildCommandPath,
   createContext,
   extractLocaleArg,
+  formatUpdateNotice,
   getCompletionParent,
+  maybePrintUpdateNotice,
   resolveNoColorSetting,
   resolveNoUnicodeSetting,
   withGlobalOptions,
 } from '../src/cli.js';
 import { cli } from '../src/cli.js';
 import type { CommandContext } from '../src/core/interfaces/commands.js';
+import type { VersionService } from '../src/services/version.service.js';
+import type { VersionCheckResult } from '../src/types/version.js';
 
 describe('createContext --jq / --json validation', () => {
   const fakeProgram = (opts: Record<string, unknown>): Command =>
@@ -813,5 +818,156 @@ describe('CLI leaf command options', () => {
     expect(optional(requireCommand('pr', 'edit'))).toEqual(['id']);
     expect(optional(requireCommand('pr', 'diff'))).toEqual(['id']);
     expect(optional(requireCommand('repo', 'view'))).toEqual(['repository']);
+  });
+});
+
+describe('buildCommandPath', () => {
+  // Minimal Commander-shaped stub: name() + parent chain up to the root, whose
+  // parent is null (matching the real `cli` program).
+  const node = (name: string, parent: Command | null): Command =>
+    ({ name: () => name, parent }) as unknown as Command;
+
+  it('returns an empty string for the root program', () => {
+    const root = node('bb', null);
+    expect(buildCommandPath(root)).toBe('');
+  });
+
+  it('returns the name for a top-level command', () => {
+    const root = node('bb', null);
+    expect(buildCommandPath(node('browse', root))).toBe('browse');
+  });
+
+  it('joins the full path for a deeply nested command', () => {
+    const root = node('bb', null);
+    const pr = node('pr', root);
+    const comments = node('comments', pr);
+    expect(buildCommandPath(node('add', comments))).toBe('pr comments add');
+  });
+});
+
+describe('formatUpdateNotice', () => {
+  const result: VersionCheckResult = {
+    currentVersion: '1.0.0',
+    latestVersion: '2.0.0',
+    updateAvailable: true,
+  };
+
+  it('includes both versions, the install command, and the disable hint', () => {
+    const notice = formatUpdateNotice(
+      result,
+      'bun install -g @pilatos/bitbucket-cli',
+      '─'.repeat(50)
+    );
+
+    expect(notice).toContain('2.0.0');
+    expect(notice).toContain('1.0.0');
+    expect(notice).toContain('bun install -g @pilatos/bitbucket-cli');
+    expect(notice).toContain('bb config set skipVersionCheck true');
+    expect(notice).toContain('─'.repeat(50));
+  });
+
+  it('brackets the banner with blank lines', () => {
+    const lines = formatUpdateNotice(result, 'install', '---').split('\n');
+    expect(lines[0]).toBe('');
+    expect(lines[lines.length - 1]).toBe('');
+  });
+
+  it('uses the supplied separator (honors --no-unicode)', () => {
+    const ascii = formatUpdateNotice(result, 'install', '-'.repeat(50));
+    expect(ascii).toContain('-'.repeat(50));
+    expect(ascii).not.toContain('─');
+  });
+});
+
+describe('maybePrintUpdateNotice', () => {
+  const updateResult: VersionCheckResult = {
+    currentVersion: '1.0.0',
+    latestVersion: '2.0.0',
+    updateAvailable: true,
+  };
+
+  const stubVersionService = (
+    checkForUpdate: () => Promise<VersionCheckResult | null>
+  ): VersionService =>
+    ({
+      checkForUpdate,
+      getInstallCommand: () => 'bun install -g @pilatos/bitbucket-cli',
+    }) as unknown as VersionService;
+
+  // Capture process.stderr.write and toggle isTTY, restoring both afterwards.
+  async function withStderr(
+    isTTY: boolean | undefined,
+    fn: (writes: string[]) => Promise<void>
+  ): Promise<void> {
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write;
+    const originalIsTTY = process.stderr.isTTY;
+    process.stderr.write = ((chunk: string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    // isTTY is a plain data property on the stream; assign directly.
+    (process.stderr as { isTTY?: boolean }).isTTY = isTTY;
+    try {
+      await fn(writes);
+    } finally {
+      process.stderr.write = originalWrite;
+      (process.stderr as { isTTY?: boolean }).isTTY = originalIsTTY;
+    }
+  }
+
+  it('writes the notice when an update is available on a non-JSON TTY', async () => {
+    await withStderr(true, async (writes) => {
+      await maybePrintUpdateNotice(
+        stubVersionService(async () => updateResult),
+        { json: false }
+      );
+      expect(writes.length).toBe(1);
+      expect(writes[0]).toContain('2.0.0');
+    });
+  });
+
+  it('writes nothing in JSON mode (keeps piped stdout clean)', async () => {
+    await withStderr(true, async (writes) => {
+      await maybePrintUpdateNotice(
+        stubVersionService(async () => updateResult),
+        { json: true }
+      );
+      expect(writes.length).toBe(0);
+    });
+  });
+
+  it('writes nothing when stderr is not a TTY', async () => {
+    await withStderr(false, async (writes) => {
+      await maybePrintUpdateNotice(
+        stubVersionService(async () => updateResult),
+        { json: false }
+      );
+      expect(writes.length).toBe(0);
+    });
+  });
+
+  it('writes nothing when no update is available', async () => {
+    await withStderr(true, async (writes) => {
+      await maybePrintUpdateNotice(
+        stubVersionService(async () => null),
+        {
+          json: false,
+        }
+      );
+      expect(writes.length).toBe(0);
+    });
+  });
+
+  it('swallows errors from the version check', async () => {
+    await withStderr(true, async (writes) => {
+      await maybePrintUpdateNotice(
+        stubVersionService(async () => {
+          throw new Error('network down');
+        }),
+        { json: false }
+      );
+      expect(writes.length).toBe(0);
+    });
   });
 });

--- a/tests/core/base-command.test.ts
+++ b/tests/core/base-command.test.ts
@@ -115,6 +115,17 @@ class TestCommandWithParseHelpers extends BaseCommand<
   }
 }
 
+class TestCommandHelpHint extends BaseCommand<{ option?: string }, void> {
+  public readonly name = 'test-help-hint';
+  public readonly description = 'Test command exercising appendHelpHint';
+
+  async execute(): Promise<void> {
+    // requireOption routes its message through appendHelpHint(), which reads
+    // the command path captured from the context in run().
+    this.requireOption(undefined, 'name');
+  }
+}
+
 describe('BaseCommand', () => {
   let output: ReturnType<typeof createMockOutputService>;
   let originalNodeEnv: string | undefined;
@@ -636,6 +647,46 @@ describe('BaseCommand', () => {
           'This will permanently delete repo/x.'
         )
       ).toThrow('This will permanently delete repo/x.\nUse --yes to confirm.');
+    });
+  });
+
+  describe('appendHelpHint command path', () => {
+    it('uses the threaded command path for a nested command hint', async () => {
+      const command = new TestCommandHelpHint(output);
+
+      await expect(
+        command.run({}, { globalOptions: {}, commandPath: 'pr comments add' })
+      ).rejects.toThrow('Run `bb pr comments add --help` for usage.');
+    });
+
+    it('uses the threaded command path for a top-level command hint', async () => {
+      const command = new TestCommandHelpHint(output);
+
+      await expect(
+        command.run({}, { globalOptions: {}, commandPath: 'browse' })
+      ).rejects.toThrow('Run `bb browse --help` for usage.');
+    });
+
+    it('falls back to `bb --help` when no command path is present', async () => {
+      const command = new TestCommandHelpHint(output);
+
+      await expect(command.run({}, { globalOptions: {} })).rejects.toThrow(
+        'Run `bb --help` for usage.'
+      );
+    });
+
+    it('ignores process.argv when building the hint', async () => {
+      const originalArgv = process.argv;
+      process.argv = ['node', 'bb', 'repo', 'delete', 'misleading'];
+      try {
+        const command = new TestCommandHelpHint(output);
+
+        await expect(
+          command.run({}, { globalOptions: {}, commandPath: 'browse' })
+        ).rejects.toThrow('Run `bb browse --help` for usage.');
+      } finally {
+        process.argv = originalArgv;
+      }
     });
   });
 


### PR DESCRIPTION
Clears the remaining three open items in the **Now — next release** milestone, plus the docs gaps found while double-checking the already-shipped items.

## What's in here

### Closes #254 — Thread the resolved command path through `CommandContext`
- `CommandContext` now carries a `commandPath`. A root `preAction` hook derives the **exact** path from Commander's executing command (`buildCommandPath`) and stamps it via `createContext`.
- `BaseCommand` captures it in `run()`; `getCommandPath()` no longer slices `process.argv`. The `bb <command> --help` hint on validation errors is now correct for top-level (`bb browse`) and deeply nested (`bb pr comments add`) commands — the old first-two-tokens heuristic got both wrong.
- Verified live: `bb pr view <bad>` → `bb pr view --help`; `bb pr reviewers add <bad>` → `bb pr reviewers add --help`.

### Closes #250 — Run the update check after every command (stderr/TTY-gated)
- Moved the version check into a root `postAction` hook so it fires after **any** command, not just bare `bb`.
- New pure `formatUpdateNotice` + `maybePrintUpdateNotice` helpers route the notice to **stderr** and gate on TTY + non-JSON; CI/skip/throttle stay in `VersionService`. `--json` and piped stdout stay byte-clean. Honors `--no-unicode`.
- `index.ts` now uses `cli.parseAsync` so the async hook is awaited (also fixes a latent issue where sync `parse` never awaited async actions).

### Closes #252 — Add coverage measurement and a CI coverage gate
- `bunfig.toml` enables Bun coverage (`text` + `lcov`) with a **scalar per-file** `coverageThreshold` and `coveragePathIgnorePatterns` for `src/generated/**`, `src/index.ts`, and `src/cli.ts` (Commander wiring, exercised end-to-end).
- Baseline **0.75** — measured per-file floor is ~80% funcs / ~90% lines (aggregate 98.15% / 99.03%). Empirically verified the gate is real: it **fails at 0.82**, passes at ≤0.80. Ratchet upward in a follow-up.
- New `test:coverage` script. CI runs coverage on the **Linux leg only** (Bun's exit code is the hard gate) and uploads lcov to Codecov, **reporting-only** (`fail_ci_if_error: false`).

### Docs (the "did we update docs?" check)
Audited docs for the four already-shipped milestone items (#253 `--with-token`, #251 Renovate, #249 `BB_HTTP_TIMEOUT`, #248 `bb api`). Three were already complete; the gaps fixed here:
- **#251 Renovate was entirely undocumented** → added a *Dependency Updates* section to `CONTRIBUTING.md`.
- Updated the *Update Notifications* section in `configuration.mdx` to match the new #250 behavior (after every command, stderr-only).
- Added a `BB_HTTP_TIMEOUT` cross-reference for #249 discoverability.

## ⚠️ Reviewer notes
- **Codecov needs a `CODECOV_TOKEN` repo secret** to actually upload. Without it CI still passes (upload is non-blocking) and the Bun threshold remains the real gate — remove the upload step if you'd rather not wire up Codecov.
- Coverage baseline measured on local Bun 1.3.9; CI pins **1.3.6**. If 1.3.6 computes slightly differently, the 0.75 baseline has ~5pt of margin.
- The `codecov-action` is SHA-pinned to the current `v5` tag; Renovate will keep it current.

## Validation
- `bun test` — 1155 pass, 0 fail
- `bun run lint` (tsc) — clean
- `bun run format:check` — clean
- `bun run lint:docs` — clean
- `bun run test:coverage` — passes the gate; `bun run build` — succeeds