### PR TITLE
test: drift guard for completion tables and wrapper-key registry

### DIFF
--- a/.changeset/completion-wrapper-drift-guard.md
+++ b/.changeset/completion-wrapper-drift-guard.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Advertise the global `--jq` flag in shell completion. It was a documented root option but was missing from the completion table, so `bb <tab>` never suggested it.
+
+Internally, a new drift-guard test now walks the live Commander command tree and fails CI if the hand-maintained shell-completion tables (`ROOT_COMPLETIONS`, `SUBCOMMAND_COMPLETIONS`, `COMMENTS_SUBCOMMANDS`) or the JSON `WRAPPER_ARRAY_KEYS` registry fall out of sync with the commands — turning a silent maintenance hazard into a build failure.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ export function getCompletionParent(
  * Subcommands keyed by their direct parent. `comments` is handled
  * specially because it appears under both `pr` and `snippet`.
  */
-const ROOT_COMPLETIONS: readonly string[] = [
+export const ROOT_COMPLETIONS: readonly string[] = [
   'auth',
   'repo',
   'pr',
@@ -66,6 +66,7 @@ const ROOT_COMPLETIONS: readonly string[] = [
   '--help',
   '--version',
   '--json',
+  '--jq',
   '--no-color',
   '--no-unicode',
   '--no-truncate',
@@ -74,49 +75,53 @@ const ROOT_COMPLETIONS: readonly string[] = [
   '--locale',
 ];
 
-const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> = new Map([
-  ['auth', ['login', 'logout', 'status', 'token']],
-  ['repo', ['clone', 'create', 'list', 'view', 'delete', 'default-reviewers']],
-  ['default-reviewers', ['list', 'add', 'remove']],
-  [
-    'pr',
+export const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> =
+  new Map([
+    ['auth', ['login', 'logout', 'status', 'token']],
     [
-      'create',
-      'list',
-      'view',
-      'activity',
-      'checks',
-      'edit',
-      'merge',
-      'approve',
-      'decline',
-      'ready',
-      'checkout',
-      'diff',
-      'comments',
-      'reviewers',
+      'repo',
+      ['clone', 'create', 'list', 'view', 'delete', 'default-reviewers'],
     ],
-  ],
-  ['reviewers', ['list', 'add', 'remove']],
-  [
-    'snippet',
+    ['default-reviewers', ['list', 'add', 'remove']],
     [
-      'list',
-      'view',
-      'create',
-      'edit',
-      'delete',
-      'watch',
-      'unwatch',
-      'comments',
+      'pr',
+      [
+        'create',
+        'list',
+        'view',
+        'activity',
+        'checks',
+        'edit',
+        'merge',
+        'approve',
+        'decline',
+        'ready',
+        'checkout',
+        'diff',
+        'comments',
+        'reviewers',
+      ],
     ],
-  ],
-  ['config', ['get', 'set', 'list']],
-  ['completion', ['install', 'uninstall']],
-  ['api', ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']],
-]);
+    ['reviewers', ['list', 'add', 'remove']],
+    [
+      'snippet',
+      [
+        'list',
+        'view',
+        'create',
+        'edit',
+        'delete',
+        'watch',
+        'unwatch',
+        'comments',
+      ],
+    ],
+    ['config', ['get', 'set', 'list']],
+    ['completion', ['install', 'uninstall']],
+    ['api', ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']],
+  ]);
 
-const COMMENTS_SUBCOMMANDS: readonly string[] = [
+export const COMMENTS_SUBCOMMANDS: readonly string[] = [
   'list',
   'add',
   'edit',

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -45,7 +45,7 @@ function stripControl(value: string): string {
 // "items" key. When `--json fields` is passed, project across that array
 // instead of the wrapper. Order matters: the first match wins. Keys must
 // match the actual JSON output produced by the commands in src/commands/**.
-const WRAPPER_ARRAY_KEYS: readonly string[] = [
+export const WRAPPER_ARRAY_KEYS: readonly string[] = [
   'pullRequests', // pr list
   'repositories', // repo list
   'snippets', // snippet list

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Drift guard for the hand-synced CLI registries (issue #255).
+ *
+ * Three tables must be kept aligned with the code BY HAND, and drift is
+ * otherwise silent:
+ *
+ *  1. The shell-completion tables in src/cli.ts — `ROOT_COMPLETIONS`,
+ *     `SUBCOMMAND_COMPLETIONS`, `COMMENTS_SUBCOMMANDS` — must mirror the live
+ *     Commander command tree (`cli`) and the declared root options.
+ *  2. The `WRAPPER_ARRAY_KEYS` list in src/services/output.service.ts must
+ *     contain the array wrapper key emitted by every collection-style command,
+ *     in the right order (first match wins for `--json fields` projection).
+ *
+ * These tests walk the real `cli` tree so adding a command (or a root flag)
+ * without updating the completion tables fails CI, mirroring the
+ * scripts/check-*-docs.ts drift guards.
+ *
+ * Carve-outs (intentional, asserted explicitly rather than reconciled):
+ *  - `comments` appears under both `pr` and `snippet`; it is keyed by name in
+ *    COMMENTS_SUBCOMMANDS, not in SUBCOMMAND_COMPLETIONS.
+ *  - `api` is a leaf with a positional `[methodOrEndpoint]`; its
+ *    SUBCOMMAND_COMPLETIONS entry lists HTTP method *values*, not subcommands.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { Command } from 'commander';
+import {
+  cli,
+  ROOT_COMPLETIONS,
+  SUBCOMMAND_COMPLETIONS,
+  COMMENTS_SUBCOMMANDS,
+} from '../src/cli.js';
+import { WRAPPER_ARRAY_KEYS } from '../src/services/output.service.js';
+
+// Commander adds an implicit `help` subcommand to nodes in some
+// configurations; never advertise it as a real command.
+function realChildNames(cmd: Command): string[] {
+  return cmd.commands
+    .map((c) => c.name())
+    .filter((n) => n !== 'help')
+    .sort();
+}
+
+// Every descendant node that itself has subcommands (a "group"), excluding the
+// root program.
+function collectGroups(cmd: Command, acc: Command[] = []): Command[] {
+  for (const child of cmd.commands) {
+    if (child.commands.length > 0) {
+      acc.push(child);
+    }
+    collectGroups(child, acc);
+  }
+  return acc;
+}
+
+function allNodes(cmd: Command, acc: Command[] = []): Command[] {
+  for (const child of cmd.commands) {
+    acc.push(child);
+    allNodes(child, acc);
+  }
+  return acc;
+}
+
+// `comments` lives under both `pr` and `snippet`; reconciled by name.
+const SPECIAL_PARENTS: Record<string, string[]> = {
+  comments: [...COMMENTS_SUBCOMMANDS].sort(),
+};
+
+// `api` is a leaf whose completion entry holds HTTP-method argument values, not
+// real subcommands — excluded from tree reconciliation, asserted separately.
+const API_VALUE_COMPLETIONS = new Set(['api']);
+
+describe('CLI completion drift (issue #255)', () => {
+  describe('Guard 1: command tree <-> completion tables', () => {
+    it('top-level command tokens match the real tree', () => {
+      const cmdTokens = ROOT_COMPLETIONS.filter(
+        (t) => !t.startsWith('-')
+      ).sort();
+      expect(cmdTokens).toEqual(realChildNames(cli));
+    });
+
+    it('root flag tokens match declared options plus built-ins', () => {
+      // `--help` is Commander's built-in; `--version` is registered via
+      // `.version()` and shows up in `cli.options`. Treat both as built-ins so
+      // the check neither requires them from `.option()` nor rejects them.
+      const builtins = new Set(['--help', '--version']);
+      const declared = new Set(
+        cli.options.map((o) => o.long).filter((l): l is string => Boolean(l))
+      );
+      const flagTokens = ROOT_COMPLETIONS.filter((t) => t.startsWith('--'));
+
+      // No phantom flags advertised that aren't real.
+      for (const flag of flagTokens) {
+        expect(declared.has(flag) || builtins.has(flag)).toBe(true);
+      }
+
+      // Every user-declared root option is advertised for completion. This is
+      // the assertion that catches a newly added global flag (e.g. it caught
+      // the missing `--jq`).
+      for (const long of declared) {
+        if (builtins.has(long)) continue;
+        expect(flagTokens).toContain(long);
+      }
+    });
+
+    it('every nested group has a completion list with exact children', () => {
+      for (const group of collectGroups(cli)) {
+        const name = group.name();
+        if (API_VALUE_COMPLETIONS.has(name)) continue;
+
+        const expected =
+          SPECIAL_PARENTS[name] ?? SUBCOMMAND_COMPLETIONS.get(name);
+        expect(
+          expected,
+          `no completion list for command group "${name}"`
+        ).toBeDefined();
+        expect(
+          [...(expected ?? [])].sort(),
+          `children drift under "${name}"`
+        ).toEqual(realChildNames(group));
+      }
+    });
+
+    it('comments group is special-cased, not in SUBCOMMAND_COMPLETIONS', () => {
+      expect(SUBCOMMAND_COMPLETIONS.has('comments')).toBe(false);
+      const groupsNamedComments = collectGroups(cli).filter(
+        (g) => g.name() === 'comments'
+      );
+      // Present under both `pr` and `snippet`.
+      expect(groupsNamedComments.length).toBe(2);
+      for (const group of groupsNamedComments) {
+        expect(realChildNames(group)).toEqual(SPECIAL_PARENTS.comments);
+      }
+    });
+
+    it('api is a value-completion leaf, not a subcommand group', () => {
+      const api = cli.commands.find((c) => c.name() === 'api');
+      expect(api, 'api command not found').toBeDefined();
+      expect(realChildNames(api as Command)).toEqual([]);
+      // The documented HTTP-method completion values still exist.
+      expect(SUBCOMMAND_COMPLETIONS.get('api')).toBeDefined();
+    });
+
+    it('no orphan SUBCOMMAND_COMPLETIONS keys', () => {
+      const groupNames = new Set(collectGroups(cli).map((g) => g.name()));
+      for (const key of SUBCOMMAND_COMPLETIONS.keys()) {
+        if (API_VALUE_COMPLETIONS.has(key)) continue;
+        expect(
+          groupNames.has(key),
+          `SUBCOMMAND_COMPLETIONS has "${key}" but no such command group exists`
+        ).toBe(true);
+      }
+    });
+
+    it('no command defines an alias (completion tables assume none)', () => {
+      for (const node of allNodes(cli)) {
+        expect(
+          node.aliases(),
+          `command "${node.name()}" defines an alias; completion tables must be updated to handle it`
+        ).toEqual([]);
+      }
+    });
+  });
+
+  describe('Guard 2: wrapper-array-key registry', () => {
+    // The canonical wrapper-key order. `values` is the generic paginated
+    // fallback and must stay LAST (first-match-wins in projection).
+    const EXPECTED_WRAPPER_ARRAY_KEYS = [
+      'pullRequests',
+      'repositories',
+      'snippets',
+      'comments',
+      'reviewers',
+      'activities',
+      'statuses',
+      'files',
+      'values',
+    ];
+
+    // Documents which command emits which array wrapper key. Keeps the registry
+    // honest: every value must be registered, and every command path must
+    // resolve to a real command (catches renames).
+    const COLLECTION_COMMAND_KEYS: Record<string, string> = {
+      'pr list': 'pullRequests',
+      'repo list': 'repositories',
+      'snippet list': 'snippets',
+      'pr comments list': 'comments',
+      'snippet comments list': 'comments',
+      'pr reviewers list': 'reviewers',
+      'repo default-reviewers list': 'reviewers',
+      'pr activity': 'activities',
+      'pr checks': 'statuses',
+      'pr diff --stat': 'files',
+      'pr diff --name-only': 'files',
+    };
+
+    it('WRAPPER_ARRAY_KEYS matches the expected set, in order', () => {
+      expect([...WRAPPER_ARRAY_KEYS]).toEqual(EXPECTED_WRAPPER_ARRAY_KEYS);
+    });
+
+    it('values is the last fallback element', () => {
+      expect(WRAPPER_ARRAY_KEYS[WRAPPER_ARRAY_KEYS.length - 1]).toBe('values');
+    });
+
+    it('has no duplicate keys', () => {
+      expect(new Set(WRAPPER_ARRAY_KEYS).size).toBe(WRAPPER_ARRAY_KEYS.length);
+    });
+
+    it('every collection command key is registered', () => {
+      for (const key of Object.values(COLLECTION_COMMAND_KEYS)) {
+        expect(WRAPPER_ARRAY_KEYS).toContain(key);
+      }
+    });
+
+    it('has no orphan keys beyond the documented fallback', () => {
+      const used = new Set(Object.values(COLLECTION_COMMAND_KEYS));
+      const allowedOrphans = new Set(['values']);
+      const orphans = WRAPPER_ARRAY_KEYS.filter(
+        (k) => !used.has(k) && !allowedOrphans.has(k)
+      );
+      expect(orphans).toEqual([]);
+    });
+
+    it('every documented command path resolves to a real command', () => {
+      for (const path of Object.keys(COLLECTION_COMMAND_KEYS)) {
+        const tokens = path.split(' ').filter((t) => !t.startsWith('-'));
+        let node: Command | undefined = cli;
+        for (const token of tokens) {
+          node = node?.commands.find((c) => c.name() === token);
+          expect(
+            node,
+            `command path "${path}" does not resolve (at "${token}")`
+          ).toBeDefined();
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #255.

## What

Adds `tests/cli-completion-drift.test.ts`, a drift guard that walks the **live Commander command tree** (`cli`) and asserts the three hand-maintained registries stay in sync with the real commands — turning a silent maintenance hazard into a CI failure, mirroring the existing `scripts/check-*-docs.ts` guards.

**Guard 1 — command tree ↔ completion tables** (`src/cli.ts`)
- Top-level command tokens in `ROOT_COMPLETIONS` exactly match the real top-level commands (bidirectional: catches added *and* stale entries).
- Root flag tokens match the declared `.option()` set plus the `--help`/`--version` built-ins.
- Every nested command group has a matching `SUBCOMMAND_COMPLETIONS` entry whose children exactly match the real subcommands.
- `comments` is special-cased (present under both `pr` and `snippet`, keyed in `COMMENTS_SUBCOMMANDS`).
- `api` is asserted to be a value-completion leaf (its table entry lists HTTP method values, not subcommands).
- No orphan table keys; tripwire if any command introduces an alias (the tables assume none).

**Guard 2 — wrapper-key registry** (`src/services/output.service.ts`)
- `WRAPPER_ARRAY_KEYS` matches the expected list **in order** (the first-match-wins ordering is load-bearing for `--json fields` projection; `values` must stay last).
- No duplicates; every collection command's wrapper key is registered; no orphan keys beyond the documented `values` fallback; every documented command path resolves to a real command.

## Existing drift fixed

`--jq` was a documented root option (`src/cli.ts`) but was **missing from `ROOT_COMPLETIONS`**, so `bb <tab>` never suggested it. Added it — the new flag-coverage assertion is what surfaced it.

## Supporting changes

- Exported `ROOT_COMPLETIONS`, `SUBCOMMAND_COMPLETIONS`, `COMMENTS_SUBCOMMANDS` (cli.ts) and `WRAPPER_ARRAY_KEYS` (output.service.ts) so the test can consume them. Pure data exports, no behavior change.
- Changeset (`patch`).

## Verification

- `bun test` — 1168 pass / 0 fail (13 new).
- `bun run lint` (tsc --noEmit) — clean.
- `bun run format:check` — clean.
- Confirmed the guards **fail** on injected drift: removing `--jq`, reordering `WRAPPER_ARRAY_KEYS`, and adding a ghost subcommand each produce a clear failure.

## Acceptance criteria

- [x] Test fails when the Commander tree and completion tables diverge
- [x] Test fails when a list command's wrapper key is missing from `WRAPPER_ARRAY_KEYS`

## Notes / out of scope

Guard 2 is a curated mirror, not derived from runtime output — it proves the registry changed consciously and that every documented command path resolves, but does not execute commands to prove array-ness. A runtime-capture approach was evaluated and rejected as high-effort/brittle for marginal extra coverage; deriving completions from Commander directly remains the longer-term follow-up referenced in the issue.