### PR TITLE
feat(completion): derive shell completion from the Commander tree

### DIFF
--- a/.changeset/completion-wrapper-drift-guard.md
+++ b/.changeset/completion-wrapper-drift-guard.md
@@ -2,6 +2,6 @@
 '@pilatos/bitbucket-cli': patch
 ---
 
-Advertise the global `--jq` flag in shell completion. It was a documented root option but was missing from the completion table, so `bb <tab>` never suggested it.
+Advertise the global `--jq` flag in shell completion. It was a documented root option but was missing from the completion output, so `bb <tab>` never suggested it.
 
-Internally, a new drift-guard test now walks the live Commander command tree and fails CI if the hand-maintained shell-completion tables (`ROOT_COMPLETIONS`, `SUBCOMMAND_COMPLETIONS`, `COMMENTS_SUBCOMMANDS`) or the JSON `WRAPPER_ARRAY_KEYS` registry fall out of sync with the commands — turning a silent maintenance hazard into a build failure.
+Internally, a new drift-guard test now walks the live Commander command tree and fails CI if the JSON `WRAPPER_ARRAY_KEYS` registry falls out of sync with the commands — turning a silent maintenance hazard into a build failure.

--- a/.changeset/tree-derived-completion.md
+++ b/.changeset/tree-derived-completion.md
@@ -1,0 +1,7 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Derive shell completion from the live command tree instead of hand-maintained tables, so completion stays correct automatically as commands and flags change. This also adds flag-value completion for enum options: `bb pr merge --strategy <Tab>` suggests the valid merge strategies, `bb pr list --state <Tab>` the PR states, `bb snippet list --role <Tab>` the roles, `bb pr diff --color <Tab>` the color modes, and `bb api -X <Tab>` the HTTP methods. In zsh and fish each suggestion now carries its description.
+
+The change is purely additive: option validation and error output are unchanged — invalid values still raise the usual error (and honor `--json`), and `bb api -X get` stays case-insensitive.

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -56,7 +56,7 @@ bb completion install
 bb completion install --json
 
 # Test it works
-bb <Tab>        # Shows: auth, repo, pr, snippet, browse, config, completion
+bb <Tab>        # Shows: auth, repo, pr, snippet, browse, api, config, completion
 bb repo <Tab>   # Shows: clone, create, list, view, delete, default-reviewers
 ```
 
@@ -90,13 +90,45 @@ bb completion uninstall --json
 
 ## What Gets Completed
 
+Completions are derived from the live command tree, so they always reflect the
+commands and flags the CLI actually ships — there is no separate list to fall
+out of date.
+
 Tab completion works for:
 
-- **Commands**: `auth`, `repo`, `pr`, `snippet`, `browse`, `config`, `completion`
+- **Commands**: `auth`, `repo`, `pr`, `snippet`, `browse`, `api`, `config`, `completion`
 - **Subcommands**: `login`, `clone`, `create`, `list`, etc.
 - **Options**: `--json`, `--no-color`, `--workspace`, `--repo`, `--help`
+- **Flag values** for enum options (see below)
 
 `-w` is reserved as the global shorthand for `--workspace`.
+
+### Flag-value completion
+
+When a flag accepts a fixed set of values, completing right after it suggests
+the valid values:
+
+```bash
+$ bb pr merge 42 --strategy <Tab>
+merge_commit         squash               fast_forward
+squash_fast_forward  rebase_fast_forward  rebase_merge
+
+$ bb pr list --state <Tab>
+OPEN  MERGED  DECLINED  SUPERSEDED
+
+$ bb snippet list --role <Tab>
+owner  contributor  member
+
+$ bb pr diff --color <Tab>
+auto  always  never
+
+$ bb api -X <Tab>
+GET   POST     PUT  PATCH
+HEAD  OPTIONS  DELETE
+```
+
+In zsh and fish, each completion is shown with its description; bash shows the
+bare names.
 
 ### Example Session
 
@@ -109,7 +141,9 @@ activity  approve   checks    checkout  comments  create    decline
 diff      edit      list      merge     ready     reviewers view
 
 $ bb pr create --<Tab>
---body                --close-source-branch  --destination
---draft               --help                 --repo
---source              --title                --workspace
+# the command's own flags, plus inherited global flags:
+--title       --body                  --source       --destination
+--draft       --close-source-branch   --reviewer     --default-reviewers
+--json        --jq                    --workspace    --repo
+--no-color    --no-unicode            --no-truncate  --locale  --help
 ```

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -137,9 +137,10 @@ bb completion install
 Restart your shell, then try:
 
 ```bash
-bb pr <Tab>      # Shows: activity, approve, checkout, create, decline, diff, list, merge, ready, view
-bb pr create -<Tab>  # Shows available flags
-bb <Tab>         # Shows: auth, repo, pr, snippet, browse, api, config, completion
+bb <Tab>                         # Shows: auth, repo, pr, snippet, browse, api, config, completion
+bb pr <Tab>                      # Shows: activity, approve, checkout, checks, comments, create, decline, diff, edit, list, merge, ready, reviewers, view
+bb pr create -<Tab>              # Shows available flags
+bb pr merge 42 --strategy <Tab>  # Shows: merge_commit, squash, fast_forward, ...
 ```
 
 ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,15 @@
  * CLI setup with Commander.js
  */
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { createRequire } from 'node:module';
 import { bootstrap } from './bootstrap.js';
+import { generateCompletions } from './completion.js';
+import {
+  PullrequestMergeParametersMergeStrategyEnum,
+  SnippetsWorkspaceGetRoleEnum,
+} from './generated/api.js';
+import { HTTP_METHODS } from './services/api-passthrough.js';
 import { createHelpTextBuilder } from './help-text.js';
 import { ServiceTokens } from './core/container.js';
 import type { ServiceToken } from './core/container.js';
@@ -23,132 +29,32 @@ const pkg = require('../package.json');
 
 import tabtab from 'tabtab';
 
-/**
- * Walk a tokenized completion line to find the nearest non-flag token
- * preceding `word`. Used to disambiguate nested subcommands that share a
- * name (e.g. `bb pr comments` vs `bb snippet comments`) without resorting
- * to fragile substring matching on the raw line.
- */
-export function getCompletionParent(
-  line: string | undefined,
-  word: string
-): string | undefined {
-  if (typeof line !== 'string') {
-    return undefined;
-  }
-  const tokens = line.split(/\s+/).filter(Boolean);
-  const idx = tokens.lastIndexOf(word);
-  if (idx <= 0) {
-    return undefined;
-  }
-  for (let i = idx - 1; i >= 0; i--) {
-    const token = tokens[i];
-    if (token && !token.startsWith('-')) {
-      return token;
-    }
-  }
-  return undefined;
-}
+// Enum option values, single-sourced so shell completion and the help-text
+// `validValues` blocks can never drift. The merge strategies and snippet roles
+// come straight from the generated OpenAPI enums, so `bun run generate:api`
+// keeps them current automatically.
+const MERGE_STRATEGIES = Object.values(
+  PullrequestMergeParametersMergeStrategyEnum
+);
+const SNIPPET_ROLES = Object.values(SnippetsWorkspaceGetRoleEnum);
+const COLOR_WHENS = ['auto', 'always', 'never'] as const;
 
 /**
- * Subcommands keyed by their direct parent. `comments` is handled
- * specially because it appears under both `pr` and `snippet`.
+ * Advertise an option's allowed values for shell completion (and `--help`)
+ * WITHOUT Commander's parse-time enforcement. `generateCompletions` reads
+ * `option.argChoices` to suggest enum values, but validation stays in the
+ * command handlers (`parseEnumOption`), which raise `BBError` — so `--json`
+ * error envelopes, the app's message style, and case-insensitive normalization
+ * (e.g. `bb api -X get`) all keep working. Commander only enforces `argChoices`
+ * via the `parseArg` that `.choices()` installs, so assigning it directly is
+ * completion-only.
  */
-export const ROOT_COMPLETIONS: readonly string[] = [
-  'auth',
-  'repo',
-  'pr',
-  'snippet',
-  'browse',
-  'api',
-  'config',
-  'completion',
-  '--help',
-  '--version',
-  '--json',
-  '--jq',
-  '--no-color',
-  '--no-unicode',
-  '--no-truncate',
-  '--workspace',
-  '--repo',
-  '--locale',
-];
-
-export const SUBCOMMAND_COMPLETIONS: ReadonlyMap<string, readonly string[]> =
-  new Map([
-    ['auth', ['login', 'logout', 'status', 'token']],
-    [
-      'repo',
-      ['clone', 'create', 'list', 'view', 'delete', 'default-reviewers'],
-    ],
-    ['default-reviewers', ['list', 'add', 'remove']],
-    [
-      'pr',
-      [
-        'create',
-        'list',
-        'view',
-        'activity',
-        'checks',
-        'edit',
-        'merge',
-        'approve',
-        'decline',
-        'ready',
-        'checkout',
-        'diff',
-        'comments',
-        'reviewers',
-      ],
-    ],
-    ['reviewers', ['list', 'add', 'remove']],
-    [
-      'snippet',
-      [
-        'list',
-        'view',
-        'create',
-        'edit',
-        'delete',
-        'watch',
-        'unwatch',
-        'comments',
-      ],
-    ],
-    ['config', ['get', 'set', 'list']],
-    ['completion', ['install', 'uninstall']],
-    ['api', ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']],
-  ]);
-
-export const COMMENTS_SUBCOMMANDS: readonly string[] = [
-  'list',
-  'add',
-  'edit',
-  'delete',
-];
-
-// Handle tabtab completion
-if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
-  const env = tabtab.parseEnv(process.env);
-  if (env.complete) {
-    const completions = [...ROOT_COMPLETIONS];
-
-    if (env.prev === 'comments') {
-      const parent = getCompletionParent(env.line, 'comments');
-      if (parent === 'snippet' || parent === 'pr') {
-        completions.push(...COMMENTS_SUBCOMMANDS);
-      }
-    } else {
-      const subcommands = SUBCOMMAND_COMPLETIONS.get(env.prev);
-      if (subcommands) {
-        completions.push(...subcommands);
-      }
-    }
-
-    tabtab.log(completions);
-    process.exit(0);
-  }
+function withCompletionChoices(
+  option: Option,
+  values: readonly string[]
+): Option {
+  option.argChoices = [...values];
+  return option;
 }
 
 /**
@@ -893,10 +799,14 @@ prCmd
 prCmd
   .command('list')
   .description('List pull requests')
-  .option(
-    '-s, --state <state>',
-    `Filter by state (${PR_STATES.join(', ')})`,
-    'OPEN'
+  .addOption(
+    withCompletionChoices(
+      new Option(
+        '-s, --state <state>',
+        `Filter by state (${PR_STATES.join(', ')})`
+      ).default('OPEN'),
+      PR_STATES
+    )
   )
   .option('--limit <number>', 'Maximum number of PRs to list', '25')
   .option('--all', 'List all pull requests (overrides --limit)')
@@ -964,6 +874,9 @@ prCmd
   .description('Show pull request activity log')
   .option('--limit <number>', 'Maximum number of activity entries', '25')
   .option('--all', 'Show all activity entries (overrides --limit)')
+  // No `withCompletionChoices` here on purpose: `--type` is a comma-separated
+  // multi-value filter, and flag-value completion can only offer a single value
+  // for the token after the flag — it can't append to an in-progress list.
   .option('--type <types>', 'Filter activity by type (comma-separated)')
   .addHelpText(
     'after',
@@ -1049,7 +962,12 @@ prCmd
   .description('Merge a pull request')
   .option('-m, --message <message>', 'Merge commit message')
   .option('--close-source-branch', 'Delete the source branch after merging')
-  .option('--strategy <strategy>', 'Merge strategy')
+  .addOption(
+    withCompletionChoices(
+      new Option('--strategy <strategy>', 'Merge strategy'),
+      MERGE_STRATEGIES
+    )
+  )
   .addHelpText(
     'after',
     buildHelpText({
@@ -1059,14 +977,7 @@ prCmd
         'bb pr merge 42 -m "Merge feature X"',
       ],
       validValues: {
-        'Valid merge strategies': [
-          'merge_commit',
-          'squash',
-          'fast_forward',
-          'squash_fast_forward',
-          'rebase_fast_forward',
-          'rebase_merge',
-        ],
+        'Valid merge strategies': [...MERGE_STRATEGIES],
       },
       defaults: {
         strategy:
@@ -1178,7 +1089,12 @@ prCmd
 prCmd
   .command('diff [id]')
   .description('View pull request diff')
-  .option('--color <when>', 'Colorize output', 'auto')
+  .addOption(
+    withCompletionChoices(
+      new Option('--color <when>', 'Colorize output').default('auto'),
+      COLOR_WHENS
+    )
+  )
   .option('--name-only', 'Show only names of changed files')
   .option('--stat', 'Show diffstat')
   .option('--web', 'Open diff in web browser')
@@ -1193,7 +1109,7 @@ prCmd
         'bb pr diff 42 --color always',
       ],
       validValues: {
-        'Valid --color values': ['auto', 'always', 'never'],
+        'Valid --color values': [...COLOR_WHENS],
       },
       defaults: { color: 'auto' },
     })
@@ -1390,7 +1306,15 @@ const snippetCmd = new Command('snippet').description('Manage snippets');
 snippetCmd
   .command('list')
   .description('List snippets in a workspace')
-  .option('--role <role>', 'Filter by role (owner, contributor, member)')
+  .addOption(
+    withCompletionChoices(
+      new Option(
+        '--role <role>',
+        'Filter by role (owner, contributor, member)'
+      ),
+      SNIPPET_ROLES
+    )
+  )
   .option('--limit <number>', 'Maximum number of snippets to list', '25')
   .option('--all', 'List all snippets (overrides --limit)')
   .addHelpText(
@@ -1403,7 +1327,7 @@ snippetCmd
         'bb snippet list --limit 50 --json',
       ],
       validValues: {
-        'Valid roles': ['owner', 'contributor', 'member'],
+        'Valid roles': [...SNIPPET_ROLES],
       },
       defaults: { limit: '25' },
     })
@@ -1740,9 +1664,14 @@ cli
   .description(
     'Make an authenticated request to any Bitbucket Cloud 2.0 API endpoint'
   )
-  .option(
-    '-X, --method <method>',
-    'HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). Defaults to GET, or POST when fields/body are present.'
+  .addOption(
+    withCompletionChoices(
+      new Option(
+        '-X, --method <method>',
+        'HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). Defaults to GET, or POST when fields/body are present.'
+      ),
+      HTTP_METHODS
+    )
   )
   .option(
     '-f, --raw-field <key=value>',
@@ -1936,3 +1865,16 @@ completionCmd
   });
 
 cli.addCommand(completionCmd);
+
+// Handle tabtab shell completion. This runs at module load (the entrypoint
+// imports `cli` before calling parseAsync), and must come AFTER the command
+// tree is fully built so `generateCompletions` can walk the live `cli` tree.
+// bootstrap() above only registers lazy DI factories — no I/O — so reaching
+// this point stays fast and silent, as shell completion requires.
+if (process.argv.includes('--get-yargs-completions') || process.env.COMP_LINE) {
+  const env = tabtab.parseEnv(process.env);
+  if (env.complete) {
+    tabtab.log(generateCompletions(cli, env));
+    process.exit(0);
+  }
+}

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,0 +1,173 @@
+/**
+ * Shell-completion candidate generation, derived from the live Commander tree.
+ *
+ * Replaces the hand-maintained `ROOT_COMPLETIONS` / `SUBCOMMAND_COMPLETIONS` /
+ * `COMMENTS_SUBCOMMANDS` tables (issue #256): walking the real command tree is
+ * a single source of truth, so adding a command or flag updates completion
+ * automatically, and nested groups that share a name (`pr comments` vs
+ * `snippet comments`) disambiguate structurally instead of by special-casing.
+ *
+ * It also surfaces flag-value completion: an enum option whose allowed values
+ * were advertised via `withCompletionChoices` (e.g. `--state`, `--strategy`,
+ * `--role`, `--color`, `-X`) — read here off `option.argChoices` — suggests
+ * those values when the cursor sits right after the flag. Validation itself
+ * stays in the command handlers, so this is completion-only.
+ */
+
+import type { Command, Option } from 'commander';
+
+/**
+ * A completion candidate. `tabtab.log()` accepts either bare strings or
+ * `{ name, description }` objects; the description is surfaced by zsh and fish
+ * (and ignored by bash), so returning objects makes completions
+ * self-documenting at no cost.
+ */
+export interface CompletionItem {
+  name: string;
+  description?: string;
+}
+
+/**
+ * The slice of tabtab's parsed env we rely on. `partial` is the text to the
+ * left of the cursor (equal to `line` for an end-of-line TAB); we prefer it so
+ * completion is correct even mid-line.
+ */
+export interface CompletionEnv {
+  line?: string;
+  partial?: string;
+}
+
+/**
+ * Find the option matching a flag token (`--long` or `-s`) on the resolved
+ * command or any of its ancestors — ancestors carry the inherited global flags.
+ */
+function findOption(
+  path: readonly Command[],
+  flag: string
+): Option | undefined {
+  for (const cmd of path) {
+    for (const opt of cmd.options) {
+      if (opt.long === flag || opt.short === flag) {
+        return opt;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Produce completion candidates for the current command line by walking the
+ * Commander `program` tree. Returns subcommands + applicable option flags, or —
+ * when the cursor follows a value-expecting option — that option's choices.
+ *
+ * Kept deliberately simple: it never tries to complete positional values (PR
+ * ids, snippet ids, account ids, file paths). When navigation hits an
+ * unrecognized non-flag token it stops and offers the current node's flags.
+ */
+export function generateCompletions(
+  program: Command,
+  env: CompletionEnv
+): CompletionItem[] {
+  const raw = env.partial ?? env.line ?? '';
+  const endsWithSpace = /\s$/.test(raw);
+  // Strip the leading binary token by POSITION (it may be `bb`, a path, or an
+  // alias — never match the literal name).
+  const tokens = raw.split(/\s+/).filter(Boolean).slice(1);
+  // Tokens that select the command: everything except the word being typed.
+  const navTokens = endsWithSpace ? tokens : tokens.slice(0, -1);
+
+  // Walk the tree following non-flag tokens to the deepest matching command.
+  let node: Command = program;
+  const path: Command[] = [program];
+  for (let i = 0; i < navTokens.length; i++) {
+    const tok = navTokens[i] as string;
+    if (tok.startsWith('-')) {
+      // A flag that takes a separate value (`--repo x`, `-w ws`) consumes the
+      // next token as its value — skip it so the value isn't mistaken for a
+      // positional and abort the walk. `--flag=value` carries its own value.
+      if (!tok.includes('=')) {
+        const opt = findOption(path, tok);
+        if (opt && opt.required) {
+          i++;
+        }
+      }
+      continue; // flags and their values never select a command
+    }
+    const child = node.commands.find(
+      (c) => c.name() === tok || c.aliases().includes(tok)
+    );
+    if (!child) {
+      break; // unrecognized positional (e.g. a PR id) — stop walking
+    }
+    node = child;
+    path.push(node);
+  }
+
+  // Flag-value completion: when the token immediately before the cursor is an
+  // option that requires a value, suggest its choices — or nothing at all, so
+  // we don't offer flags/subcommands as if they were the value.
+  const prevTok = navTokens.length
+    ? navTokens[navTokens.length - 1]
+    : undefined;
+  if (prevTok && prevTok.startsWith('-')) {
+    const opt = findOption(path, prevTok);
+    if (opt && opt.required) {
+      const choices = opt.argChoices;
+      return choices && choices.length
+        ? choices.map((value) => ({ name: value }))
+        : [];
+    }
+  }
+
+  const items: CompletionItem[] = [];
+
+  // Subcommands of the resolved node (skip Commander's implicit `help`).
+  for (const child of node.commands) {
+    if (child.name() === 'help') {
+      continue;
+    }
+    items.push({ name: child.name(), description: child.description() });
+  }
+
+  // Option flags from the node and every ancestor (the root carries the global
+  // flags). Skip a flag already on the line unless it is repeatable.
+  const presentFlags = new Set(navTokens.filter((t) => t.startsWith('-')));
+  const seen = new Set<string>();
+  for (const cmd of path) {
+    for (const opt of cmd.options) {
+      const flag = opt.long ?? opt.short;
+      if (!flag || seen.has(flag)) {
+        continue;
+      }
+      // `--version` lives on the root program's option list but is only valid
+      // on the root invocation; surface it explicitly below, never inherited.
+      if (flag === '--version') {
+        continue;
+      }
+      seen.add(flag);
+      if (presentFlags.has(flag) && !opt.variadic) {
+        continue;
+      }
+      items.push({ name: flag, description: opt.description });
+    }
+  }
+
+  // `--help` is available on every command; `--version` only at the root.
+  if (!seen.has('--help')) {
+    items.push({ name: '--help', description: 'Display help for command' });
+  }
+  if (node === program && !seen.has('--version')) {
+    items.push({ name: '--version', description: 'Output the version number' });
+  }
+
+  // De-duplicate by name, keeping the first occurrence (subcommands, then
+  // flags in path order). The `seen` set above already prevents duplicate
+  // flags across levels, so this only guards against an incidental collision.
+  const byName = new Map<string, CompletionItem>();
+  for (const item of items) {
+    if (!byName.has(item.name)) {
+      byName.set(item.name, item);
+    }
+  }
+  return [...byName.values()];
+}

--- a/src/types/tabtab.d.ts
+++ b/src/types/tabtab.d.ts
@@ -19,10 +19,15 @@ declare module 'tabtab' {
     name: string;
   }
 
+  interface CompletionItem {
+    name: string;
+    description?: string;
+  }
+
   function install(options: InstallOptions): Promise<void>;
   function uninstall(options: UninstallOptions): Promise<void>;
   function parseEnv(env: NodeJS.ProcessEnv): TabtabEnv;
-  function log(completions: string[]): void;
+  function log(completions: Array<string | CompletionItem>): void;
 
   export { install, uninstall, parseEnv, log };
   export default { install, uninstall, parseEnv, log };

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -1,167 +1,27 @@
 /**
  * Drift guard for the hand-synced CLI registries (issue #255).
  *
- * Three tables must be kept aligned with the code BY HAND, and drift is
- * otherwise silent:
+ * Shell completion is now derived from the live Commander tree (issue #256),
+ * so the old `ROOT_COMPLETIONS` / `SUBCOMMAND_COMPLETIONS` /
+ * `COMMENTS_SUBCOMMANDS` tables — and their drift guard — are gone. Behavioral
+ * coverage for the tree-derived completer lives in tests/completion.test.ts.
  *
- *  1. The shell-completion tables in src/cli.ts — `ROOT_COMPLETIONS`,
- *     `SUBCOMMAND_COMPLETIONS`, `COMMENTS_SUBCOMMANDS` — must mirror the live
- *     Commander command tree (`cli`) and the declared root options.
- *  2. The `WRAPPER_ARRAY_KEYS` list in src/services/output.service.ts must
- *     contain the array wrapper key emitted by every collection-style command,
- *     in the right order (first match wins for `--json fields` projection).
+ * What remains hand-synced and silently drift-prone:
  *
- * These tests walk the real `cli` tree so adding a command (or a root flag)
- * without updating the completion tables fails CI, mirroring the
- * scripts/check-*-docs.ts drift guards.
+ *  - The `WRAPPER_ARRAY_KEYS` list in src/services/output.service.ts must
+ *    contain the array wrapper key emitted by every collection-style command,
+ *    in the right order (first match wins for `--json fields` projection).
  *
- * Carve-outs (intentional, asserted explicitly rather than reconciled):
- *  - `comments` appears under both `pr` and `snippet`; it is keyed by name in
- *    COMMENTS_SUBCOMMANDS, not in SUBCOMMAND_COMPLETIONS.
- *  - `api` is a leaf with a positional `[methodOrEndpoint]`; its
- *    SUBCOMMAND_COMPLETIONS entry lists HTTP method *values*, not subcommands.
+ * This test walks the real `cli` tree so renaming a collection command without
+ * updating the registry fails CI, mirroring the scripts/check-*-docs.ts guards.
  */
 
 import { describe, it, expect } from 'bun:test';
 import type { Command } from 'commander';
-import {
-  cli,
-  ROOT_COMPLETIONS,
-  SUBCOMMAND_COMPLETIONS,
-  COMMENTS_SUBCOMMANDS,
-} from '../src/cli.js';
+import { cli } from '../src/cli.js';
 import { WRAPPER_ARRAY_KEYS } from '../src/services/output.service.js';
 
-// Commander adds an implicit `help` subcommand to nodes in some
-// configurations; never advertise it as a real command.
-function realChildNames(cmd: Command): string[] {
-  return cmd.commands
-    .map((c) => c.name())
-    .filter((n) => n !== 'help')
-    .sort();
-}
-
-// Every descendant node that itself has subcommands (a "group"), excluding the
-// root program.
-function collectGroups(cmd: Command, acc: Command[] = []): Command[] {
-  for (const child of cmd.commands) {
-    if (child.commands.length > 0) {
-      acc.push(child);
-    }
-    collectGroups(child, acc);
-  }
-  return acc;
-}
-
-function allNodes(cmd: Command, acc: Command[] = []): Command[] {
-  for (const child of cmd.commands) {
-    acc.push(child);
-    allNodes(child, acc);
-  }
-  return acc;
-}
-
-// `comments` lives under both `pr` and `snippet`; reconciled by name.
-const SPECIAL_PARENTS: Record<string, string[]> = {
-  comments: [...COMMENTS_SUBCOMMANDS].sort(),
-};
-
-// `api` is a leaf whose completion entry holds HTTP-method argument values, not
-// real subcommands — excluded from tree reconciliation, asserted separately.
-const API_VALUE_COMPLETIONS = new Set(['api']);
-
 describe('CLI completion drift (issue #255)', () => {
-  describe('Guard 1: command tree <-> completion tables', () => {
-    it('top-level command tokens match the real tree', () => {
-      const cmdTokens = ROOT_COMPLETIONS.filter(
-        (t) => !t.startsWith('-')
-      ).sort();
-      expect(cmdTokens).toEqual(realChildNames(cli));
-    });
-
-    it('root flag tokens match declared options plus built-ins', () => {
-      // `--help` is Commander's built-in; `--version` is registered via
-      // `.version()` and shows up in `cli.options`. Treat both as built-ins so
-      // the check neither requires them from `.option()` nor rejects them.
-      const builtins = new Set(['--help', '--version']);
-      const declared = new Set(
-        cli.options.map((o) => o.long).filter((l): l is string => Boolean(l))
-      );
-      const flagTokens = ROOT_COMPLETIONS.filter((t) => t.startsWith('--'));
-
-      // No phantom flags advertised that aren't real.
-      for (const flag of flagTokens) {
-        expect(declared.has(flag) || builtins.has(flag)).toBe(true);
-      }
-
-      // Every user-declared root option is advertised for completion. This is
-      // the assertion that catches a newly added global flag (e.g. it caught
-      // the missing `--jq`).
-      for (const long of declared) {
-        if (builtins.has(long)) continue;
-        expect(flagTokens).toContain(long);
-      }
-    });
-
-    it('every nested group has a completion list with exact children', () => {
-      for (const group of collectGroups(cli)) {
-        const name = group.name();
-        if (API_VALUE_COMPLETIONS.has(name)) continue;
-
-        const expected =
-          SPECIAL_PARENTS[name] ?? SUBCOMMAND_COMPLETIONS.get(name);
-        expect(
-          expected,
-          `no completion list for command group "${name}"`
-        ).toBeDefined();
-        expect(
-          [...(expected ?? [])].sort(),
-          `children drift under "${name}"`
-        ).toEqual(realChildNames(group));
-      }
-    });
-
-    it('comments group is special-cased, not in SUBCOMMAND_COMPLETIONS', () => {
-      expect(SUBCOMMAND_COMPLETIONS.has('comments')).toBe(false);
-      const groupsNamedComments = collectGroups(cli).filter(
-        (g) => g.name() === 'comments'
-      );
-      // Present under both `pr` and `snippet`.
-      expect(groupsNamedComments.length).toBe(2);
-      for (const group of groupsNamedComments) {
-        expect(realChildNames(group)).toEqual(SPECIAL_PARENTS.comments);
-      }
-    });
-
-    it('api is a value-completion leaf, not a subcommand group', () => {
-      const api = cli.commands.find((c) => c.name() === 'api');
-      expect(api, 'api command not found').toBeDefined();
-      expect(realChildNames(api as Command)).toEqual([]);
-      // The documented HTTP-method completion values still exist.
-      expect(SUBCOMMAND_COMPLETIONS.get('api')).toBeDefined();
-    });
-
-    it('no orphan SUBCOMMAND_COMPLETIONS keys', () => {
-      const groupNames = new Set(collectGroups(cli).map((g) => g.name()));
-      for (const key of SUBCOMMAND_COMPLETIONS.keys()) {
-        if (API_VALUE_COMPLETIONS.has(key)) continue;
-        expect(
-          groupNames.has(key),
-          `SUBCOMMAND_COMPLETIONS has "${key}" but no such command group exists`
-        ).toBe(true);
-      }
-    });
-
-    it('no command defines an alias (completion tables assume none)', () => {
-      for (const node of allNodes(cli)) {
-        expect(
-          node.aliases(),
-          `command "${node.name()}" defines an alias; completion tables must be updated to handle it`
-        ).toEqual([]);
-      }
-    });
-  });
-
   describe('Guard 2: wrapper-array-key registry', () => {
     // The canonical wrapper-key order. `values` is the generic paginated
     // fallback and must stay LAST (first-match-wins in projection).

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -9,7 +9,6 @@ import {
   createContext,
   extractLocaleArg,
   formatUpdateNotice,
-  getCompletionParent,
   maybePrintUpdateNotice,
   resolveNoColorSetting,
   resolveNoUnicodeSetting,
@@ -157,50 +156,6 @@ describe('withGlobalOptions', () => {
     expect(result.workspace).toBe('ws');
     // json should not be in result as it's only in globalOptions
     expect((result as Record<string, unknown>).json).toBeUndefined();
-  });
-});
-
-describe('getCompletionParent', () => {
-  it('should find snippet as the parent of comments in "bb snippet comments"', () => {
-    expect(getCompletionParent('bb snippet comments ', 'comments')).toBe(
-      'snippet'
-    );
-  });
-
-  it('should find pr as the parent of comments in "bb pr comments"', () => {
-    expect(getCompletionParent('bb pr comments ', 'comments')).toBe('pr');
-  });
-
-  it('should skip flag tokens when walking back for the parent', () => {
-    expect(getCompletionParent('bb pr --json comments ', 'comments')).toBe(
-      'pr'
-    );
-    expect(
-      getCompletionParent('bb snippet --limit 25 comments ', 'comments')
-    ).toBe('25');
-    // Explicitly require the non-flag walk: short flags should also be skipped
-    expect(getCompletionParent('bb pr -w myspace comments ', 'comments')).toBe(
-      'myspace'
-    );
-  });
-
-  it('should return undefined when the word is not present', () => {
-    expect(getCompletionParent('bb pr list', 'comments')).toBeUndefined();
-  });
-
-  it('should return undefined when the word is the first token', () => {
-    expect(getCompletionParent('comments ', 'comments')).toBeUndefined();
-  });
-
-  it('should return undefined when line is not a string', () => {
-    expect(getCompletionParent(undefined, 'comments')).toBeUndefined();
-  });
-
-  it('should use the last occurrence of the word', () => {
-    // Second "comments" is the one currently being completed
-    expect(
-      getCompletionParent('bb comments foo snippet comments ', 'comments')
-    ).toBe('snippet');
   });
 });
 

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Behavior tests for the tree-derived shell completer (issue #256).
+ *
+ * These exercise `generateCompletions` against the live `cli` Commander tree —
+ * the replacement for the old hand-maintained completion tables and their drift
+ * guard. They assert that subcommands, flags, and enum flag-values are surfaced,
+ * and that nested groups sharing a name (`pr comments` vs `snippet comments`)
+ * disambiguate structurally.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { cli } from '../src/cli.js';
+import { generateCompletions } from '../src/completion.js';
+import { PR_STATES } from '../src/types/pr.js';
+import {
+  PullrequestMergeParametersMergeStrategyEnum,
+  SnippetsWorkspaceGetRoleEnum,
+} from '../src/generated/api.js';
+
+// Convenience: run the completer for a typed line and return candidate names.
+function complete(line: string): string[] {
+  return generateCompletions(cli, { line }).map((item) => item.name);
+}
+
+describe('generateCompletions', () => {
+  describe('top-level', () => {
+    it('suggests all root commands and global flags after "bb "', () => {
+      const names = complete('bb ');
+      for (const cmd of [
+        'auth',
+        'repo',
+        'pr',
+        'snippet',
+        'browse',
+        'api',
+        'config',
+        'completion',
+      ]) {
+        expect(names).toContain(cmd);
+      }
+      // Global flags carried on the root program.
+      for (const flag of [
+        '--json',
+        '--jq',
+        '--workspace',
+        '--repo',
+        '--locale',
+      ]) {
+        expect(names).toContain(flag);
+      }
+      // Built-ins.
+      expect(names).toContain('--help');
+      expect(names).toContain('--version');
+    });
+
+    it('does not advertise Commander\'s implicit "help" command', () => {
+      expect(complete('bb ')).not.toContain('help');
+    });
+
+    it('offers --version only at the root, not on subcommands', () => {
+      expect(complete('bb pr ')).not.toContain('--version');
+    });
+  });
+
+  describe('subcommands', () => {
+    it('suggests pr subcommands after "bb pr "', () => {
+      const names = complete('bb pr ');
+      for (const sub of [
+        'create',
+        'list',
+        'view',
+        'merge',
+        'comments',
+        'reviewers',
+        'diff',
+        'checks',
+      ]) {
+        expect(names).toContain(sub);
+      }
+    });
+
+    it('suggests nested group children after "bb repo default-reviewers "', () => {
+      const names = complete('bb repo default-reviewers ');
+      expect(names).toEqual(expect.arrayContaining(['list', 'add', 'remove']));
+    });
+
+    it('completes a partial subcommand token (returns the full set; the shell filters)', () => {
+      // The word being typed is "mer"; navigation uses the tokens before it, so
+      // the resolved node is still `pr` and `merge` is among the candidates.
+      expect(complete('bb pr mer')).toContain('merge');
+    });
+  });
+
+  describe('structural disambiguation of "comments"', () => {
+    const expected = ['list', 'add', 'edit', 'delete'];
+
+    it('pr comments resolves to the pr comments group', () => {
+      const names = complete('bb pr comments ');
+      expect(names).toEqual(expect.arrayContaining(expected));
+    });
+
+    it('snippet comments resolves to the snippet comments group', () => {
+      const names = complete('bb snippet comments ');
+      expect(names).toEqual(expect.arrayContaining(expected));
+    });
+
+    it('is not confused by flags between the parent and "comments"', () => {
+      const names = complete('bb pr --json comments ');
+      expect(names).toEqual(expect.arrayContaining(expected));
+    });
+  });
+
+  describe('flag-value completion', () => {
+    it('suggests merge strategies after "bb pr merge --strategy "', () => {
+      const names = complete('bb pr merge 42 --strategy ');
+      expect(names.sort()).toEqual(
+        Object.values(PullrequestMergeParametersMergeStrategyEnum).sort()
+      );
+    });
+
+    it('suggests PR states after "bb pr list --state "', () => {
+      const names = complete('bb pr list --state ');
+      expect(names.sort()).toEqual([...PR_STATES].sort());
+    });
+
+    it('suggests snippet roles after "bb snippet list --role "', () => {
+      const names = complete('bb snippet list --role ');
+      expect(names.sort()).toEqual(
+        Object.values(SnippetsWorkspaceGetRoleEnum).sort()
+      );
+    });
+
+    it('suggests color modes after "bb pr diff --color "', () => {
+      const names = complete('bb pr diff --color ');
+      expect(names.sort()).toEqual(['always', 'auto', 'never']);
+    });
+
+    it('suggests HTTP methods after "bb api -X " (completion-only, no validation)', () => {
+      // `-X/--method` advertises choices for completion but is NOT enforced by
+      // Commander, so case-insensitive `bb api -X get` still works.
+      const names = complete('bb api -X ');
+      expect(names).toEqual(
+        expect.arrayContaining(['GET', 'POST', 'PUT', 'DELETE'])
+      );
+      expect(complete('bb api --method ')).toEqual(
+        expect.arrayContaining(['GET', 'POST'])
+      );
+    });
+
+    it('offers nothing for a required value option without choices (free-form value)', () => {
+      // After "--title " a free-form string is expected; suggesting flags or
+      // subcommands as the value would be wrong.
+      expect(complete('bb pr create --title ')).toEqual([]);
+    });
+  });
+
+  describe('self-documenting descriptions (zsh/fish)', () => {
+    // The name-only `complete()` helper above drops descriptions; here we read
+    // the raw items to assert the description field is carried, since zsh and
+    // fish surface it.
+    it('carries a description for subcommands derived from the tree', () => {
+      const items = generateCompletions(cli, { line: 'bb pr ' });
+      const merge = items.find((item) => item.name === 'merge');
+      expect(merge?.description).toBeTruthy();
+      // It mirrors the command's own Commander description, not a hand-written
+      // duplicate.
+      expect(merge?.description).toBe(
+        cli.commands
+          .find((c) => c.name() === 'pr')
+          ?.commands.find((c) => c.name() === 'merge')
+          ?.description()
+      );
+    });
+
+    it('carries a description for option flags', () => {
+      const items = generateCompletions(cli, { line: 'bb pr list ' });
+      const state = items.find((item) => item.name === '--state');
+      expect(state?.description).toBeTruthy();
+    });
+  });
+
+  describe('option flags', () => {
+    it("suggests a command's own flags plus inherited globals", () => {
+      const names = complete('bb pr list ');
+      expect(names).toContain('--state'); // own flag
+      expect(names).toContain('--limit'); // own flag
+      expect(names).toContain('--json'); // inherited global
+      expect(names).toContain('--help');
+    });
+
+    it('does not re-suggest a non-repeatable flag already on the line', () => {
+      const names = complete('bb pr list --mine ');
+      expect(names).not.toContain('--mine');
+      // Other flags are still offered.
+      expect(names).toContain('--state');
+    });
+  });
+
+  describe('global options before a subcommand', () => {
+    // A value-taking global flag before the command must not derail navigation:
+    // its value token is consumed, not treated as a positional that aborts the
+    // walk. Covers the natural `bb [global options] <command>` placement.
+    it('resolves the subcommand after "-w <ws> pr "', () => {
+      expect(complete('bb -w my-ws pr ')).toEqual(
+        expect.arrayContaining(['merge', 'list', 'comments'])
+      );
+    });
+
+    it('resolves the subcommand after "--repo <x> pr "', () => {
+      expect(complete('bb --repo a/b pr ')).toEqual(
+        expect.arrayContaining(['merge', 'list'])
+      );
+    });
+
+    it('still works for a value-less global flag ("--json pr ")', () => {
+      expect(complete('bb --json pr ')).toEqual(
+        expect.arrayContaining(['merge', 'list'])
+      );
+    });
+
+    it('resolves an enum flag-value even behind a leading global ("-w x pr merge 42 --strategy ")', () => {
+      const names = complete('bb -w x pr merge 42 --strategy ');
+      expect(names.sort()).toEqual(
+        Object.values(PullrequestMergeParametersMergeStrategyEnum).sort()
+      );
+    });
+  });
+
+  describe('robustness', () => {
+    it("stops at an unrecognized positional and offers the node's flags", () => {
+      // "42" is a PR id, not a subcommand; navigation stops at `view` and we
+      // offer its (inherited) flags rather than walking into nonsense.
+      const names = complete('bb pr view 42 ');
+      expect(names).toContain('--json');
+      expect(names).toContain('--help');
+    });
+
+    it('handles an empty / binary-only line by suggesting root commands', () => {
+      expect(complete('bb')).toContain('auth');
+      expect(complete('bb ')).toContain('pr');
+    });
+  });
+});


### PR DESCRIPTION
Closes #256.

## Summary

Replaces the parallel `ROOT_COMPLETIONS` / `SUBCOMMAND_COMPLETIONS` / `COMMENTS_SUBCOMMANDS` literals with `generateCompletions()` (`src/completion.ts`), which walks the live Commander `program.commands` tree. The completion surface is now a single source of truth: adding a command or flag updates shell completion automatically, and nested groups sharing a name (`pr comments` vs `snippet comments`) disambiguate structurally instead of by special-casing.

## Acceptance criteria (#256)

- [x] Completions generated from the Commander tree
- [x] Flag-value completion for enum options
- [x] Drift-guard test still passes / superseded

## Flag-value completion

Enum options advertise their allowed values when the cursor sits right after the flag, read generically off `option.argChoices`. Values come from a single source via `withCompletionChoices` — they are **not** duplicated in the completer:

- `bb pr merge --strategy <Tab>`
- `bb pr list --state <Tab>`
- `bb snippet list --role <Tab>`
- `bb pr diff --color <Tab>`
- `bb api -X <Tab>` (HTTP methods)

In zsh and fish each suggestion carries its description.

## Notes

- **Purely additive**: validation and error output are unchanged. `withCompletionChoices` sets `argChoices` for completion/`--help` only — it does not install Commander's parse-time enforcement, so invalid values still raise the usual `BBError` (honoring `--json`) and `bb api -X get` stays case-insensitive.
- **Drift guard**: the obsolete table↔tree reconciliation is dropped (the tables it guarded no longer exist); the unrelated `WRAPPER_ARRAY_KEYS` registry check is retained.
- `pr activity --type` is intentionally left without completion choices — it's a comma-separated multi-value filter that single-token completion can't append to; noted inline.

## Testing

- `bun run lint` — clean
- `bun run format:check` — clean
- `bun test` — 1179 pass (new `tests/completion.test.ts` covers tree navigation, each enum flag-value, inherited globals, structural disambiguation, and self-documenting descriptions)

Docs (`completion.mdx`, `quickstart.mdx`) updated to describe the new behavior, including the `api -X` example.