### PR TITLE
feat: roadmap foundations and six new command groups (pipeline, commit, status, issue, workspace, project)

### DIFF
--- a/.changeset/commit-status-command-groups.md
+++ b/.changeset/commit-status-command-groups.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add `bb commit` and `bb status` command groups. `bb commit list` lists commit history (defaulting to the current git branch, with `--ref <branch|tag|sha>` to pick any revision) and `bb commit view <sha>` shows full commit details including author, date, parents, and message. `bb status list <sha>` lists the build statuses reported on a commit, and `bb status set <sha> --key <key> --state <state>` creates or updates a build status — idempotently per key, so CI re-runs can safely re-report INPROGRESS/SUCCESSFUL/FAILED states. All commands support the standard repo-scoped context resolution, `--json`/`--jq` envelopes, and shell completion for `--state` values.

--- a/.changeset/issue-command-group.md
+++ b/.changeset/issue-command-group.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add the `bb issue` command group for Bitbucket's built-in issue tracker, mirroring `gh issue` ergonomics: `bb issue list` (with `--state`/`--kind`/`--assignee`/`--reporter` filters and a raw `--query` escape hatch), `bb issue view <id>`, `bb issue create` (`--title`, `--body`/`--body-file`, `--kind`, `--priority`, `--assignee`), `bb issue edit <id>`, `bb issue close <id>` (optionally posting a `--comment` first), and `bb issue comment <id>`. All commands emit stable `--json` envelopes, and 404s from a disabled issue tracker are reported with an actionable message pointing at Repository settings → Issue tracker (many teams use Jira instead).

--- a/.changeset/pipeline-command-group.md
+++ b/.changeset/pipeline-command-group.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add the `bb pipeline` command group for Bitbucket Pipelines (CI/CD): `bb pipeline list` (filter by `--status`/`--branch`, sortable, paginated), `bb pipeline view <id>` (details plus per-step summary), `bb pipeline run` (trigger on the current or a given branch, with `--commit`, custom `--pipeline` definitions, and repeatable `--var key=value` variables), `bb pipeline stop <id>`, and `bb pipeline logs <id>` (raw step logs with `--step` selection by UUID or index). Pipeline IDs are accepted as build numbers or UUIDs everywhere, and every command emits a stable, documented `--json` envelope.

--- a/.changeset/retry-transient-network-errors.md
+++ b/.changeset/retry-transient-network-errors.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Transient network failures (dropped sockets, temporary DNS hiccups, request timeouts) on read requests now retry up to 3 times with exponential backoff instead of failing immediately. Only idempotent methods (GET/HEAD/OPTIONS) are retried; write requests still fail fast since the CLI cannot know whether the server already processed them. Permanent-looking failures such as unknown host or connection refused are not retried.

--- a/.changeset/serialize-oauth-token-refresh.md
+++ b/.changeset/serialize-oauth-token-refresh.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+Concurrent API calls no longer race the OAuth token refresh. Refreshes are now serialized behind an in-flight lock, so parallel requests that see an expired token (or all hit 401) share a single POST to the token endpoint instead of each sending the rotated refresh token and silently logging you out.

--- a/.changeset/shared-axios-instance.md
+++ b/.changeset/shared-axios-instance.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+All API surfaces (generated Bitbucket clients, snippet file transfers, and the `bb api` passthrough) now share a single configured HTTP client, so retry/backoff, OAuth token refresh, and timeout behavior are uniform across every command.

--- a/.changeset/workspace-project-command-groups.md
+++ b/.changeset/workspace-project-command-groups.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+Add the `bb workspace` and `bb project` command groups for discovery — no more guessing slugs and keys. `bb workspace list` shows every workspace you have access to (filterable with `--role owner|collaborator|member`) so you can pick a slug for `-w/--workspace` or `bb config set defaultWorkspace`, and `bb workspace view [slug]` shows workspace details (defaulting to the current workspace context). `bb project list` lists the projects in a workspace, `bb project view <key>` shows project details, and `bb project create --key <KEY> --name <name>` creates a project (private by default, `--public` to flip; keys are validated and uppercased automatically) ready for `bb repo create -p <KEY>`. All commands work non-interactively and emit stable, documented `--json` envelopes.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -111,6 +111,11 @@ export default defineConfig({
               badge: { text: "New", variant: "tip" },
             },
             {
+              label: "Issue Commands",
+              slug: "commands/issue",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
               label: "Browse",
               slug: "commands/browse",
             },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -116,6 +116,16 @@ export default defineConfig({
               badge: { text: "New", variant: "tip" },
             },
             {
+              label: "Workspace Commands",
+              slug: "commands/workspace",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
+              label: "Project Commands",
+              slug: "commands/project",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
               label: "Browse",
               slug: "commands/browse",
             },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -101,6 +101,16 @@ export default defineConfig({
               badge: { text: "New", variant: "tip" },
             },
             {
+              label: "Commit Commands",
+              slug: "commands/commit",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
+              label: "Status Commands",
+              slug: "commands/status",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
               label: "Browse",
               slug: "commands/browse",
             },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,11 @@ export default defineConfig({
             },
             { label: "Snippet Commands", slug: "commands/snippet" },
             {
+              label: "Pipeline Commands",
+              slug: "commands/pipeline",
+              badge: { text: "New", variant: "tip" },
+            },
+            {
               label: "Browse",
               slug: "commands/browse",
             },

--- a/docs/src/content/docs/commands/commit.mdx
+++ b/docs/src/content/docs/commands/commit.mdx
@@ -1,0 +1,112 @@
+---
+title: Commit Commands - Inspect Repository History
+description: Reference for Bitbucket CLI commit commands. List commit history for a branch, tag, or revision and view full commit details from the command line.
+---
+
+Inspect commits in a Bitbucket repository — list the history of a branch, tag,
+or revision, and view the full details of a single commit.
+
+Commit commands operate at **repository** scope. Run them inside a cloned
+Bitbucket repository, or pass `-w, --workspace <workspace>` and
+`-r, --repo <repo>` explicitly.
+
+Global options available on all commit commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+Commit SHAs are accepted as raw strings: full 40-character hashes and
+abbreviated prefixes (e.g. `abc1234`) both pass through to the API unchanged,
+so humans and scripts can use whichever they have.
+
+---
+
+## `bb commit list`
+
+List commits, newest first.
+
+```bash
+bb commit list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--ref <ref>` | Branch, tag, or commit SHA to list history for (default: current git branch) |
+| `--limit <number>` | Maximum number of commits (default: 25) |
+| `--all` | List all commits (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# Inside a git repository: history of the current branch
+bb commit list
+
+bb commit list --ref main
+bb commit list --ref v1.0.0 --limit 50
+
+# Stable JSON envelope: { workspace, repoSlug, [ref], count, commits }
+bb commit list --json
+
+# Hashes only, via built-in --jq
+bb commit list --json --jq '.commits[].hash'
+```
+
+### Notes
+
+- **Default ref:** with no `--ref`, the CLI uses the current git branch when
+  run inside a git repository. When branch detection fails (outside a git
+  repository, detached HEAD), it falls back to the repository's default
+  commit listing instead of erroring.
+- The table shows the short hash (7 characters), the first line of the commit
+  message (truncated to 60 characters; disable with `--no-truncate`), the
+  author (Bitbucket display name, or the name parsed from the raw git author),
+  and the commit date.
+- `--limit` is enforced across paginated responses; a hint appears when
+  results were capped (suppressed with `--json`).
+- An unknown `--ref` returns an actionable "Ref `<ref>` not found" error.
+
+---
+
+## `bb commit view`
+
+View the full details of a single commit.
+
+```bash
+bb commit view <sha> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `sha` | Commit hash (full or abbreviated, e.g. `abc1234`) |
+
+### Examples
+
+```bash
+bb commit view abc1234
+
+# Stable JSON envelope: { workspace, repoSlug, commit }
+bb commit view abc1234 --json
+
+# Raw author string of the commit
+bb commit view abc1234 --json --jq '.commit.author.raw'
+```
+
+### Notes
+
+- The human view shows the full hash, author (raw `Name <email>` when
+  available), date, parent commits (short hashes), and the complete commit
+  message including the body.
+- In `--json` mode, `commit` is the raw commit resource as returned by the
+  Bitbucket API (hash, author, parents, message, links, ...).
+- A `404` returns an actionable "Commit `<sha>` not found" error.
+
+---
+
+## See also
+
+- [Status Commands](/commands/status/) — read and report build statuses on commits.
+- [Scripting & Automation](/guides/scripting/) — JSON envelopes, `--jq`, exit codes.

--- a/docs/src/content/docs/commands/issue.mdx
+++ b/docs/src/content/docs/commands/issue.mdx
@@ -1,0 +1,296 @@
+---
+title: Issue Commands - Manage the Bitbucket Issue Tracker
+description: Reference for Bitbucket CLI issue commands. List, view, create, edit, close, and comment on Bitbucket Cloud issues from the command line, mirroring gh issue.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Manage issues in a repository's built-in issue tracker — list, view, create,
+edit, close, and comment, mirroring the ergonomics of `gh issue`.
+
+Issue commands operate at **repository** scope. Run them inside a cloned
+Bitbucket repository, or pass `-w, --workspace <workspace>` and
+`-r, --repo <repo>` explicitly.
+
+Global options available on all issue commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+<Aside type="caution">
+  Bitbucket's issue tracker is **opt-in per repository** and disabled by
+  default — many teams use Jira instead. When the tracker is disabled, the
+  Bitbucket API answers `404` on every issues endpoint, so `bb issue list` and
+  `bb issue create` fail with: *"This repository's issue tracker is disabled
+  (or the repo was not found). Enable it under Repository settings → Issue
+  tracker on Bitbucket, or check `--workspace`/`--repo`. Many teams use Jira
+  instead — see the docs."* Enable the tracker under **Repository settings →
+  Issue tracker** before using these commands.
+</Aside>
+
+Issue IDs are accepted as raw numeric strings (e.g. `42`), so humans and
+scripts can pass them straight through.
+
+---
+
+## `bb issue list`
+
+List issues. By default only "open-ish" issues are shown (states `new` and
+`open`), sorted most recently updated first.
+
+```bash
+bb issue list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--state <state>` | Filter by exact state: `submitted`, `new`, `open`, `resolved`, `on-hold`, `invalid`, `duplicate`, `wontfix`, or `closed` |
+| `--kind <kind>` | Filter by kind: `bug`, `enhancement`, `proposal`, or `task` |
+| `--assignee <username>` | Filter by assignee username |
+| `--reporter <username>` | Filter by reporter username |
+| `--query <q>` | Raw Bitbucket `q` filter expression (escape hatch) |
+| `--limit <number>` | Maximum number of issues (default: 25) |
+| `--all` | List all issues (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue list
+bb issue list --state resolved
+bb issue list --kind bug --assignee some.user
+bb issue list --limit 50
+
+# Raw q escape hatch (replaces the default state filter)
+bb issue list --query 'priority="blocker" AND state!="closed"'
+
+# Project to specific fields (returns a flat array)
+bb issue list --json id,title,state
+
+# Filter with built-in --jq — ids of critical issues
+bb issue list --json --jq '.issues[] | select(.priority == "critical") | .id'
+```
+
+### Notes
+
+- **Filter composition:** without `--state` or `--query` the command filters on
+  `(state="new" OR state="open")`, mirroring `gh issue list` defaulting to open
+  issues. An explicit `--state` matches exactly (the CLI's `on-hold` maps to
+  the API's `"on hold"`). `--kind`, `--assignee`, and `--reporter` clauses are
+  AND-ed on. `--query` is used verbatim and replaces the default state filter,
+  but is still AND-ed with the other flags.
+- **JSON envelope:** `{ workspace, repoSlug, filters, count, issues }`. The
+  `filters` object echoes the active flags plus the effective `q` expression
+  that was sent to the API.
+- `--limit` is enforced across paginated responses; a hint shows when results
+  were capped (suppressed with `--json`).
+
+---
+
+## `bb issue view`
+
+View the full details of a single issue.
+
+```bash
+bb issue view <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Issue ID (e.g. `42`) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue view 42
+
+# Machine-readable
+bb issue view 42 --json --jq '.issue.state'
+```
+
+### Notes
+
+- Human output shows the id, title, state, kind, priority, reporter, assignee,
+  created/updated dates, votes, the issue body, and the web URL.
+- **JSON envelope:** `{ workspace, repoSlug, issue }`.
+- A `404` is reported as `Issue #<id> not found`, with a reminder that a
+  disabled issue tracker 404s identically.
+
+---
+
+## `bb issue create`
+
+Create an issue.
+
+```bash
+bb issue create --title <title> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-t, --title <title>` | Issue title (**required**) |
+| `-b, --body <text>` | Issue description (Markdown) |
+| `-F, --body-file <file>` | Read the description from a file (mutually exclusive with `--body`) |
+| `--kind <kind>` | `bug`, `enhancement`, `proposal`, or `task` |
+| `--priority <priority>` | `trivial`, `minor`, `major`, `critical`, or `blocker` |
+| `--assignee <username>` | Assign the issue to a user |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue create --title "Crash on login"
+bb issue create --title "Crash on login" --kind bug --priority major --assignee some.user
+bb issue create --title "RFC: new API" --body-file ./rfc.md
+
+# Capture the new issue id in a script
+bb issue create --title "Crash on login" --json --jq '.issue.id'
+```
+
+### Notes
+
+- On success the new issue number and its web URL are printed.
+- **JSON envelope:** `{ workspace, repoSlug, issue }` with the created issue.
+- A `404` here means the issue tracker is disabled (see the note at the top of
+  this page).
+
+---
+
+## `bb issue edit`
+
+Edit an issue. At least one change flag is required.
+
+```bash
+bb issue edit <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Issue ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-t, --title <title>` | New title |
+| `-b, --body <text>` | New description (replaces the existing body) |
+| `--kind <kind>` | New kind |
+| `--priority <priority>` | New priority |
+| `--assignee <username>` | Reassign to a user |
+| `--state <state>` | New state (`on-hold` for the API's `"on hold"`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue edit 42 --title "Crash on login (Safari only)"
+bb issue edit 42 --state on-hold --priority critical
+
+# Machine-readable
+bb issue edit 42 --assignee some.user --json --jq '.issue.assignee.display_name'
+```
+
+### Notes
+
+- Only the flags you pass are changed; everything else is left untouched.
+- **JSON envelope:** `{ workspace, repoSlug, issue }` with the updated issue.
+
+---
+
+## `bb issue close`
+
+Close an issue — sugar for `bb issue edit <id> --state closed`, optionally
+posting a comment first.
+
+```bash
+bb issue close <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Issue ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-c, --comment <text>` | Post this comment before closing |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue close 42
+bb issue close 42 --comment "Fixed in 1.4.2"
+
+# Machine-readable
+bb issue close 42 --json --jq '.issue.state'
+```
+
+### Notes
+
+- With `--comment`, the comment is posted **before** the state change so it
+  lands while the issue is still open (matching `gh issue close --comment`).
+- **JSON envelope:** `{ workspace, repoSlug, issue }` with the closed issue.
+
+---
+
+## `bb issue comment`
+
+Add a comment to an issue.
+
+```bash
+bb issue comment <id> --body <text>
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Issue ID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-b, --body <text>` | Comment text in Markdown (**required**) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb issue comment 42 --body "Reproduced on main"
+
+# Machine-readable
+bb issue comment 42 --body "Reproduced on main" --json --jq '.comment.id'
+```
+
+### Notes
+
+- **JSON envelope:** `{ workspace, repoSlug, comment }` with the created
+  comment.

--- a/docs/src/content/docs/commands/pipeline.mdx
+++ b/docs/src/content/docs/commands/pipeline.mdx
@@ -1,0 +1,217 @@
+---
+title: Pipeline Commands - Run and Inspect Bitbucket Pipelines
+description: Reference for Bitbucket CLI pipeline commands. List, view, trigger, stop, and read logs of Bitbucket Pipelines builds from the command line.
+---
+
+Manage Bitbucket Pipelines (CI/CD) — list runs, inspect builds and steps,
+trigger pipelines, stop them, and stream step logs.
+
+Pipeline commands operate at **repository** scope. Run them inside a cloned
+Bitbucket repository, or pass `-w, --workspace <workspace>` and
+`-r, --repo <repo>` explicitly.
+
+Global options available on all pipeline commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+Pipeline IDs are accepted in two forms everywhere an `<id>` is expected: the
+**build number** you see in the UI (e.g. `42`) or the **pipeline UUID**
+including curly braces (e.g. `{a1b2c3d4-...}`). Both pass through to the API
+unchanged, so humans and scripts can use whichever they have.
+
+---
+
+## `bb pipeline list`
+
+List pipelines for a repository, newest first.
+
+```bash
+bb pipeline list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--status <status>` | Filter by status: `PARSING`, `PENDING`, `PAUSED`, `HALTED`, `BUILDING`, `ERROR`, `PASSED`, `FAILED`, `STOPPED`, `UNKNOWN` (case-insensitive) |
+| `--branch <branch>` | Filter by target branch |
+| `--sort <attribute>` | Sort attribute: `created_on`, `run_creation_date`, `creator.uuid`; prefix with `-` for descending (default: `-created_on`) |
+| `--limit <number>` | Maximum number of pipelines (default: 25) |
+| `--all` | List all pipelines (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb pipeline list
+bb pipeline list --status FAILED
+bb pipeline list --branch main --limit 50
+
+# Stable JSON envelope: { workspace, repoSlug, [status], [branch], sort, count, pipelines }
+bb pipeline list --json
+
+# Build numbers of recent failures, via built-in --jq
+bb pipeline list --status FAILED --json --jq '.pipelines[].build_number'
+```
+
+### Notes
+
+- The table shows build number, status (colored), ref, trigger, created date, and duration for completed runs.
+- `--limit` is enforced across paginated responses; a hint appears when results were capped (suppressed with `--json`).
+
+---
+
+## `bb pipeline view`
+
+View pipeline details and a per-step summary.
+
+```bash
+bb pipeline view <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Pipeline build number (e.g. `42`) or UUID (e.g. `{a1b2c3d4-...}`) |
+
+### Examples
+
+```bash
+bb pipeline view 42
+bb pipeline view {a1b2c3d4-0000-0000-0000-000000000000}
+
+# Stable JSON envelope: { workspace, repoSlug, pipeline, steps }
+bb pipeline view 42 --json
+
+# Status name of the run
+bb pipeline view 42 --json --jq '.pipeline.state.result.name // .pipeline.state.name'
+```
+
+### Notes
+
+- The human view shows number, UUID, status, ref, trigger, creator, created/completed timestamps, duration, and a step table (name, status, duration).
+- A `404` returns an actionable "Pipeline `<id>` not found" error.
+
+---
+
+## `bb pipeline run`
+
+Trigger a pipeline run on a branch.
+
+```bash
+bb pipeline run [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-b, --branch <branch>` | Branch to run on (default: current git branch) |
+| `--commit <hash>` | Run against a specific commit on the branch |
+| `-p, --pipeline <name>` | Custom pipeline definition from `bitbucket-pipelines.yml` |
+| `--var <key=value...>` | Pipeline variable; repeatable, value may contain `=` |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# Run the default pipeline for the current branch
+bb pipeline run
+
+bb pipeline run --branch main
+bb pipeline run --pipeline deploy-prod --var ENV=prod --var DRY_RUN=false
+bb pipeline run --branch main --commit abc123def456
+
+# JSON returns the created pipeline resource; grab the build number
+bb pipeline run --branch main --json --jq '.build_number'
+```
+
+### Notes
+
+- Outside a git repository, `--branch` is required (the error tells you so).
+- `--pipeline <name>` selects a `custom:` pipeline defined in `bitbucket-pipelines.yml`.
+- Variables are sent unsecured; secured variables must be configured in repository settings.
+- On success the CLI prints the build number plus ready-to-paste `bb pipeline view` / `bb pipeline logs` commands.
+
+---
+
+## `bb pipeline stop`
+
+Stop a running pipeline.
+
+```bash
+bb pipeline stop <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Pipeline build number or UUID |
+
+### Examples
+
+```bash
+bb pipeline stop 42
+
+# Stable JSON envelope: { workspace, repoSlug, pipelineId, stopped }
+bb pipeline stop 42 --json --jq '.stopped'
+```
+
+### Notes
+
+- No `--yes` confirmation is required: stopping CI is reversible — rerun with `bb pipeline run`.
+
+---
+
+## `bb pipeline logs`
+
+Print the raw log of a pipeline step.
+
+```bash
+bb pipeline logs <id> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Pipeline build number or UUID |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `-s, --step <uuid-or-index>` | Step to fetch: a step UUID (braces optional) or a 1-based index |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# Single-step pipelines need no --step
+bb pipeline logs 42
+
+bb pipeline logs 42 --step 2
+bb pipeline logs 42 --step {step-uuid}
+
+# Stable JSON envelope: { workspace, repoSlug, pipelineId, stepUuid, log }
+bb pipeline logs 42 --json --jq '.log'
+```
+
+### Notes
+
+- With exactly one step, it is selected automatically.
+- With several steps and no `--step`, the CLI lists the steps (with indexes and UUIDs) instead of guessing; in `--json` mode it returns `{ workspace, repoSlug, pipelineId, count, steps }` so scripts and agents can pick a step UUID and call again.
+- The log is printed verbatim to stdout, so it pipes cleanly into `grep`, `less`, or a file.
+
+---
+
+## See also
+
+- [Scripting & Automation](/guides/scripting/) — JSON envelopes, `--jq`, exit codes.
+- [CI/CD Integration](/guides/cicd/) — using `bb` inside pipelines.

--- a/docs/src/content/docs/commands/pipeline.mdx
+++ b/docs/src/content/docs/commands/pipeline.mdx
@@ -91,6 +91,7 @@ bb pipeline view 42 --json --jq '.pipeline.state.result.name // .pipeline.state.
 ### Notes
 
 - The human view shows number, UUID, status, ref, trigger, creator, created/completed timestamps, duration, and a step table (name, status, duration).
+- The step table and the JSON `steps` array are complete even on large pipelines — the CLI follows the steps endpoint's pagination.
 - A `404` returns an actionable "Pipeline `<id>` not found" error.
 
 ---
@@ -125,8 +126,8 @@ bb pipeline run --branch main
 bb pipeline run --pipeline deploy-prod --var ENV=prod --var DRY_RUN=false
 bb pipeline run --branch main --commit abc123def456
 
-# JSON returns the created pipeline resource; grab the build number
-bb pipeline run --branch main --json --jq '.build_number'
+# Stable JSON envelope: { workspace, repoSlug, pipeline }; grab the build number
+bb pipeline run --branch main --json --jq '.pipeline.build_number'
 ```
 
 ### Notes
@@ -207,6 +208,7 @@ bb pipeline logs 42 --json --jq '.log'
 
 - With exactly one step, it is selected automatically.
 - With several steps and no `--step`, the CLI lists the steps (with indexes and UUIDs) instead of guessing; in `--json` mode it returns `{ workspace, repoSlug, pipelineId, count, steps }` so scripts and agents can pick a step UUID and call again.
+- Every step is selectable even on large pipelines — the CLI follows the steps endpoint's pagination, so indexes and UUIDs beyond the API's default page size of 10 work.
 - The log is printed verbatim to stdout, so it pipes cleanly into `grep`, `less`, or a file.
 
 ---

--- a/docs/src/content/docs/commands/project.mdx
+++ b/docs/src/content/docs/commands/project.mdx
@@ -1,0 +1,144 @@
+---
+title: Project Commands - Manage Bitbucket Projects
+description: Reference for Bitbucket CLI project commands. List, view, and create Bitbucket Cloud projects to organize repositories from the command line.
+---
+
+Manage Bitbucket Cloud projects — the grouping layer for repositories inside a
+workspace. Use these commands to discover the project keys you pass to
+`bb repo create -p <KEY>`.
+
+Project commands operate at **workspace** scope (no repo context required).
+Use `-w, --workspace <workspace>` or set a default with
+`bb config set defaultWorkspace <workspace>` — see
+[`bb workspace list`](/commands/workspace/) to discover your slugs.
+
+Global options available on all project commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
+
+---
+
+## `bb project list`
+
+List projects in a workspace.
+
+```bash
+bb project list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `--limit <number>` | Maximum number of projects (default: 25) |
+| `--all` | List all projects (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb project list
+bb project list -w my-workspace
+bb project list --all
+
+# Project to specific fields (returns a flat array)
+bb project list --json key,name
+
+# Grab keys for scripting with built-in --jq
+bb project list --json --jq '.projects[].key'
+```
+
+### JSON output
+
+The `--json` envelope is `{ workspace, count, projects }`, where `projects` is
+the array of project objects.
+
+### Notes
+
+- Long descriptions are truncated to 50 characters in the table (disable with
+  the global `--no-truncate`); `--json` always carries the full values.
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
+
+---
+
+## `bb project view`
+
+View project details.
+
+```bash
+bb project view <key> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `key` | Project key (e.g. `PROJ`; lowercase input is uppercased automatically) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb project view PROJ
+bb project view PROJ -w my-workspace
+
+# Stable JSON envelope: { workspace, project }
+bb project view PROJ --json --jq '.project.name'
+```
+
+### Notes
+
+- Bitbucket stores project keys uppercased, so `bb project view proj` resolves
+  the same project as `bb project view PROJ`.
+- An unknown key returns `Project <KEY> not found in workspace <workspace>.`
+  (exit code 1, `--json` gives a structured error envelope).
+
+---
+
+## `bb project create`
+
+Create a new project in a workspace.
+
+```bash
+bb project create [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-k, --key <key>` | Project key, e.g. `PROJ` (required; uppercased automatically) |
+| `-n, --name <name>` | Project name (required) |
+| `-d, --description <description>` | Project description |
+| `--private` | Create a private project (default) |
+| `--public` | Create a public project |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb project create --key PROJ --name "My Project"
+bb project create -k PROJ -n "My Project" -d "Team things" --public
+
+# Then create repositories inside it
+bb repo create my-repo -p PROJ
+
+# Stable JSON envelope: { workspace, project }
+bb project create -k PROJ -n "My Project" --json --jq '.project.key'
+```
+
+### Notes
+
+- Projects are private by default; `--private` and `--public` cannot both be
+  set. Note that private projects cannot contain public repositories.
+- Keys must start with a letter and contain only letters, digits, and
+  underscores. Bitbucket requires uppercase keys, so lowercase input is
+  uppercased automatically (the CLI prints a note when it does).
+- The command is fully non-interactive: all inputs are flags, so it is safe
+  for scripts and automation.

--- a/docs/src/content/docs/commands/status.mdx
+++ b/docs/src/content/docs/commands/status.mdx
@@ -1,0 +1,148 @@
+---
+title: Status Commands - Commit Build Statuses
+description: Reference for Bitbucket CLI status commands. List build statuses on a commit and report CI build results (INPROGRESS, SUCCESSFUL, FAILED) from scripts and pipelines.
+---
+
+Manage build statuses on commits — the red/green/yellow indicators Bitbucket
+shows next to commits and pull requests. `bb status set` is built for CI
+scripts: it is non-interactive, idempotent per status key, and JSON-friendly.
+
+Status commands operate at **repository** scope. Run them inside a cloned
+Bitbucket repository, or pass `-w, --workspace <workspace>` and
+`-r, --repo <repo>` explicitly.
+
+Global options available on all status commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+---
+
+## `bb status list`
+
+List the build statuses reported on a commit.
+
+```bash
+bb status list <sha> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `sha` | Commit hash (full or abbreviated, e.g. `abc1234`) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--limit <number>` | Maximum number of statuses (default: 25) |
+| `--all` | List all statuses (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb status list abc1234
+bb status list abc1234 --all
+
+# Stable JSON envelope: { workspace, repoSlug, commit, count, statuses }
+bb status list abc1234 --json
+
+# States only, via built-in --jq
+bb status list abc1234 --json --jq '.statuses[].state'
+```
+
+### Notes
+
+- The table shows the status key, state (colored: green `SUCCESSFUL`, red
+  `FAILED`, yellow `INPROGRESS`, gray `STOPPED`), name, description
+  (truncated to 40 characters; disable with `--no-truncate`), and URL —
+  the same rendering as `bb pr checks`.
+- A `404` returns an actionable "Commit `<sha>` not found" error.
+
+---
+
+## `bb status set`
+
+Create or update a build status on a commit.
+
+```bash
+bb status set <sha> --key <key> --state <state> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `sha` | Commit hash (full or abbreviated) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace |
+| `-r, --repo <repo>` | Repository |
+| `--key <key>` | **Required.** Unique status key, e.g. `BB-DEPLOY`. Re-running with the same key updates the existing status. |
+| `--state <state>` | **Required.** One of `SUCCESSFUL`, `FAILED`, `INPROGRESS`, `STOPPED` (case-insensitive) |
+| `--url <url>` | Link back to the build system |
+| `--name <name>` | Build identifier, e.g. `BB-DEPLOY-1` |
+| `--description <description>` | Short build description |
+| `--refname <refname>` | Ref the build ran on, e.g. a branch name |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb status set abc1234 --key CI --state INPROGRESS
+bb status set abc1234 --key CI --state SUCCESSFUL --url https://ci.example.com/builds/42
+bb status set abc1234 --key LINT --state FAILED --description "ESLint found 3 errors" --refname main
+
+# Stable JSON envelope: { workspace, repoSlug, commit, status }
+bb status set abc1234 --key CI --state SUCCESSFUL --json --jq '.status.state'
+```
+
+#### CI recipe: wrap a build in INPROGRESS → SUCCESSFUL/FAILED
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHA="$(git rev-parse HEAD)"
+KEY="CI"
+URL="https://ci.example.com/builds/${BUILD_ID:-local}"
+
+# Mark the commit as building before the work starts
+bb status set "$SHA" --key "$KEY" --state INPROGRESS --url "$URL" \
+  --name "CI Build ${BUILD_ID:-local}" --refname "$(git branch --show-current)"
+
+# Run the build; report the result either way
+if ./run-build.sh; then
+  bb status set "$SHA" --key "$KEY" --state SUCCESSFUL --url "$URL"
+else
+  bb status set "$SHA" --key "$KEY" --state FAILED --url "$URL" \
+    --description "Build failed; see logs"
+  exit 1
+fi
+```
+
+### Notes
+
+- **Idempotent per key:** the CLI first POSTs a new status; if Bitbucket
+  rejects it because a status with that key already exists on the commit
+  (typical on CI re-runs), it automatically falls back to updating the
+  existing status via PUT. Repeated `bb status set` calls with the same
+  `--key` are therefore always safe.
+- `--state` is validated client-side against the API enum; an invalid value
+  lists the allowed states.
+- On success the CLI prints `✓ Status <key> set to <state> on <short-sha>`;
+  with `--json` it returns the resulting status resource wrapped in
+  `{ workspace, repoSlug, commit, status }`.
+- These statuses are what `bb pr checks` aggregates for a pull request.
+
+---
+
+## See also
+
+- [Commit Commands](/commands/commit/) — list and inspect the commits themselves.
+- [CI/CD Integration](/guides/cicd/) — using `bb` inside pipelines.
+- [Scripting & Automation](/guides/scripting/) — JSON envelopes, `--jq`, exit codes.

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -1,0 +1,108 @@
+---
+title: Workspace Commands - Discover Bitbucket Workspaces
+description: Reference for Bitbucket CLI workspace commands. List the workspaces you have access to and view workspace details from the command line.
+---
+
+Discover and inspect Bitbucket Cloud workspaces. Use these commands to find
+the workspace slugs you need for `-w, --workspace`, for
+[`bb config set defaultWorkspace`](/reference/configuration/), and for
+`bb repo create`.
+
+Workspace commands operate at **account** scope: `bb workspace list` needs no
+workspace context at all (it lists your own workspaces), while
+`bb workspace view` falls back to the resolved workspace context when no slug
+is passed.
+
+Global options available on all workspace commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
+
+---
+
+## `bb workspace list`
+
+List the workspaces the authenticated user has access to.
+
+```bash
+bb workspace list [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--role <role>` | Filter by your role: `owner`, `collaborator`, or `member` |
+| `--limit <number>` | Maximum number of workspaces (default: 25) |
+| `--all` | List all workspaces (overrides `--limit`) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+bb workspace list
+bb workspace list --role owner
+bb workspace list --all
+
+# Project to specific fields (returns a flat array)
+bb workspace list --json slug,name
+
+# Grab slugs for scripting with built-in --jq
+bb workspace list --json --jq '.workspaces[].slug'
+```
+
+### JSON output
+
+The `--json` envelope is `{ filters, count, workspaces }`, where `workspaces`
+is the array of workspace objects and `filters` echoes the active `--role`
+filter (empty object when unfiltered).
+
+### Notes
+
+- Requires no workspace context — this is the discovery entry point when you
+  do not know your slugs yet.
+- After listing, use a slug with `-w <slug>` on any command, or set a default
+  once: `bb config set defaultWorkspace <slug>`.
+- Role semantics: `owner` = admin access, `collaborator` = write access to at
+  least one repository, `member` = member of at least one group or repository.
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
+
+---
+
+## `bb workspace view`
+
+View workspace details.
+
+```bash
+bb workspace view [slug] [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `slug` | Workspace slug (optional; defaults to the resolved workspace context) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-w, --workspace <workspace>` | Workspace (used when no `slug` argument is passed) |
+| `--json` | Output as JSON |
+
+### Examples
+
+```bash
+# View the current workspace (from -w, the current repo, or defaultWorkspace)
+bb workspace view
+
+bb workspace view my-workspace
+
+# Stable JSON envelope: { workspace: { ... } }
+bb workspace view my-workspace --json --jq '.workspace.uuid'
+```
+
+### Notes
+
+- Without a `slug`, the workspace is resolved like any other command: `-w`
+  flag, then the current repository's remote, then the configured
+  `defaultWorkspace`.
+- A missing or inaccessible workspace returns a clear not-found error
+  (exit code 1, `--json` gives a structured error envelope).

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -90,7 +90,8 @@ bb workspace view [slug] [options]
 ### Examples
 
 ```bash
-# View the current workspace (from -w, the current repo, or defaultWorkspace)
+# View the current workspace (from -w, the current repo's remote,
+# BB_WORKSPACE, or defaultWorkspace)
 bb workspace view
 
 bb workspace view my-workspace
@@ -102,7 +103,8 @@ bb workspace view my-workspace --json --jq '.workspace.uuid'
 ### Notes
 
 - Without a `slug`, the workspace is resolved like any other command: `-w`
-  flag, then the current repository's remote, then the configured
+  flag, then the current repository's Bitbucket remote, then the
+  `BB_WORKSPACE` environment variable, then the configured
   `defaultWorkspace`.
 - A missing or inaccessible workspace returns a clear not-found error
   (exit code 1, `--json` gives a structured error envelope).

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -111,6 +111,12 @@ Here are the commands you'll use most often:
 
 ## Set a Default Workspace
 
+Not sure what your workspace slug is? List the workspaces you have access to:
+
+```bash
+bb workspace list
+```
+
 If you work primarily in one workspace, set it as default:
 
 ```bash

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -44,7 +44,11 @@ Pick your editor and paste the command:
     **Draft:** `bb pr create -t "WIP" --draft` → later `bb pr ready <id>`
     **Comments:** `bb pr comments list <id>` / `bb pr comments add <id> "text"`
     **Repos:** `bb repo list`, `bb repo clone workspace/repo`, `bb repo view`
-    **Raw API:** `bb api <endpoint>` — any Bitbucket 2.0 endpoint not covered above (e.g. `bb api /repositories/{workspace}/{repo}/issues`; supports `--paginate` and `--jq`)
+    **CI/CD:** `bb pipeline list`, `bb pipeline run --branch main`, `bb pipeline view/logs/stop <id>`
+    **Commits:** `bb commit list`, `bb commit view <sha>`; build statuses: `bb status list <sha>`, `bb status set <sha> --key CI --state SUCCESSFUL`
+    **Issues:** `bb issue list`, `bb issue view <id>`, `bb issue create -t "title"`, `bb issue edit/comment/close <id>`
+    **Workspaces & projects:** `bb workspace list/view`, `bb project list/view/create`
+    **Raw API:** `bb api <endpoint>` — any Bitbucket 2.0 endpoint not covered above (e.g. `bb api /repositories/{workspace}/{repo}/branch-restrictions`; supports `--paginate` and `--jq`)
 
     ## Tips
 
@@ -91,8 +95,24 @@ Pick your editor and paste the command:
     - `bb repo list` / `bb repo view` / `bb repo clone workspace/repo`
     - `bb repo default-reviewers list` / `add <uuid>` / `remove <uuid> --yes` - Manage repo default reviewers
 
+    **Pipelines (CI/CD):**
+    - `bb pipeline list` / `bb pipeline view <id>` / `bb pipeline logs <id> --step <n>`
+    - `bb pipeline run --branch main` / `bb pipeline stop <id>`
+
+    **Commits & build statuses:**
+    - `bb commit list` / `bb commit view <sha>`
+    - `bb status list <sha>` / `bb status set <sha> --key CI --state SUCCESSFUL`
+
+    **Issues:**
+    - `bb issue list` / `bb issue view <id>` / `bb issue create -t "title"`
+    - `bb issue edit <id>` / `bb issue comment <id> -b "text"` / `bb issue close <id>`
+
+    **Workspaces & projects:**
+    - `bb workspace list` / `bb workspace view [slug]`
+    - `bb project list` / `bb project view <key>` / `bb project create`
+
     **Raw API access:**
-    - `bb api <endpoint>` - Authenticated call to any Bitbucket 2.0 endpoint (escape hatch for anything without a typed command; e.g. `bb api /repositories/{workspace}/{repo}/issues`; supports `--paginate` and `--jq`)
+    - `bb api <endpoint>` - Authenticated call to any Bitbucket 2.0 endpoint (escape hatch for anything without a typed command; e.g. `bb api /repositories/{workspace}/{repo}/branch-restrictions`; supports `--paginate` and `--jq`)
 
     **Configuration:**
     - `bb config set defaultWorkspace myworkspace`
@@ -137,6 +157,10 @@ Pick your editor and paste the command:
     - `bb pr ready <id>` - Mark draft as ready
     - `bb pr comments add <id> "text"` - Comment on PR
     - `bb repo list/view/clone` - Repository operations
+    - `bb pipeline list/view/run/stop/logs` - CI/CD pipelines
+    - `bb commit list/view` + `bb status list/set <sha>` - Commits and build statuses
+    - `bb issue list/view/create/edit/comment/close` - Issue tracker
+    - `bb workspace list/view` + `bb project list/view/create` - Workspaces and projects
     - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
@@ -167,6 +191,10 @@ Pick your editor and paste the command:
     - `bb pr ready <id>` - Mark draft as ready
     - `bb pr comments add <id> "text"` - Comment on PR
     - `bb repo list/view/clone` - Repository operations
+    - `bb pipeline list/view/run/stop/logs` - CI/CD pipelines
+    - `bb commit list/view` + `bb status list/set <sha>` - Commits and build statuses
+    - `bb issue list/view/create/edit/comment/close` - Issue tracker
+    - `bb workspace list/view` + `bb project list/view/create` - Workspaces and projects
     - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
@@ -284,6 +312,12 @@ bb auth login   # Reads from env vars automatically
 | `admin:repository:bitbucket` | `bb repo delete` — delete repos (optional) |
 | `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view`, `bb pr diff` — browse PRs |
 | `write:pullrequest:bitbucket` | `bb pr create`, `bb pr merge`, `bb pr approve` — manage PRs |
+| `read:pipeline:bitbucket` | `bb pipeline list`, `bb pipeline view`, `bb pipeline logs` — inspect CI/CD |
+| `write:pipeline:bitbucket` | `bb pipeline run`, `bb pipeline stop` — control CI/CD |
+| `read:issue:bitbucket` | `bb issue list`, `bb issue view` — browse issues |
+| `write:issue:bitbucket` | `bb issue create`, `bb issue edit`, `bb issue close` — manage issues |
+| `read:workspace:bitbucket` | `bb workspace list`, `bb workspace view` — discover workspaces |
+| `read:project:bitbucket` | `bb project list`, `bb project view` — browse projects |
 
 <Aside type="tip">
   For read-only workflows (listing and viewing PRs), you only need the `read` scopes. OAuth users don't need to select scopes manually — they are requested automatically.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -87,6 +87,16 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
+  <Card title="CI/CD from the Terminal" icon="approve-check">
+    Trigger, inspect, and stop Bitbucket Pipelines without leaving your shell.
+
+    ```bash
+    bb pipeline run --branch main
+    bb pipeline list --status FAILED
+    bb pipeline logs 42
+    ```
+  </Card>
+
   <Card title="Jump to the Web UI" icon="external">
     Open Bitbucket pages — PRs, files, commits, settings — in your browser.
 

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -301,6 +301,8 @@ bb config set defaultWorkspace myworkspace
 
 **Cause:** The request failed before an HTTP response was received (offline, DNS issue, proxy/TLS issue, etc.).
 
+Transient failures (dropped connections, temporary DNS errors, timeouts) on read requests are automatically retried up to 3 times with exponential backoff before this error surfaces. Permanent-looking failures (e.g. unknown host, connection refused) and write requests fail immediately.
+
 **Solution:**
 - Check internet and DNS connectivity
 - Verify proxy/TLS settings if applicable

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -147,7 +147,7 @@ The CLI uses a small number of consistent output patterns. Understanding these p
 
 ### Pattern 1: Collection (List Commands)
 
-Used by: `pr list`, `repo list`, `pr comments list`, `pr activity`, `pr reviewers list`, `pr checks`
+Used by: `pr list`, `repo list`, `pr comments list`, `pr activity`, `pr reviewers list`, `pr checks`, `pipeline list`, `commit list`, `status list`, `issue list`, `workspace list`, `project list`, `snippet list`
 
 Returns an envelope with metadata and a named array:
 
@@ -166,11 +166,13 @@ Returns an envelope with metadata and a named array:
 
 | Field | Type | Present in |
 |-------|------|-----------|
-| `workspace` | string | PR and repo collections |
-| `repoSlug` | string | PR collections |
+| `workspace` | string | Repository- and workspace-scoped collections (PR, repo, pipeline, commit, status, issue, project) |
+| `repoSlug` | string | Repository-scoped collections (PR, pipeline, commit, status, issue) |
 | `count` | number | All collections |
 | `state` | string | `pr list` |
-| `filters` | object | `pr list` (when `--mine` is used), `pr activity` |
+| `filters` | object | `pr list` (when `--mine` is used), `pr activity`, `issue list`, `workspace list` |
+| `commit` | string | `status list` |
+| `sort` | string | `pipeline list` |
 
 **Collection key names:**
 
@@ -182,6 +184,13 @@ Returns an envelope with metadata and a named array:
 | `pr activity` | `activities` |
 | `pr reviewers list` | `reviewers` |
 | `pr checks` | `statuses` (inside a `summary` + `statuses` structure) |
+| `pipeline list` | `pipelines` |
+| `commit list` | `commits` |
+| `status list` | `statuses` |
+| `issue list` | `issues` |
+| `workspace list` | `workspaces` |
+| `project list` | `projects` |
+| `snippet list` | `snippets` |
 
 #### Example: `bb pr list --json`
 

--- a/docs/src/content/docs/reference/token-scopes.mdx
+++ b/docs/src/content/docs/reference/token-scopes.mdx
@@ -24,11 +24,18 @@ The CLI uses these scopes:
 | Scope | Grants |
 |-------|--------|
 | `read:user:bitbucket` | Read your own user profile (required by `bb auth status`, used to verify any login) |
-| `read:repository:bitbucket` | List and view repositories, list default reviewers |
-| `write:repository:bitbucket` | Create repositories, manage default reviewers |
+| `read:repository:bitbucket` | List and view repositories, commits, and commit build statuses; list default reviewers |
+| `write:repository:bitbucket` | Create repositories, manage default reviewers, set commit build statuses |
 | `admin:repository:bitbucket` | Delete repositories |
 | `read:pullrequest:bitbucket` | List, view, and diff pull requests; read comments, activity, checks, and reviewers |
 | `write:pullrequest:bitbucket` | Create, edit, approve, decline, merge, and mark PRs ready; add/edit/delete comments; add/remove reviewers |
+| `read:pipeline:bitbucket` | List and view pipelines and their steps, read step logs |
+| `write:pipeline:bitbucket` | Trigger and stop pipelines |
+| `read:issue:bitbucket` | List and view issues |
+| `write:issue:bitbucket` | Create, edit, comment on, and close issues |
+| `read:workspace:bitbucket` | List and view workspaces |
+| `read:project:bitbucket` | List and view projects |
+| `admin:project:bitbucket` | Create projects |
 | `read:snippet:bitbucket` | List and view snippets |
 | `write:snippet:bitbucket` | Create, edit, and delete snippets |
 
@@ -85,6 +92,61 @@ context).
 | `bb pr reviewers add` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
 | `bb pr reviewers remove` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
 
+### Pipelines (`bb pipeline …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb pipeline list` | `read:pipeline:bitbucket` |
+| `bb pipeline view` | `read:pipeline:bitbucket` |
+| `bb pipeline logs` | `read:pipeline:bitbucket` |
+| `bb pipeline run` | `write:pipeline:bitbucket` |
+| `bb pipeline stop` | `write:pipeline:bitbucket` |
+
+### Commits (`bb commit …`)
+
+Commits are part of the repository resource, so commit commands reuse the
+repository scopes:
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb commit list` | `read:repository:bitbucket` |
+| `bb commit view` | `read:repository:bitbucket` |
+
+### Build Statuses (`bb status …`)
+
+Commit build statuses also live under the repository resource:
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb status list` | `read:repository:bitbucket` |
+| `bb status set` | `write:repository:bitbucket` |
+
+### Issues (`bb issue …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb issue list` | `read:issue:bitbucket` |
+| `bb issue view` | `read:issue:bitbucket` |
+| `bb issue create` | `write:issue:bitbucket` |
+| `bb issue edit` | `write:issue:bitbucket` |
+| `bb issue close` | `write:issue:bitbucket` |
+| `bb issue comment` | `write:issue:bitbucket` |
+
+### Workspaces (`bb workspace …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb workspace list` | `read:workspace:bitbucket` |
+| `bb workspace view` | `read:workspace:bitbucket` |
+
+### Projects (`bb project …`)
+
+| Command | Required scopes |
+|---------|-----------------|
+| `bb project list` | `read:project:bitbucket` |
+| `bb project view` | `read:project:bitbucket` |
+| `bb project create` | `admin:project:bitbucket` |
+
 ### Snippets (`bb snippet …`)
 
 | Command | Required scopes |
@@ -114,6 +176,7 @@ creating the token.
 read:user:bitbucket
 read:repository:bitbucket
 read:pullrequest:bitbucket
+read:pipeline:bitbucket
 ```
 
 ### Bot account that creates and merges PRs
@@ -132,6 +195,25 @@ read:user:bitbucket
 read:repository:bitbucket
 write:repository:bitbucket
 admin:repository:bitbucket
+```
+
+### CI/CD automation (trigger pipelines, report build statuses)
+
+```
+read:user:bitbucket
+read:repository:bitbucket
+write:repository:bitbucket
+read:pipeline:bitbucket
+write:pipeline:bitbucket
+```
+
+### Issue triage bot
+
+```
+read:user:bitbucket
+read:repository:bitbucket
+read:issue:bitbucket
+write:issue:bitbucket
 ```
 
 <Aside type="caution" title="Principle of least privilege">

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -28,6 +28,7 @@ import {
   UsersApi,
   CommitStatusesApi,
   SnippetsApi,
+  PipelinesApi,
 } from './generated/api.js';
 
 // Auth commands
@@ -79,6 +80,13 @@ import { ListSnippetCommentsCommand } from './commands/snippet/comments.list.com
 import { AddSnippetCommentCommand } from './commands/snippet/comments.add.command.js';
 import { EditSnippetCommentCommand } from './commands/snippet/comments.edit.command.js';
 import { DeleteSnippetCommentCommand } from './commands/snippet/comments.delete.command.js';
+
+// Pipeline commands
+import { ListPipelinesCommand } from './commands/pipeline/list.command.js';
+import { ViewPipelineCommand } from './commands/pipeline/view.command.js';
+import { RunPipelineCommand } from './commands/pipeline/run.command.js';
+import { StopPipelineCommand } from './commands/pipeline/stop.command.js';
+import { LogsPipelineCommand } from './commands/pipeline/logs.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -199,6 +207,7 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     CommitStatusesApi
   );
   registerApiClient(container, ServiceTokens.SnippetsApi, SnippetsApi);
+  registerApiClient(container, ServiceTokens.PipelinesApi, PipelinesApi);
 
   registerCommand(
     container,
@@ -569,6 +578,59 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     DeleteSnippetCommentCommand,
     [
       ServiceTokens.SnippetsApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Pipeline commands
+  registerCommand(
+    container,
+    ServiceTokens.ListPipelinesCommand,
+    ListPipelinesCommand,
+    [
+      ServiceTokens.PipelinesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.ViewPipelineCommand,
+    ViewPipelineCommand,
+    [
+      ServiceTokens.PipelinesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.RunPipelineCommand,
+    RunPipelineCommand,
+    [
+      ServiceTokens.PipelinesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.GitService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.StopPipelineCommand,
+    StopPipelineCommand,
+    [
+      ServiceTokens.PipelinesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.LogsPipelineCommand,
+    LogsPipelineCommand,
+    [
+      ServiceTokens.PipelinesApi,
       ServiceTokens.ContextService,
       ServiceTokens.OutputService,
     ]

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -30,6 +30,7 @@ import {
   CommitsApi,
   SnippetsApi,
   PipelinesApi,
+  IssueTrackerApi,
 } from './generated/api.js';
 
 // Auth commands
@@ -96,6 +97,14 @@ import { ViewCommitCommand } from './commands/commit/view.command.js';
 // Status commands (commit build statuses)
 import { ListCommitStatusesCommand } from './commands/status/list.command.js';
 import { SetCommitStatusCommand } from './commands/status/set.command.js';
+
+// Issue commands
+import { ListIssuesCommand } from './commands/issue/list.command.js';
+import { ViewIssueCommand } from './commands/issue/view.command.js';
+import { CreateIssueCommand } from './commands/issue/create.command.js';
+import { EditIssueCommand } from './commands/issue/edit.command.js';
+import { CloseIssueCommand } from './commands/issue/close.command.js';
+import { CommentIssueCommand } from './commands/issue/comment.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -218,6 +227,7 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   registerApiClient(container, ServiceTokens.CommitsApi, CommitsApi);
   registerApiClient(container, ServiceTokens.SnippetsApi, SnippetsApi);
   registerApiClient(container, ServiceTokens.PipelinesApi, PipelinesApi);
+  registerApiClient(container, ServiceTokens.IssueTrackerApi, IssueTrackerApi);
 
   registerCommand(
     container,
@@ -686,6 +696,58 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     SetCommitStatusCommand,
     [
       ServiceTokens.CommitStatusesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Issue commands
+  registerCommand(
+    container,
+    ServiceTokens.ListIssuesCommand,
+    ListIssuesCommand,
+    [
+      ServiceTokens.IssueTrackerApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(container, ServiceTokens.ViewIssueCommand, ViewIssueCommand, [
+    ServiceTokens.IssueTrackerApi,
+    ServiceTokens.ContextService,
+    ServiceTokens.OutputService,
+  ]);
+  registerCommand(
+    container,
+    ServiceTokens.CreateIssueCommand,
+    CreateIssueCommand,
+    [
+      ServiceTokens.IssueTrackerApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(container, ServiceTokens.EditIssueCommand, EditIssueCommand, [
+    ServiceTokens.IssueTrackerApi,
+    ServiceTokens.ContextService,
+    ServiceTokens.OutputService,
+  ]);
+  registerCommand(
+    container,
+    ServiceTokens.CloseIssueCommand,
+    CloseIssueCommand,
+    [
+      ServiceTokens.IssueTrackerApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.CommentIssueCommand,
+    CommentIssueCommand,
+    [
+      ServiceTokens.IssueTrackerApi,
       ServiceTokens.ContextService,
       ServiceTokens.OutputService,
     ]

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -108,9 +108,8 @@ type ApiClientCtor<T> = new (
 ) => T;
 
 /**
- * Register a generated OpenAPI client. Each client follows the same pattern:
- * pull ConfigService + OAuthService, build an axios instance, construct with
- * `new Ctor(undefined, undefined, axios)`.
+ * Register a generated OpenAPI client. Each client resolves the shared axios
+ * instance lazily and is constructed with `new Ctor(undefined, undefined, axios)`.
  */
 function registerApiClient<T>(
   container: Container,
@@ -118,19 +117,8 @@ function registerApiClient<T>(
   ctor: ApiClientCtor<T>
 ): void {
   container.register(token, () => {
-    const credentialStore = container.resolve<ConfigService>(
-      ServiceTokens.CredentialStore
-    );
-    const oauthService = container.resolve<OAuthService>(
-      ServiceTokens.OAuthService
-    );
-    const outputService = container.resolve<OutputService>(
-      ServiceTokens.OutputService
-    );
-    const axiosInstance = createApiClient(
-      credentialStore,
-      outputService,
-      oauthService
+    const axiosInstance = container.resolve<AxiosInstance>(
+      ServiceTokens.SharedApiAxios
     );
     return new ctor(undefined, undefined, axiosInstance);
   });
@@ -182,19 +170,13 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ServiceTokens.ConfigService,
   ]);
 
-  // API clients backed by a per-client axios instance
-  registerApiClient(container, ServiceTokens.PullrequestsApi, PullrequestsApi);
-  registerApiClient(container, ServiceTokens.RepositoriesApi, RepositoriesApi);
-  registerApiClient(container, ServiceTokens.UsersApi, UsersApi);
-  registerApiClient(
-    container,
-    ServiceTokens.CommitStatusesApi,
-    CommitStatusesApi
-  );
-
-  // Snippets share one axios instance between the generated API and the
-  // raw-file helper service, so they register the axios separately.
-  container.register(ServiceTokens.SnippetsAxios, () => {
+  // One shared axios instance backs every API surface: the generated clients,
+  // the snippet raw-file helper, and the `bb api` passthrough. Auth, retry/
+  // backoff, OAuth refresh, and timeout behavior are configured once and stay
+  // uniform across all of them. Sharing is safe because per-request interceptor
+  // state (__retryCount / __tokenRefreshed) lives on each request's config
+  // object, never on the instance itself.
+  container.register(ServiceTokens.SharedApiAxios, () => {
     const credentialStore = container.resolve<ConfigService>(
       ServiceTokens.CredentialStore
     );
@@ -206,17 +188,23 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     );
     return createApiClient(credentialStore, outputService, oauthService);
   });
-  container.register(ServiceTokens.SnippetsApi, () => {
-    const axiosInstance = container.resolve<AxiosInstance>(
-      ServiceTokens.SnippetsAxios
-    );
-    return new SnippetsApi(undefined, undefined, axiosInstance);
-  });
+
+  // Generated API clients, all constructed on the shared axios instance
+  registerApiClient(container, ServiceTokens.PullrequestsApi, PullrequestsApi);
+  registerApiClient(container, ServiceTokens.RepositoriesApi, RepositoriesApi);
+  registerApiClient(container, ServiceTokens.UsersApi, UsersApi);
+  registerApiClient(
+    container,
+    ServiceTokens.CommitStatusesApi,
+    CommitStatusesApi
+  );
+  registerApiClient(container, ServiceTokens.SnippetsApi, SnippetsApi);
+
   registerCommand(
     container,
     ServiceTokens.SnippetFilesService,
     SnippetFilesService,
-    [ServiceTokens.SnippetsAxios]
+    [ServiceTokens.SharedApiAxios]
   );
 
   registerCommand(
@@ -610,22 +598,10 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ServiceTokens.OutputService,
   ]);
 
-  // Raw API passthrough (bb api). Uses its own axios instance built from the
-  // authenticated stack, mirroring the SnippetsAxios pattern.
-  container.register(ServiceTokens.ApiAxios, () => {
-    const credentialStore = container.resolve<ConfigService>(
-      ServiceTokens.CredentialStore
-    );
-    const oauthService = container.resolve<OAuthService>(
-      ServiceTokens.OAuthService
-    );
-    const outputService = container.resolve<OutputService>(
-      ServiceTokens.OutputService
-    );
-    return createApiClient(credentialStore, outputService, oauthService);
-  });
+  // Raw API passthrough (bb api) rides on the same shared axios instance as
+  // the generated clients, so it inherits identical auth/retry/timeout rules.
   registerCommand(container, ServiceTokens.ApiCommand, ApiCommand, [
-    ServiceTokens.ApiAxios,
+    ServiceTokens.SharedApiAxios,
     ServiceTokens.ContextService,
     ServiceTokens.OutputService,
   ]);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -27,6 +27,7 @@ import {
   RepositoriesApi,
   UsersApi,
   CommitStatusesApi,
+  CommitsApi,
   SnippetsApi,
   PipelinesApi,
 } from './generated/api.js';
@@ -87,6 +88,14 @@ import { ViewPipelineCommand } from './commands/pipeline/view.command.js';
 import { RunPipelineCommand } from './commands/pipeline/run.command.js';
 import { StopPipelineCommand } from './commands/pipeline/stop.command.js';
 import { LogsPipelineCommand } from './commands/pipeline/logs.command.js';
+
+// Commit commands
+import { ListCommitsCommand } from './commands/commit/list.command.js';
+import { ViewCommitCommand } from './commands/commit/view.command.js';
+
+// Status commands (commit build statuses)
+import { ListCommitStatusesCommand } from './commands/status/list.command.js';
+import { SetCommitStatusCommand } from './commands/status/set.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -206,6 +215,7 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     ServiceTokens.CommitStatusesApi,
     CommitStatusesApi
   );
+  registerApiClient(container, ServiceTokens.CommitsApi, CommitsApi);
   registerApiClient(container, ServiceTokens.SnippetsApi, SnippetsApi);
   registerApiClient(container, ServiceTokens.PipelinesApi, PipelinesApi);
 
@@ -631,6 +641,51 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     LogsPipelineCommand,
     [
       ServiceTokens.PipelinesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Commit commands
+  registerCommand(
+    container,
+    ServiceTokens.ListCommitsCommand,
+    ListCommitsCommand,
+    [
+      ServiceTokens.CommitsApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.GitService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.ViewCommitCommand,
+    ViewCommitCommand,
+    [
+      ServiceTokens.CommitsApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Status commands (commit build statuses)
+  registerCommand(
+    container,
+    ServiceTokens.ListCommitStatusesCommand,
+    ListCommitStatusesCommand,
+    [
+      ServiceTokens.CommitStatusesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.SetCommitStatusCommand,
+    SetCommitStatusCommand,
+    [
+      ServiceTokens.CommitStatusesApi,
       ServiceTokens.ContextService,
       ServiceTokens.OutputService,
     ]

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -31,6 +31,8 @@ import {
   SnippetsApi,
   PipelinesApi,
   IssueTrackerApi,
+  WorkspacesApi,
+  ProjectsApi,
 } from './generated/api.js';
 
 // Auth commands
@@ -105,6 +107,15 @@ import { CreateIssueCommand } from './commands/issue/create.command.js';
 import { EditIssueCommand } from './commands/issue/edit.command.js';
 import { CloseIssueCommand } from './commands/issue/close.command.js';
 import { CommentIssueCommand } from './commands/issue/comment.command.js';
+
+// Workspace commands
+import { ListWorkspacesCommand } from './commands/workspace/list.command.js';
+import { ViewWorkspaceCommand } from './commands/workspace/view.command.js';
+
+// Project commands
+import { ListProjectsCommand } from './commands/project/list.command.js';
+import { ViewProjectCommand } from './commands/project/view.command.js';
+import { CreateProjectCommand } from './commands/project/create.command.js';
 
 // Config commands
 import { GetConfigCommand } from './commands/config/get.command.js';
@@ -228,6 +239,8 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
   registerApiClient(container, ServiceTokens.SnippetsApi, SnippetsApi);
   registerApiClient(container, ServiceTokens.PipelinesApi, PipelinesApi);
   registerApiClient(container, ServiceTokens.IssueTrackerApi, IssueTrackerApi);
+  registerApiClient(container, ServiceTokens.WorkspacesApi, WorkspacesApi);
+  registerApiClient(container, ServiceTokens.ProjectsApi, ProjectsApi);
 
   registerCommand(
     container,
@@ -748,6 +761,57 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     CommentIssueCommand,
     [
       ServiceTokens.IssueTrackerApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Workspace commands
+  registerCommand(
+    container,
+    ServiceTokens.ListWorkspacesCommand,
+    ListWorkspacesCommand,
+    [ServiceTokens.WorkspacesApi, ServiceTokens.OutputService]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.ViewWorkspaceCommand,
+    ViewWorkspaceCommand,
+    [
+      ServiceTokens.WorkspacesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+
+  // Project commands. Listing lives on the Workspaces API surface
+  // (GET /workspaces/{workspace}/projects); view/create on the Projects API.
+  registerCommand(
+    container,
+    ServiceTokens.ListProjectsCommand,
+    ListProjectsCommand,
+    [
+      ServiceTokens.WorkspacesApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.ViewProjectCommand,
+    ViewProjectCommand,
+    [
+      ServiceTokens.ProjectsApi,
+      ServiceTokens.ContextService,
+      ServiceTokens.OutputService,
+    ]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.CreateProjectCommand,
+    CreateProjectCommand,
+    [
+      ServiceTokens.ProjectsApi,
       ServiceTokens.ContextService,
       ServiceTokens.OutputService,
     ]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,11 @@ import {
   PullrequestMergeParametersMergeStrategyEnum,
   SnippetsWorkspaceGetRoleEnum,
 } from './generated/api.js';
+import {
+  DEFAULT_PIPELINE_SORT,
+  PIPELINE_SORTS,
+  PIPELINE_STATUSES,
+} from './commands/pipeline/list.command.js';
 import { HTTP_METHODS } from './services/api-passthrough.js';
 import { createHelpTextBuilder } from './help-text.js';
 import { ServiceTokens } from './core/container.js';
@@ -1597,6 +1602,173 @@ snippetCommentsCmd
 
 snippetCmd.addCommand(snippetCommentsCmd);
 cli.addCommand(snippetCmd);
+
+// Pipeline commands
+const pipelineCmd = new Command('pipeline').description(
+  'Manage Bitbucket Pipelines (CI/CD)'
+);
+
+pipelineCmd
+  .command('list')
+  .description('List pipelines for a repository')
+  .addOption(
+    withCompletionChoices(
+      new Option('--status <status>', 'Filter by pipeline status'),
+      PIPELINE_STATUSES
+    )
+  )
+  .option('--branch <branch>', 'Filter by target branch')
+  .addOption(
+    withCompletionChoices(
+      new Option(
+        '--sort <attribute>',
+        'Sort attribute (prefix with - for descending)'
+      ),
+      PIPELINE_SORTS
+    )
+  )
+  .option('--limit <number>', 'Maximum number of pipelines to list', '25')
+  .option('--all', 'List all pipelines (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pipeline list',
+        'bb pipeline list --status FAILED',
+        'bb pipeline list --branch main --limit 50',
+        "bb pipeline list --json --jq '.pipelines[].build_number'",
+      ],
+      validValues: {
+        'Valid statuses': [...PIPELINE_STATUSES],
+        'Valid sort attributes': [...PIPELINE_SORTS],
+      },
+      defaults: { limit: '25', sort: DEFAULT_PIPELINE_SORT },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListPipelinesCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+pipelineCmd
+  .command('view <id>')
+  .description(
+    'View pipeline details and step summary (id: build number or UUID)'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pipeline view 42',
+        'bb pipeline view {a1b2c3d4-0000-0000-0000-000000000000}',
+        "bb pipeline view 42 --json --jq '.pipeline.state'",
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewPipelineCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+pipelineCmd
+  .command('run')
+  .description('Trigger a pipeline run')
+  .option(
+    '-b, --branch <branch>',
+    'Branch to run on (default: current git branch)'
+  )
+  .option('--commit <hash>', 'Run against a specific commit on the branch')
+  .option(
+    '-p, --pipeline <name>',
+    'Custom pipeline definition to run (from bitbucket-pipelines.yml)'
+  )
+  .option(
+    '--var <key=value...>',
+    'Pipeline variable (repeatable; value may contain =)'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pipeline run',
+        'bb pipeline run --branch main',
+        'bb pipeline run --pipeline deploy-prod --var ENV=prod --var DRY_RUN=false',
+        "bb pipeline run --branch main --json --jq '.build_number'",
+      ],
+      defaults: { branch: 'current git branch' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.RunPipelineCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+pipelineCmd
+  .command('stop <id>')
+  .description('Stop a running pipeline (id: build number or UUID)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pipeline stop 42',
+        'bb pipeline stop {a1b2c3d4-0000-0000-0000-000000000000} --json',
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.StopPipelineCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+pipelineCmd
+  .command('logs <id>')
+  .description('Print the log of a pipeline step (id: build number or UUID)')
+  .option(
+    '-s, --step <uuid-or-index>',
+    'Step to fetch (UUID or 1-based index; default: the only step)'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb pipeline logs 42',
+        'bb pipeline logs 42 --step 2',
+        'bb pipeline logs 42 --step {step-uuid}',
+        "bb pipeline logs 42 --json --jq '.log'",
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.LogsPipelineCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(pipelineCmd);
 
 // Browse command (top-level)
 cli

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
   PIPELINE_SORTS,
   PIPELINE_STATUSES,
 } from './commands/pipeline/list.command.js';
+import { COMMIT_STATUS_STATES } from './commands/status/shared.js';
 import { HTTP_METHODS } from './services/api-passthrough.js';
 import { createHelpTextBuilder } from './help-text.js';
 import { ServiceTokens } from './core/container.js';
@@ -1769,6 +1770,141 @@ pipelineCmd
   });
 
 cli.addCommand(pipelineCmd);
+
+// Commit commands
+const commitCmd = new Command('commit').description(
+  'Inspect commits in a repository'
+);
+
+commitCmd
+  .command('list')
+  .description('List commits (defaults to the current git branch)')
+  .option(
+    '--ref <ref>',
+    'Branch, tag, or commit to list history for (default: current git branch, falling back to the repository default listing)'
+  )
+  .option('--limit <number>', 'Maximum number of commits to list', '25')
+  .option('--all', 'List all commits (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb commit list',
+        'bb commit list --ref main',
+        'bb commit list --ref v1.0.0 --limit 50',
+        "bb commit list --json --jq '.commits[].hash'",
+      ],
+      defaults: {
+        ref: 'current git branch (repository default listing outside a git repo)',
+        limit: '25',
+      },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListCommitsCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+commitCmd
+  .command('view <sha>')
+  .description('View commit details (author, date, parents, full message)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb commit view abc1234',
+        'bb commit view abc1234def5678900000000000000000000000000',
+        "bb commit view abc1234 --json --jq '.commit.author.raw'",
+      ],
+    })
+  )
+  .action(async (sha, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewCommitCommand,
+      withGlobalOptions({ sha, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(commitCmd);
+
+// Status commands (commit build statuses)
+const statusCmd = new Command('status').description(
+  'Manage build statuses on commits'
+);
+
+statusCmd
+  .command('list <sha>')
+  .description('List build statuses reported on a commit')
+  .option('--limit <number>', 'Maximum number of statuses to list', '25')
+  .option('--all', 'List all statuses (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb status list abc1234',
+        'bb status list abc1234 --all',
+        "bb status list abc1234 --json --jq '.statuses[].state'",
+      ],
+      defaults: { limit: '25' },
+    })
+  )
+  .action(async (sha, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListCommitStatusesCommand,
+      withGlobalOptions({ sha, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+statusCmd
+  .command('set <sha>')
+  .description(
+    'Create or update a build status on a commit (idempotent per --key)'
+  )
+  .option('--key <key>', 'Unique status key, e.g. BB-DEPLOY (required)')
+  .addOption(
+    withCompletionChoices(
+      new Option('--state <state>', 'Status state (required)'),
+      COMMIT_STATUS_STATES
+    )
+  )
+  .option('--url <url>', 'Link back to the build system')
+  .option('--name <name>', 'Build identifier, e.g. BB-DEPLOY-1')
+  .option('--description <description>', 'Short build description')
+  .option('--refname <refname>', 'Ref the build ran on, e.g. a branch name')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb status set abc1234 --key CI --state INPROGRESS',
+        'bb status set abc1234 --key CI --state SUCCESSFUL --url https://ci.example.com/builds/42',
+        'bb status set abc1234 --key CI --state FAILED --description "Unit tests failed" --refname main',
+        "bb status set abc1234 --key CI --state SUCCESSFUL --json --jq '.status.state'",
+      ],
+      validValues: { 'Valid states': [...COMMIT_STATUS_STATES] },
+    })
+  )
+  .action(async (sha, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.SetCommitStatusCommand,
+      withGlobalOptions({ sha, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(statusCmd);
 
 // Browse command (top-level)
 cli

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2183,7 +2183,7 @@ workspaceCmd
         "bb workspace view my-workspace --json --jq '.workspace.uuid'",
       ],
       defaults: {
-        slug: 'resolved workspace (-w, current repo, or defaultWorkspace)',
+        slug: 'resolved workspace (-w, current repo, BB_WORKSPACE, or defaultWorkspace)',
       },
     })
   )

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,11 @@ import {
   PIPELINE_STATUSES,
 } from './commands/pipeline/list.command.js';
 import { COMMIT_STATUS_STATES } from './commands/status/shared.js';
+import {
+  ISSUE_KINDS,
+  ISSUE_PRIORITIES,
+  ISSUE_STATES,
+} from './commands/issue/shared.js';
 import { HTTP_METHODS } from './services/api-passthrough.js';
 import { createHelpTextBuilder } from './help-text.js';
 import { ServiceTokens } from './core/container.js';
@@ -1905,6 +1910,222 @@ statusCmd
   });
 
 cli.addCommand(statusCmd);
+
+// Issue commands
+const issueCmd = new Command('issue').description(
+  'Manage issues in the repository issue tracker'
+);
+
+issueCmd
+  .command('list')
+  .description('List issues (defaults to open-ish states: new, open)')
+  .addOption(
+    withCompletionChoices(
+      new Option('--state <state>', 'Filter by exact state'),
+      ISSUE_STATES
+    )
+  )
+  .addOption(
+    withCompletionChoices(
+      new Option('--kind <kind>', 'Filter by kind'),
+      ISSUE_KINDS
+    )
+  )
+  .option('--assignee <username>', 'Filter by assignee username')
+  .option('--reporter <username>', 'Filter by reporter username')
+  .option(
+    '--query <q>',
+    'Raw Bitbucket q filter expression (replaces the default state filter; AND-ed with other flags)'
+  )
+  .option('--limit <number>', 'Maximum number of issues to list', '25')
+  .option('--all', 'List all issues (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue list',
+        'bb issue list --state resolved',
+        'bb issue list --kind bug --assignee some.user',
+        'bb issue list --query \'priority="blocker" AND state!="closed"\'',
+        "bb issue list --json --jq '.issues[].id'",
+      ],
+      validValues: {
+        'Valid states': [...ISSUE_STATES],
+        'Valid kinds': [...ISSUE_KINDS],
+      },
+      defaults: { state: 'new + open', limit: '25' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListIssuesCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+issueCmd
+  .command('view <id>')
+  .description('View issue details')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue view 42',
+        "bb issue view 42 --json --jq '.issue.state'",
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewIssueCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+issueCmd
+  .command('create')
+  .description('Create an issue')
+  .option('-t, --title <title>', 'Issue title (required)')
+  .option('-b, --body <text>', 'Issue description (Markdown)')
+  .option('-F, --body-file <file>', 'Read the issue description from a file')
+  .addOption(
+    withCompletionChoices(
+      new Option('--kind <kind>', 'Issue kind'),
+      ISSUE_KINDS
+    )
+  )
+  .addOption(
+    withCompletionChoices(
+      new Option('--priority <priority>', 'Issue priority'),
+      ISSUE_PRIORITIES
+    )
+  )
+  .option('--assignee <username>', 'Assign the issue to a user')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue create --title "Crash on login"',
+        'bb issue create --title "Crash on login" --kind bug --priority major',
+        'bb issue create --title "RFC: new API" --body-file ./rfc.md',
+        'bb issue create --title "Crash on login" --json --jq \'.issue.id\'',
+      ],
+      validValues: {
+        'Valid kinds': [...ISSUE_KINDS],
+        'Valid priorities': [...ISSUE_PRIORITIES],
+      },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.CreateIssueCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+issueCmd
+  .command('edit <id>')
+  .description('Edit an issue (requires at least one change flag)')
+  .option('-t, --title <title>', 'New title')
+  .option('-b, --body <text>', 'New description (replaces the existing body)')
+  .addOption(
+    withCompletionChoices(new Option('--kind <kind>', 'New kind'), ISSUE_KINDS)
+  )
+  .addOption(
+    withCompletionChoices(
+      new Option('--priority <priority>', 'New priority'),
+      ISSUE_PRIORITIES
+    )
+  )
+  .option('--assignee <username>', 'Reassign the issue to a user')
+  .addOption(
+    withCompletionChoices(
+      new Option('--state <state>', 'New state'),
+      ISSUE_STATES
+    )
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue edit 42 --title "Crash on login (Safari only)"',
+        'bb issue edit 42 --state on-hold --priority critical',
+        'bb issue edit 42 --assignee some.user --json',
+      ],
+      validValues: {
+        'Valid states': [...ISSUE_STATES],
+        'Valid kinds': [...ISSUE_KINDS],
+        'Valid priorities': [...ISSUE_PRIORITIES],
+      },
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.EditIssueCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+issueCmd
+  .command('close <id>')
+  .description('Close an issue (optionally posting a closing comment first)')
+  .option('-c, --comment <text>', 'Post this comment before closing')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue close 42',
+        'bb issue close 42 --comment "Fixed in 1.4.2"',
+        "bb issue close 42 --json --jq '.issue.state'",
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.CloseIssueCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+issueCmd
+  .command('comment <id>')
+  .description('Add a comment to an issue')
+  .option('-b, --body <text>', 'Comment text (Markdown, required)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb issue comment 42 --body "Reproduced on main"',
+        'bb issue comment 42 --body "Reproduced on main" --json --jq \'.comment.id\'',
+      ],
+    })
+  )
+  .action(async (id, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.CommentIssueCommand,
+      withGlobalOptions({ id, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(issueCmd);
 
 // Browse command (top-level)
 cli

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import {
   ISSUE_PRIORITIES,
   ISSUE_STATES,
 } from './commands/issue/shared.js';
+import { WORKSPACE_ROLES } from './commands/workspace/list.command.js';
 import { HTTP_METHODS } from './services/api-passthrough.js';
 import { createHelpTextBuilder } from './help-text.js';
 import { ServiceTokens } from './core/container.js';
@@ -2126,6 +2127,162 @@ issueCmd
   });
 
 cli.addCommand(issueCmd);
+
+// Workspace commands
+const workspaceCmd = new Command('workspace').description(
+  'Discover and inspect Bitbucket workspaces'
+);
+
+workspaceCmd
+  .command('list')
+  .description('List workspaces you have access to')
+  .addOption(
+    withCompletionChoices(
+      new Option(
+        '--role <role>',
+        'Filter by your role (owner, collaborator, member)'
+      ),
+      WORKSPACE_ROLES
+    )
+  )
+  .option('--limit <number>', 'Maximum number of workspaces to list', '25')
+  .option('--all', 'List all workspaces (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb workspace list',
+        'bb workspace list --role owner',
+        "bb workspace list --json --jq '.workspaces[].slug'",
+      ],
+      validValues: { 'Valid roles': [...WORKSPACE_ROLES] },
+      defaults: { limit: '25' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListWorkspacesCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+workspaceCmd
+  .command('view [slug]')
+  .description(
+    'View workspace details (defaults to the current workspace context)'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb workspace view',
+        'bb workspace view my-workspace',
+        "bb workspace view my-workspace --json --jq '.workspace.uuid'",
+      ],
+      defaults: {
+        slug: 'resolved workspace (-w, current repo, or defaultWorkspace)',
+      },
+    })
+  )
+  .action(async (slug, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewWorkspaceCommand,
+      withGlobalOptions({ slug, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(workspaceCmd);
+
+// Project commands
+const projectCmd = new Command('project').description(
+  'Manage projects in a workspace'
+);
+
+projectCmd
+  .command('list')
+  .description('List projects in a workspace')
+  .option('--limit <number>', 'Maximum number of projects to list', '25')
+  .option('--all', 'List all projects (overrides --limit)')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb project list',
+        'bb project list -w my-workspace',
+        "bb project list --json --jq '.projects[].key'",
+      ],
+      defaults: { limit: '25' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ListProjectsCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+projectCmd
+  .command('view <key>')
+  .description('View project details')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb project view PROJ',
+        'bb project view PROJ -w my-workspace',
+        "bb project view PROJ --json --jq '.project.name'",
+      ],
+    })
+  )
+  .action(async (key, options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.ViewProjectCommand,
+      withGlobalOptions({ key, ...options }, context),
+      cli,
+      context
+    );
+  });
+
+projectCmd
+  .command('create')
+  .description('Create a new project in a workspace')
+  .option('-k, --key <key>', 'Project key, e.g. PROJ (required; uppercased)')
+  .option('-n, --name <name>', 'Project name (required)')
+  .option('-d, --description <description>', 'Project description')
+  .option('--private', 'Create a private project (default)')
+  .option('--public', 'Create a public project')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb project create --key PROJ --name "My Project"',
+        'bb project create -k PROJ -n "My Project" -d "Team things" --public',
+        'bb project create -k PROJ -n "My Project" --json --jq \'.project.key\'',
+      ],
+      defaults: { private: 'true (visibility is private unless --public)' },
+    })
+  )
+  .action(async (options) => {
+    const context = createContext(cli);
+    await runCommand(
+      ServiceTokens.CreateProjectCommand,
+      withGlobalOptions(options, context),
+      cli,
+      context
+    );
+  });
+
+cli.addCommand(projectCmd);
 
 // Browse command (top-level)
 cli

--- a/src/commands/commit/list.command.ts
+++ b/src/commands/commit/list.command.ts
@@ -1,0 +1,123 @@
+/**
+ * List commits command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IGitService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { BaseCommit, CommitsApi } from '../../generated/api.js';
+import { resolveLimit } from '../../services/pagination.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+import { firstMessageLine, formatAuthor, shortHash } from './shared.js';
+
+export interface ListCommitsOptions extends GlobalOptions {
+  ref?: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListCommitsCommand extends BaseCommand<ListCommitsOptions, void> {
+  public readonly name = 'list';
+  public readonly description = 'List commits in a repository';
+
+  constructor(
+    private readonly commitsApi: CommitsApi,
+    private readonly contextService: IContextService,
+    private readonly gitService: IGitService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListCommitsOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    // Validate --limit before any network call; runList re-resolves the same
+    // value.
+    resolveLimit(options);
+
+    const ref = options.ref ?? (await this.detectCurrentBranch());
+
+    await this.runList<BaseCommit>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          // Pagination params are not modeled on the generated request
+          // interfaces; they go through raw axios params.
+          const axiosOptions = { params: { page, pagelen } };
+          const response = ref
+            ? await this.commitsApi
+                .repositoriesWorkspaceRepoSlugCommitsRevisionGet(
+                  {
+                    workspace: repoContext.workspace,
+                    repoSlug: repoContext.repoSlug,
+                    revision: ref,
+                  },
+                  axiosOptions
+                )
+                .catch((error: unknown) =>
+                  rethrowWithNotFoundContext(
+                    error,
+                    `Ref '${ref}' not found in ${repoContext.workspace}/${repoContext.repoSlug}. Pass --ref <branch|tag|sha> to choose a different ref.`
+                  )
+                )
+            : await this.commitsApi.repositoriesWorkspaceRepoSlugCommitsGet(
+                {
+                  workspace: repoContext.workspace,
+                  repoSlug: repoContext.repoSlug,
+                },
+                axiosOptions
+              );
+          return response.data;
+        },
+        wrapperKey: 'commits',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          ...(ref ? { ref } : {}),
+        },
+        emptyMessage: () =>
+          ref ? `No commits found on '${ref}'` : 'No commits found',
+        tableHeaders: ['HASH', 'MESSAGE', 'AUTHOR', 'DATE'],
+        mapRow: (commit) => [
+          this.output.highlight(shortHash(commit.hash)),
+          this.truncateText(
+            firstMessageLine(commit.message),
+            60,
+            context.globalOptions
+          ),
+          formatAuthor(commit.author),
+          commit.date ? this.output.formatDate(commit.date) : '-',
+        ],
+        noun: 'commits',
+      },
+      context
+    );
+  }
+
+  /**
+   * DX default: with no --ref, list the current git branch's history when run
+   * inside a git repository. Outside a repo (or when branch detection fails,
+   * e.g. detached HEAD states that error out) fall back to the repository's
+   * default commit listing instead of failing.
+   */
+  private async detectCurrentBranch(): Promise<string | undefined> {
+    try {
+      const branch = await this.gitService.getCurrentBranch();
+      return branch || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/commands/commit/shared.ts
+++ b/src/commands/commit/shared.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared helpers for commit commands
+ */
+
+import type { BaseCommit } from '../../generated/api.js';
+
+/** Short (7-character) form of a commit hash, the git CLI convention. */
+export function shortHash(hash: string | undefined): string {
+  return hash ? hash.slice(0, 7) : '-';
+}
+
+/** First line of a commit message, for table rendering. */
+export function firstMessageLine(message: string | undefined): string {
+  if (!message) {
+    return '-';
+  }
+  const newline = message.indexOf('\n');
+  return newline === -1 ? message : message.slice(0, newline);
+}
+
+/**
+ * Human-readable author name. Prefers the matched Bitbucket account's display
+ * name; otherwise parses the raw git author string ("Name <email>") down to
+ * the name part so tables stay compact.
+ */
+export function formatAuthor(author: BaseCommit['author']): string {
+  const displayName = author?.user?.display_name;
+  if (displayName) {
+    return displayName;
+  }
+  const raw = author?.raw;
+  if (!raw) {
+    return '-';
+  }
+  const emailStart = raw.indexOf('<');
+  const name = emailStart === -1 ? raw : raw.slice(0, emailStart);
+  return name.trim() || raw;
+}

--- a/src/commands/commit/view.command.ts
+++ b/src/commands/commit/view.command.ts
@@ -1,0 +1,93 @@
+/**
+ * View commit command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { BaseCommit, CommitsApi } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+import { formatAuthor, shortHash } from './shared.js';
+
+export interface ViewCommitOptions extends GlobalOptions {
+  sha: string;
+}
+
+export class ViewCommitCommand extends BaseCommand<ViewCommitOptions, void> {
+  public readonly name = 'view';
+  public readonly description = 'View commit details';
+
+  constructor(
+    private readonly commitsApi: CommitsApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ViewCommitOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const sha = this.requireOption(options.sha, 'sha');
+
+    const response = await this.commitsApi
+      .repositoriesWorkspaceRepoSlugCommitCommitGet({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        commit: sha,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Commit ${sha} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+        )
+      );
+
+    const commit = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        commit,
+      });
+      return;
+    }
+
+    const parents = (commit.parents ?? [])
+      .map((parent) => shortHash(parent.hash))
+      .join(', ');
+
+    this.output.text(
+      `${this.output.bold('commit')} ${this.output.highlight(commit.hash ?? sha)}`
+    );
+    this.output.text(
+      `${this.output.dim('Author:')}  ${this.formatFullAuthor(commit.author)}`
+    );
+    this.output.text(
+      `${this.output.dim('Date:')}    ${commit.date ? this.output.formatDate(commit.date) : '-'}`
+    );
+    this.output.text(`${this.output.dim('Parents:')} ${parents || '-'}`);
+    this.output.text('');
+    for (const line of (commit.message ?? '').trimEnd().split('\n')) {
+      this.output.text(`    ${line}`);
+    }
+  }
+
+  /**
+   * Full author line: keep the raw "Name <email>" when available (it carries
+   * the email), otherwise the matched account's display name.
+   */
+  private formatFullAuthor(author: BaseCommit['author']): string {
+    return author?.raw ?? formatAuthor(author);
+  }
+}

--- a/src/commands/issue/close.command.ts
+++ b/src/commands/issue/close.command.ts
@@ -1,0 +1,98 @@
+/**
+ * Close issue command implementation — sugar for `bb issue edit --state
+ * closed`, optionally posting a closing comment first.
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { IssueTrackerApi } from '../../generated/api.js';
+import { IssueStateEnum } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowIssueNotFound, type IssueChanges } from './shared.js';
+
+export interface CloseIssueOptions extends GlobalOptions {
+  id: string;
+  comment?: string;
+}
+
+export class CloseIssueCommand extends BaseCommand<CloseIssueOptions, void> {
+  public readonly name = 'close';
+  public readonly description = 'Close an issue';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: CloseIssueOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const notFound = (error: unknown) =>
+      rethrowIssueNotFound(
+        error,
+        options.id,
+        repoContext.workspace,
+        repoContext.repoSlug
+      );
+
+    // Post the closing comment first so the comment lands while the issue is
+    // still open (matching `gh issue close --comment` ordering).
+    if (options.comment !== undefined && options.comment !== '') {
+      await this.issueTrackerApi
+        .repositoriesWorkspaceRepoSlugIssuesIssueIdCommentsPost({
+          issueId: options.id,
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          issueComment: {
+            type: 'issue_comment',
+            content: { raw: options.comment },
+          },
+        })
+        .catch(notFound);
+    }
+
+    const changes: IssueChanges = {
+      type: 'issue',
+      state: IssueStateEnum.Closed,
+    };
+
+    const response = await this.issueTrackerApi
+      .repositoriesWorkspaceRepoSlugIssuesIssueIdPut(
+        {
+          issueId: options.id,
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+        },
+        // The generated client omits the request body for this endpoint (the
+        // OpenAPI spec doesn't model it); send it via the raw axios config.
+        { data: changes }
+      )
+      .catch(notFound);
+
+    const issue = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issue,
+      });
+      return;
+    }
+
+    this.output.success(`Issue #${options.id} closed`);
+  }
+}

--- a/src/commands/issue/comment.command.ts
+++ b/src/commands/issue/comment.command.ts
@@ -1,0 +1,79 @@
+/**
+ * Comment on issue command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { IssueTrackerApi } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowIssueNotFound } from './shared.js';
+
+export interface CommentIssueOptions extends GlobalOptions {
+  id: string;
+  body?: string;
+}
+
+export class CommentIssueCommand extends BaseCommand<
+  CommentIssueOptions,
+  void
+> {
+  public readonly name = 'comment';
+  public readonly description = 'Add a comment to an issue';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: CommentIssueOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const body = this.requireOption(options.body, 'body');
+
+    const response = await this.issueTrackerApi
+      .repositoriesWorkspaceRepoSlugIssuesIssueIdCommentsPost({
+        issueId: options.id,
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issueComment: {
+          // 'type' is the ModelObject discriminator required on request bodies.
+          type: 'issue_comment',
+          content: { raw: body },
+        },
+      })
+      .catch((error: unknown) =>
+        rethrowIssueNotFound(
+          error,
+          options.id,
+          repoContext.workspace,
+          repoContext.repoSlug
+        )
+      );
+
+    const comment = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        comment,
+      });
+      return;
+    }
+
+    this.output.success(`Comment added to issue #${options.id}`);
+  }
+}

--- a/src/commands/issue/create.command.ts
+++ b/src/commands/issue/create.command.ts
@@ -1,0 +1,127 @@
+/**
+ * Create issue command implementation
+ */
+
+import fs from 'node:fs';
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type {
+  Issue,
+  IssueKindEnum,
+  IssuePriorityEnum,
+  IssueTrackerApi,
+} from '../../generated/api.js';
+import { getLinkHref } from '../../services/response-parsers.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+import {
+  assigneeBody,
+  ISSUE_KINDS,
+  ISSUE_PRIORITIES,
+  rethrowTrackerDisabled,
+} from './shared.js';
+
+export interface CreateIssueOptions extends GlobalOptions {
+  title?: string;
+  body?: string;
+  bodyFile?: string;
+  kind?: string;
+  priority?: string;
+  assignee?: string;
+}
+
+export class CreateIssueCommand extends BaseCommand<CreateIssueOptions, void> {
+  public readonly name = 'create';
+  public readonly description = 'Create an issue';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: CreateIssueOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const title = this.requireOption(options.title, 'title');
+    const body = this.resolveBody(options);
+    const kind = options.kind
+      ? this.parseEnumOption(options.kind, 'kind', ISSUE_KINDS)
+      : undefined;
+    const priority = options.priority
+      ? this.parseEnumOption(options.priority, 'priority', ISSUE_PRIORITIES)
+      : undefined;
+
+    const issueBody: Issue = {
+      // 'type' is the ModelObject discriminator required on request bodies.
+      type: 'issue',
+      title,
+      ...(body !== undefined ? { content: { raw: body } } : {}),
+      ...(kind ? { kind: kind as IssueKindEnum } : {}),
+      ...(priority ? { priority: priority as IssuePriorityEnum } : {}),
+      ...(options.assignee ? { assignee: assigneeBody(options.assignee) } : {}),
+    };
+
+    const response = await this.issueTrackerApi
+      .repositoriesWorkspaceRepoSlugIssuesPost({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issue: issueBody,
+      })
+      .catch((error: unknown) => rethrowTrackerDisabled(error));
+
+    const issue = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issue,
+      });
+      return;
+    }
+
+    this.output.success(`Issue #${issue.id ?? '?'} created`);
+    const url = getLinkHref(issue.links, 'html');
+    if (url) {
+      this.output.text(this.output.cyan(url));
+    }
+  }
+
+  /** Resolve the issue body from --body or --body-file (mutually exclusive). */
+  private resolveBody(options: CreateIssueOptions): string | undefined {
+    if (options.body !== undefined && options.bodyFile !== undefined) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          '--body and --body-file cannot both be set.'
+        ),
+      });
+    }
+    if (options.bodyFile === undefined) {
+      return options.body;
+    }
+    try {
+      return fs.readFileSync(options.bodyFile, 'utf8');
+    } catch (error) {
+      throw new BBError({
+        code: ErrorCode.FILE_NOT_FOUND,
+        message: `Could not read --body-file: ${options.bodyFile}`,
+        cause: error instanceof Error ? error : undefined,
+        context: { file: options.bodyFile },
+      });
+    }
+  }
+}

--- a/src/commands/issue/edit.command.ts
+++ b/src/commands/issue/edit.command.ts
@@ -1,0 +1,132 @@
+/**
+ * Edit issue command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type {
+  IssueKindEnum,
+  IssuePriorityEnum,
+  IssueStateEnum,
+  IssueTrackerApi,
+} from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+import {
+  assigneeBody,
+  cliStateToApi,
+  ISSUE_KINDS,
+  ISSUE_PRIORITIES,
+  ISSUE_STATES,
+  rethrowIssueNotFound,
+  type IssueChanges,
+} from './shared.js';
+
+export interface EditIssueOptions extends GlobalOptions {
+  id: string;
+  title?: string;
+  body?: string;
+  kind?: string;
+  priority?: string;
+  assignee?: string;
+  state?: string;
+}
+
+export class EditIssueCommand extends BaseCommand<EditIssueOptions, void> {
+  public readonly name = 'edit';
+  public readonly description = 'Edit an issue';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: EditIssueOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const changes = this.buildChanges(options);
+
+    const response = await this.issueTrackerApi
+      .repositoriesWorkspaceRepoSlugIssuesIssueIdPut(
+        {
+          issueId: options.id,
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+        },
+        // The generated client omits the request body for this endpoint (the
+        // OpenAPI spec doesn't model it), so the partial update goes through
+        // the raw axios config instead. Do NOT move this into the request
+        // parameters — they are path-only.
+        { data: changes }
+      )
+      .catch((error: unknown) =>
+        rethrowIssueNotFound(
+          error,
+          options.id,
+          repoContext.workspace,
+          repoContext.repoSlug
+        )
+      );
+
+    const issue = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issue,
+      });
+      return;
+    }
+
+    this.output.success(`Issue #${options.id} updated`);
+  }
+
+  /** Build the partial PUT body, requiring at least one editable flag. */
+  private buildChanges(options: EditIssueOptions): IssueChanges {
+    const kind = options.kind
+      ? this.parseEnumOption(options.kind, 'kind', ISSUE_KINDS)
+      : undefined;
+    const priority = options.priority
+      ? this.parseEnumOption(options.priority, 'priority', ISSUE_PRIORITIES)
+      : undefined;
+    const state = options.state
+      ? this.parseEnumOption(options.state, 'state', ISSUE_STATES)
+      : undefined;
+
+    const changes: IssueChanges = {
+      // 'type' is the ModelObject discriminator required on request bodies.
+      type: 'issue',
+      ...(options.title !== undefined ? { title: options.title } : {}),
+      ...(options.body !== undefined ? { content: { raw: options.body } } : {}),
+      ...(kind ? { kind: kind as IssueKindEnum } : {}),
+      ...(priority ? { priority: priority as IssuePriorityEnum } : {}),
+      ...(options.assignee ? { assignee: assigneeBody(options.assignee) } : {}),
+      ...(state ? { state: cliStateToApi(state) as IssueStateEnum } : {}),
+    };
+
+    if (Object.keys(changes).length === 1) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: this.appendHelpHint(
+          'At least one of --title, --body, --kind, --priority, --assignee, or --state is required.'
+        ),
+      });
+    }
+
+    return changes;
+  }
+}

--- a/src/commands/issue/list.command.ts
+++ b/src/commands/issue/list.command.ts
@@ -1,0 +1,169 @@
+/**
+ * List issues command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Issue, IssueTrackerApi } from '../../generated/api.js';
+import { resolveLimit } from '../../services/pagination.js';
+import type { GlobalOptions } from '../../types/config.js';
+import {
+  cliStateToApi,
+  DEFAULT_ISSUE_SORT,
+  DEFAULT_OPEN_STATES_CLAUSE,
+  formatIssueUser,
+  ISSUE_KINDS,
+  ISSUE_STATES,
+  quoteQueryValue,
+  rethrowTrackerDisabled,
+} from './shared.js';
+
+export interface ListIssuesOptions extends GlobalOptions {
+  state?: string;
+  kind?: string;
+  assignee?: string;
+  reporter?: string;
+  query?: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListIssuesCommand extends BaseCommand<ListIssuesOptions, void> {
+  public readonly name = 'list';
+  public readonly description = 'List issues in a repository';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListIssuesOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    // Validate --limit before the enum options so an invalid limit fails
+    // fast; runList re-resolves the same value.
+    resolveLimit(options);
+
+    const state = options.state
+      ? this.parseEnumOption(options.state, 'state', ISSUE_STATES)
+      : undefined;
+    const kind = options.kind
+      ? this.parseEnumOption(options.kind, 'kind', ISSUE_KINDS)
+      : undefined;
+
+    const q = this.buildQuery({ ...options, state, kind });
+    const hasFilters = Boolean(
+      state ?? kind ?? options.assignee ?? options.reporter ?? options.query
+    );
+
+    await this.runList<Issue>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          // The generated request interface only models workspace/repoSlug;
+          // page, pagelen, q, and sort all go through raw axios params.
+          const response = await this.issueTrackerApi
+            .repositoriesWorkspaceRepoSlugIssuesGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+              },
+              { params: { page, pagelen, q, sort: DEFAULT_ISSUE_SORT } }
+            )
+            .catch((error: unknown) => rethrowTrackerDisabled(error));
+          return response.data;
+        },
+        wrapperKey: 'issues',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          filters: {
+            ...(state ? { state } : {}),
+            ...(kind ? { kind } : {}),
+            ...(options.assignee ? { assignee: options.assignee } : {}),
+            ...(options.reporter ? { reporter: options.reporter } : {}),
+            ...(options.query ? { query: options.query } : {}),
+            q,
+          },
+        },
+        emptyMessage: () =>
+          hasFilters
+            ? 'No issues found matching the given filters'
+            : 'No open issues found (try --state <state> or --query)',
+        tableHeaders: [
+          '#',
+          'TITLE',
+          'KIND',
+          'PRIORITY',
+          'STATE',
+          'ASSIGNEE',
+          'UPDATED',
+        ],
+        mapRow: (issue) => [
+          `#${issue.id ?? '?'}`,
+          this.truncateText(issue.title ?? '', 50, context.globalOptions),
+          issue.kind ?? '-',
+          issue.priority ?? '-',
+          issue.state ?? '-',
+          formatIssueUser(issue.assignee),
+          issue.updated_on ? this.output.formatDate(issue.updated_on) : '-',
+        ],
+        noun: 'issues',
+      },
+      context
+    );
+  }
+
+  /**
+   * Compose the Bitbucket `q` filter expression. Clauses are AND-ed:
+   *
+   *  - no `--state` / `--query`: default to open-ish issues
+   *    (`(state="new" OR state="open")`), mirroring `gh issue list`;
+   *  - `--state <s>`: exact state match (CLI `on-hold` maps to `"on hold"`);
+   *  - `--kind` / `--assignee` / `--reporter`: exact field matches;
+   *  - `--query <raw-q>`: escape hatch, used verbatim (parenthesized) and
+   *    suppressing the default state clause so it can express its own.
+   */
+  private buildQuery(filters: {
+    state?: string;
+    kind?: string;
+    assignee?: string;
+    reporter?: string;
+    query?: string;
+  }): string {
+    const clauses: string[] = [];
+
+    if (filters.query) {
+      clauses.push(`(${filters.query})`);
+    }
+    if (filters.state) {
+      clauses.push(`state=${quoteQueryValue(cliStateToApi(filters.state))}`);
+    } else if (!filters.query) {
+      clauses.push(DEFAULT_OPEN_STATES_CLAUSE);
+    }
+    if (filters.kind) {
+      clauses.push(`kind=${quoteQueryValue(filters.kind)}`);
+    }
+    if (filters.assignee) {
+      clauses.push(`assignee.username=${quoteQueryValue(filters.assignee)}`);
+    }
+    if (filters.reporter) {
+      clauses.push(`reporter.username=${quoteQueryValue(filters.reporter)}`);
+    }
+
+    return clauses.join(' AND ');
+  }
+}

--- a/src/commands/issue/shared.ts
+++ b/src/commands/issue/shared.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared helpers for the `bb issue` command group.
+ *
+ * Bitbucket Cloud's issue tracker is opt-in per repository: when it is
+ * disabled the API answers 404 on every `/issues` endpoint, which is easy to
+ * misread as "repo not found". The rethrow helpers here turn those 404s into
+ * actionable messages once, so every issue command reports them the same way.
+ */
+
+import type { Account, Issue } from '../../generated/api.js';
+import {
+  IssueKindEnum,
+  IssuePriorityEnum,
+  IssueStateEnum,
+} from '../../generated/api.js';
+import { getUserDisplayName } from '../../services/response-parsers.js';
+import { APIError } from '../../types/errors.js';
+
+/**
+ * CLI-facing state names. The API spells the on-hold state with a space
+ * (`"on hold"`); the CLI takes the dash form so it works unquoted in shells.
+ */
+export const ISSUE_STATES: readonly string[] = Object.values(
+  IssueStateEnum
+).map((state) => state.replace(' ', '-'));
+
+export const ISSUE_KINDS: readonly string[] = Object.values(IssueKindEnum);
+
+export const ISSUE_PRIORITIES: readonly string[] =
+  Object.values(IssuePriorityEnum);
+
+/** Issues are listed most recently updated first, mirroring `gh issue list`. */
+export const DEFAULT_ISSUE_SORT = '-updated_on';
+
+/** Map a CLI state value (`on-hold`) back to the API spelling (`on hold`). */
+export function cliStateToApi(state: string): string {
+  return state.replace('-', ' ');
+}
+
+/**
+ * Quote a value for a Bitbucket `q` filter expression, escaping backslashes
+ * and embedded double quotes so user input cannot break out of the literal.
+ */
+export function quoteQueryValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Default `q` clause when no `--state` / `--query` is given: show issues that
+ * still need attention, mirroring `gh issue list` defaulting to open issues.
+ * Parenthesized so it composes with `AND` clauses from other filters.
+ */
+export const DEFAULT_OPEN_STATES_CLAUSE = '(state="new" OR state="open")';
+
+const TRACKER_DISABLED_MESSAGE =
+  "This repository's issue tracker is disabled (or the repo was not found). " +
+  'Enable it under Repository settings → Issue tracker on Bitbucket, or ' +
+  'check --workspace/--repo. Many teams use Jira instead — see the docs.';
+
+/**
+ * Rethrow helper for the COLLECTION endpoints (`bb issue list` / `bb issue
+ * create`): a 404 there almost always means the tracker is disabled, not
+ * that an individual resource is missing.
+ */
+export function rethrowTrackerDisabled(error: unknown): never {
+  if (error instanceof APIError && error.statusCode === 404) {
+    throw new APIError(
+      TRACKER_DISABLED_MESSAGE,
+      404,
+      error.response,
+      error.context
+    );
+  }
+  throw error;
+}
+
+/**
+ * Rethrow helper for the id-specific endpoints (`view` / `edit` / `close` /
+ * `comment`): prefer "issue not found", but mention the tracker-disabled
+ * possibility because a disabled tracker 404s identically.
+ */
+export function rethrowIssueNotFound(
+  error: unknown,
+  issueId: string,
+  workspace: string,
+  repoSlug: string
+): never {
+  if (error instanceof APIError && error.statusCode === 404) {
+    throw new APIError(
+      `Issue #${issueId} not found in ${workspace}/${repoSlug}. ` +
+        "If no issues exist at all, the repository's issue tracker may be " +
+        'disabled (Repository settings → Issue tracker).',
+      404,
+      error.response,
+      error.context
+    );
+  }
+  throw error;
+}
+
+/** Display name for an issue's assignee/reporter, `-` when unset. */
+export function formatIssueUser(user: Account | undefined): string {
+  return getUserDisplayName(user) ?? '-';
+}
+
+/**
+ * Build the assignee body fragment for create/edit. The generated `Account`
+ * model no longer carries `username`, but the issue-tracker write endpoints
+ * still accept (and require) it for assignment, so the cast bridges the
+ * spec gap.
+ */
+export function assigneeBody(username: string): Account {
+  return { type: 'user', username } as Account;
+}
+
+/** Issue body shape sent on create/edit (partial on edit). */
+export type IssueChanges = Partial<Issue> & { type: 'issue' };

--- a/src/commands/issue/view.command.ts
+++ b/src/commands/issue/view.command.ts
@@ -1,0 +1,110 @@
+/**
+ * View issue command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Issue, IssueTrackerApi } from '../../generated/api.js';
+import { getLinkHref } from '../../services/response-parsers.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { formatIssueUser, rethrowIssueNotFound } from './shared.js';
+
+export interface ViewIssueOptions extends GlobalOptions {
+  id: string;
+}
+
+export class ViewIssueCommand extends BaseCommand<ViewIssueOptions, void> {
+  public readonly name = 'view';
+  public readonly description = 'View issue details';
+
+  constructor(
+    private readonly issueTrackerApi: IssueTrackerApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ViewIssueOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const response = await this.issueTrackerApi
+      .repositoriesWorkspaceRepoSlugIssuesIssueIdGet({
+        issueId: options.id,
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+      })
+      .catch((error: unknown) =>
+        rethrowIssueNotFound(
+          error,
+          options.id,
+          repoContext.workspace,
+          repoContext.repoSlug
+        )
+      );
+
+    const issue = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        issue,
+      });
+      return;
+    }
+
+    this.renderIssue(issue);
+  }
+
+  private renderIssue(issue: Issue): void {
+    this.output.text('');
+    this.output.text(
+      `${this.output.bold(`#${issue.id ?? '?'}`)}  ${issue.title ?? 'Untitled'}  ${this.output.gray(`[${issue.state ?? 'unknown'}]`)}`
+    );
+    this.output.separator();
+
+    this.output.text(`Kind:       ${issue.kind ?? '-'}`);
+    this.output.text(`Priority:   ${issue.priority ?? '-'}`);
+    this.output.text(`Reporter:   ${formatIssueUser(issue.reporter)}`);
+    this.output.text(`Assignee:   ${formatIssueUser(issue.assignee)}`);
+
+    if (issue.created_on) {
+      this.output.text(
+        `Created:    ${this.output.formatDate(issue.created_on)}`
+      );
+    }
+    if (issue.updated_on) {
+      this.output.text(
+        `Updated:    ${this.output.formatDate(issue.updated_on)}`
+      );
+    }
+
+    this.output.text(`Votes:      ${issue.votes ?? 0}`);
+
+    const body = issue.content?.raw;
+    if (body) {
+      this.output.text('');
+      this.output.text(body);
+    }
+
+    const url =
+      getLinkHref(issue.links, 'html') ?? getLinkHref(issue.links, 'self');
+    if (url) {
+      this.output.text('');
+      this.output.text(this.output.cyan(url));
+    }
+
+    this.output.text('');
+  }
+}

--- a/src/commands/pipeline/list.command.ts
+++ b/src/commands/pipeline/list.command.ts
@@ -1,0 +1,144 @@
+/**
+ * List pipelines command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Pipeline, PipelinesApi } from '../../generated/api.js';
+import {
+  GetPipelinesForRepositorySortEnum,
+  GetPipelinesForRepositoryStatusEnum,
+} from '../../generated/api.js';
+import { resolveLimit } from '../../services/pagination.js';
+import type { GlobalOptions } from '../../types/config.js';
+import {
+  colorPipelineStatus,
+  formatDuration,
+  getPipelineRef,
+  getPipelineStatus,
+  getPipelineTrigger,
+} from './shared.js';
+
+export const PIPELINE_STATUSES = Object.values(
+  GetPipelinesForRepositoryStatusEnum
+) as readonly string[];
+
+// Every generated sort attribute plus its descending `-` form. The REST API
+// accepts the leading `-` even though the generated enum only lists the
+// ascending names, so the CLI single-sources both directions from the enum.
+export const PIPELINE_SORTS: readonly string[] = Object.values(
+  GetPipelinesForRepositorySortEnum
+).flatMap((value) => [value, `-${value}`]);
+
+export const DEFAULT_PIPELINE_SORT = '-created_on';
+
+export interface ListPipelinesOptions extends GlobalOptions {
+  status?: string;
+  branch?: string;
+  sort?: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListPipelinesCommand extends BaseCommand<
+  ListPipelinesOptions,
+  void
+> {
+  public readonly name = 'list';
+  public readonly description = 'List pipelines for a repository';
+
+  constructor(
+    private readonly pipelinesApi: PipelinesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListPipelinesOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    // Validate --limit before the enum options so an invalid limit fails
+    // fast; runList re-resolves the same value.
+    resolveLimit(options);
+
+    const status = options.status
+      ? this.parseEnumOption(
+          options.status.toUpperCase(),
+          'status',
+          PIPELINE_STATUSES
+        )
+      : undefined;
+    const sort = options.sort
+      ? this.parseEnumOption(options.sort, 'sort', PIPELINE_SORTS)
+      : DEFAULT_PIPELINE_SORT;
+
+    const hasFilters = Boolean(status ?? options.branch);
+
+    await this.runList<Pipeline>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response = await this.pipelinesApi.getPipelinesForRepository(
+            {
+              workspace: repoContext.workspace,
+              repoSlug: repoContext.repoSlug,
+              ...(status
+                ? { status: status as GetPipelinesForRepositoryStatusEnum }
+                : {}),
+              ...(options.branch ? { targetBranch: options.branch } : {}),
+            },
+            // `sort` goes through raw params: the generated enum only models
+            // ascending names, but the API accepts the `-` descending prefix.
+            { params: { page, pagelen, sort } }
+          );
+
+          return response.data;
+        },
+        wrapperKey: 'pipelines',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          ...(status ? { status } : {}),
+          ...(options.branch ? { branch: options.branch } : {}),
+          sort,
+        },
+        emptyMessage: () =>
+          hasFilters
+            ? 'No pipelines found matching the given filters'
+            : 'No pipelines found',
+        tableHeaders: ['ID', 'STATUS', 'REF', 'TRIGGER', 'CREATED', 'DURATION'],
+        mapRow: (pipeline) => {
+          const pipelineStatus = getPipelineStatus(pipeline.state);
+          const completed = Boolean(pipeline.completed_on);
+          return [
+            `#${pipeline.build_number ?? '?'}`,
+            colorPipelineStatus(this.output, pipelineStatus),
+            this.truncateText(
+              getPipelineRef(pipeline),
+              40,
+              context.globalOptions
+            ),
+            getPipelineTrigger(pipeline),
+            pipeline.created_on
+              ? this.output.formatDate(pipeline.created_on)
+              : '-',
+            completed ? formatDuration(pipeline.build_seconds_used) : '-',
+          ];
+        },
+        noun: 'pipelines',
+      },
+      context
+    );
+  }
+}

--- a/src/commands/pipeline/logs.command.ts
+++ b/src/commands/pipeline/logs.command.ts
@@ -17,6 +17,7 @@ import {
 } from '../../types/errors.js';
 import {
   colorPipelineStatus,
+  fetchAllPipelineSteps,
   getPipelineStatus,
   type PipelineStepLike,
 } from './shared.js';
@@ -51,22 +52,18 @@ export class LogsPipelineCommand extends BaseCommand<
     );
     const id = this.requireOption(options.id, 'id');
 
-    const stepsResponse = await this.pipelinesApi
-      .getPipelineStepsForRepository({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pipelineUuid: id,
-      })
-      .catch((error: unknown) =>
-        rethrowWithNotFoundContext(
-          error,
-          `Pipeline ${id} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
-        )
-      );
-
-    const steps = (
-      stepsResponse.data.values ? Array.from(stepsResponse.data.values) : []
-    ) as PipelineStepLike[];
+    // The steps endpoint is paginated (default pagelen 10), so the fetch
+    // walks every page — otherwise steps 11+ would be unselectable.
+    const steps = await fetchAllPipelineSteps(this.pipelinesApi, {
+      workspace: repoContext.workspace,
+      repoSlug: repoContext.repoSlug,
+      pipelineUuid: id,
+    }).catch((error: unknown) =>
+      rethrowWithNotFoundContext(
+        error,
+        `Pipeline ${id} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+      )
+    );
 
     if (steps.length === 0) {
       throw new BBError({

--- a/src/commands/pipeline/logs.command.ts
+++ b/src/commands/pipeline/logs.command.ts
@@ -1,0 +1,190 @@
+/**
+ * Pipeline logs command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { PipelinesApi } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import {
+  BBError,
+  ErrorCode,
+  rethrowWithNotFoundContext,
+} from '../../types/errors.js';
+import {
+  colorPipelineStatus,
+  getPipelineStatus,
+  type PipelineStepLike,
+} from './shared.js';
+
+export interface LogsPipelineOptions extends GlobalOptions {
+  id: string;
+  step?: string;
+}
+
+export class LogsPipelineCommand extends BaseCommand<
+  LogsPipelineOptions,
+  void
+> {
+  public readonly name = 'logs';
+  public readonly description = 'Print the log of a pipeline step';
+
+  constructor(
+    private readonly pipelinesApi: PipelinesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: LogsPipelineOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const id = this.requireOption(options.id, 'id');
+
+    const stepsResponse = await this.pipelinesApi
+      .getPipelineStepsForRepository({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipelineUuid: id,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Pipeline ${id} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+        )
+      );
+
+    const steps = (
+      stepsResponse.data.values ? Array.from(stepsResponse.data.values) : []
+    ) as PipelineStepLike[];
+
+    if (steps.length === 0) {
+      throw new BBError({
+        code: ErrorCode.API_NOT_FOUND,
+        message: `Pipeline ${id} has no steps yet. It may still be queued — check with \`bb pipeline view ${id}\`.`,
+      });
+    }
+
+    const step = this.selectStep(steps, options.step);
+
+    // No --step and several steps to choose from: surface the choices
+    // instead of guessing. JSON mode returns the steps so scripts/agents can
+    // pick a UUID; human mode renders them with their 1-based indexes.
+    if (!step) {
+      if (context.globalOptions.json) {
+        await this.output.json({
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pipelineId: id,
+          count: steps.length,
+          steps,
+        });
+        return;
+      }
+
+      this.output.info(
+        `Pipeline ${id} has ${steps.length} steps. Pass --step <uuid-or-index> to pick one:`
+      );
+      this.output.table(
+        ['#', 'NAME', 'STATUS', 'UUID'],
+        steps.map((candidate, index) => [
+          String(index + 1),
+          candidate.name ?? '-',
+          colorPipelineStatus(this.output, getPipelineStatus(candidate.state)),
+          candidate.uuid ?? '-',
+        ])
+      );
+      return;
+    }
+
+    const stepUuid = step.uuid ?? '';
+    const logResponse = await this.pipelinesApi
+      .getPipelineStepLogForRepository(
+        {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pipelineUuid: id,
+          stepUuid,
+        },
+        { responseType: 'text' }
+      )
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `No log found for step ${stepUuid} of pipeline ${id}. The step may not have started yet.`
+        )
+      );
+
+    // The generated return type is void because the spec models this endpoint
+    // as an opaque binary body, but the response body is the raw log text.
+    const log = (logResponse.data as unknown as string) ?? '';
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipelineId: id,
+        stepUuid,
+        log,
+      });
+      return;
+    }
+
+    this.output.text(log);
+  }
+
+  /**
+   * Pick the step the user asked for: by `--step` (a step UUID — braces
+   * optional — or a 1-based index), or automatically when the pipeline has
+   * exactly one step. Returns undefined when several steps exist and no
+   * `--step` was given.
+   */
+  private selectStep(
+    steps: PipelineStepLike[],
+    selector: string | undefined
+  ): PipelineStepLike | undefined {
+    if (selector === undefined || selector === '') {
+      return steps.length === 1 ? steps[0] : undefined;
+    }
+
+    if (/^\d+$/.test(selector)) {
+      const index = this.parsePositiveInt(selector, 'step');
+      const step = steps[index - 1];
+      if (!step) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: `--step index ${index} is out of range; the pipeline has ${steps.length} step${steps.length === 1 ? '' : 's'}.`,
+          context: { step: selector },
+        });
+      }
+      return step;
+    }
+
+    const normalized = selector.replace(/^\{|\}$/g, '');
+    const step = steps.find(
+      (candidate) =>
+        candidate.uuid === selector ||
+        candidate.uuid?.replace(/^\{|\}$/g, '') === normalized
+    );
+    if (!step) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `No step matching '${selector}' found. Available steps: ${steps
+          .map((candidate, index) => `${index + 1} (${candidate.uuid ?? '-'})`)
+          .join(', ')}.`,
+        context: { step: selector },
+      });
+    }
+    return step;
+  }
+}

--- a/src/commands/pipeline/run.command.ts
+++ b/src/commands/pipeline/run.command.ts
@@ -1,0 +1,145 @@
+/**
+ * Run pipeline command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IGitService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type {
+  Pipeline,
+  PipelineTarget,
+  PipelineVariable,
+  PipelinesApi,
+} from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface RunPipelineOptions extends GlobalOptions {
+  branch?: string;
+  commit?: string;
+  pipeline?: string;
+  var?: string[];
+}
+
+export class RunPipelineCommand extends BaseCommand<RunPipelineOptions, void> {
+  public readonly name = 'run';
+  public readonly description = 'Trigger a pipeline run';
+
+  constructor(
+    private readonly pipelinesApi: PipelinesApi,
+    private readonly contextService: IContextService,
+    private readonly gitService: IGitService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: RunPipelineOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+
+    const branch = options.branch ?? (await this.resolveCurrentBranch());
+    const variables = this.parseVariables(options.var);
+
+    // `PipelineTarget` is an empty marker interface in the generated client
+    // (the spec models ref/commit targets as subtypes), so the literal is
+    // built to the documented `pipeline_ref_target` shape and cast.
+    const target = {
+      type: 'pipeline_ref_target',
+      ref_type: 'branch',
+      ref_name: branch,
+      ...(options.commit
+        ? { commit: { type: 'commit', hash: options.commit } }
+        : {}),
+      ...(options.pipeline
+        ? { selector: { type: 'custom', pattern: options.pipeline } }
+        : {}),
+    } as unknown as PipelineTarget;
+
+    const pipeline: Pipeline = {
+      type: 'pipeline',
+      target,
+      ...(variables.length > 0 ? { variables } : {}),
+    };
+
+    const response = await this.pipelinesApi.createPipelineForRepository({
+      workspace: repoContext.workspace,
+      repoSlug: repoContext.repoSlug,
+      pipeline,
+    });
+
+    const created = response.data;
+
+    if (context.globalOptions.json) {
+      // The created pipeline as returned by the API (raw resource, mirrors
+      // `bb repo view --json`); agents read `build_number` / `uuid` from it.
+      await this.output.json(created);
+      return;
+    }
+
+    const buildNumber = created.build_number;
+    this.output.success(
+      `Pipeline #${buildNumber ?? '?'} started on branch ${branch}` +
+        (options.pipeline ? ` (custom pipeline: ${options.pipeline})` : '')
+    );
+    if (buildNumber !== undefined) {
+      this.output.text(
+        this.output.dim(
+          `View it with: bb pipeline view ${buildNumber}` +
+            ` | Logs: bb pipeline logs ${buildNumber}`
+        )
+      );
+    }
+  }
+
+  private async resolveCurrentBranch(): Promise<string> {
+    try {
+      return await this.gitService.getCurrentBranch();
+    } catch {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: this.appendHelpHint(
+          'Could not determine the current git branch (not inside a git repository?). Pass --branch <branch> to choose the ref to run the pipeline on.'
+        ),
+      });
+    }
+  }
+
+  /**
+   * Parse repeated `--var key=value` flags into Bitbucket pipeline variables.
+   * The value may itself contain `=`; only the first one splits.
+   */
+  private parseVariables(vars: string[] | undefined): PipelineVariable[] {
+    if (!vars || vars.length === 0) {
+      return [];
+    }
+
+    return vars.map((entry) => {
+      const separator = entry.indexOf('=');
+      if (separator <= 0) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_INVALID,
+          message: this.appendHelpHint(
+            `--var must be in key=value format (got '${entry}').`
+          ),
+          context: { var: entry },
+        });
+      }
+      return {
+        type: 'pipeline_variable',
+        key: entry.slice(0, separator),
+        value: entry.slice(separator + 1),
+        secured: false,
+      };
+    });
+  }
+}

--- a/src/commands/pipeline/run.command.ts
+++ b/src/commands/pipeline/run.command.ts
@@ -80,9 +80,13 @@ export class RunPipelineCommand extends BaseCommand<RunPipelineOptions, void> {
     const created = response.data;
 
     if (context.globalOptions.json) {
-      // The created pipeline as returned by the API (raw resource, mirrors
-      // `bb repo view --json`); agents read `build_number` / `uuid` from it.
-      await this.output.json(created);
+      // Same context envelope as the other pipeline subcommands, so scripts
+      // read the pipeline from `.pipeline` after both `run` and `view`.
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipeline: created,
+      });
       return;
     }
 

--- a/src/commands/pipeline/shared.ts
+++ b/src/commands/pipeline/shared.ts
@@ -8,7 +8,15 @@
  */
 
 import type { IOutputService } from '../../core/interfaces/services.js';
-import type { Pipeline, PipelineStep } from '../../generated/api.js';
+import type {
+  Pipeline,
+  PipelineStep,
+  PipelinesApi,
+} from '../../generated/api.js';
+import {
+  collectPages,
+  type PaginatedCollection,
+} from '../../services/pagination.js';
 
 interface PipelineStateLike {
   name?: string;
@@ -31,6 +39,28 @@ export type PipelineStepLike = PipelineStep & {
   name?: string;
   duration_in_seconds?: number;
 };
+
+/**
+ * Fetch every step of a pipeline. The steps endpoint is paginated with a
+ * server-side default `pagelen` of 10, so a single un-paginated request
+ * silently drops steps 11+ on larger pipelines — follow `next` until the
+ * collection is exhausted.
+ */
+export async function fetchAllPipelineSteps(
+  pipelinesApi: PipelinesApi,
+  request: { workspace: string; repoSlug: string; pipelineUuid: string }
+): Promise<PipelineStepLike[]> {
+  return collectPages<PipelineStepLike>({
+    limit: Number.POSITIVE_INFINITY,
+    fetchPage: async (page, pagelen) => {
+      const response = await pipelinesApi.getPipelineStepsForRepository(
+        request,
+        { params: { page, pagelen } }
+      );
+      return response.data as PaginatedCollection<PipelineStepLike>;
+    },
+  });
+}
 
 /**
  * Resolve the most specific status name for a pipeline or step: the completed

--- a/src/commands/pipeline/shared.ts
+++ b/src/commands/pipeline/shared.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared helpers for the `bb pipeline` command group.
+ *
+ * The generated `PipelineState` / `PipelineTarget` / `PipelineTrigger` models
+ * are empty marker interfaces (the OpenAPI spec models their variants as
+ * subtypes), so the helpers here narrow the runtime payloads through small
+ * structural types instead of reaching into the generated hierarchy.
+ */
+
+import type { IOutputService } from '../../core/interfaces/services.js';
+import type { Pipeline, PipelineStep } from '../../generated/api.js';
+
+interface PipelineStateLike {
+  name?: string;
+  result?: { name?: string };
+  stage?: { name?: string };
+}
+
+interface PipelineTargetLike {
+  ref_name?: string;
+  ref_type?: string;
+  commit?: { hash?: string };
+  selector?: { type?: string; pattern?: string };
+}
+
+/**
+ * The generated `PipelineStep` interface omits a few fields the REST API
+ * actually returns (`name`, `duration_in_seconds`); widen it structurally.
+ */
+export type PipelineStepLike = PipelineStep & {
+  name?: string;
+  duration_in_seconds?: number;
+};
+
+/**
+ * Resolve the most specific status name for a pipeline or step: the completed
+ * result (`PASSED`, `FAILED`, ...) wins over the in-progress stage
+ * (`RUNNING`, `PAUSED`, ...), which wins over the coarse state name
+ * (`PENDING`, `IN_PROGRESS`, `COMPLETED`).
+ */
+export function getPipelineStatus(state: unknown): string {
+  const stateLike = (state ?? {}) as PipelineStateLike;
+  return (
+    stateLike.result?.name ?? stateLike.stage?.name ?? stateLike.name ?? '-'
+  );
+}
+
+/**
+ * Colorize a pipeline/step status name: green for success, red for failure,
+ * yellow for anything still moving, gray for terminal-but-neutral states.
+ */
+export function colorPipelineStatus(
+  output: IOutputService,
+  status: string
+): string {
+  switch (status.toUpperCase()) {
+    case 'PASSED':
+    case 'SUCCESSFUL':
+      return output.green(status);
+    case 'FAILED':
+    case 'ERROR':
+      return output.red(status);
+    case 'PENDING':
+    case 'BUILDING':
+    case 'IN_PROGRESS':
+    case 'RUNNING':
+    case 'PARSING':
+    case 'PAUSED':
+    case 'READY':
+      return output.yellow(status);
+    case 'STOPPED':
+    case 'HALTED':
+    case 'EXPIRED':
+    case 'NOT_RUN':
+      return output.gray(status);
+    default:
+      return status;
+  }
+}
+
+/**
+ * Human-readable duration from a seconds count (e.g. `1h 2m 3s`). Returns
+ * `-` when the value is missing (pipeline still running or never started).
+ */
+export function formatDuration(seconds?: number): string {
+  if (seconds === undefined || seconds === null || !Number.isFinite(seconds)) {
+    return '-';
+  }
+  const total = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${secs}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${secs}s`;
+  }
+  return `${secs}s`;
+}
+
+/**
+ * The ref a pipeline ran against: branch/tag name, falling back to the
+ * commit hash for commit-target pipelines.
+ */
+export function getPipelineRef(pipeline: Pipeline): string {
+  const target = (pipeline.target ?? {}) as PipelineTargetLike;
+  return target.ref_name ?? target.commit?.hash?.slice(0, 12) ?? '-';
+}
+
+/** The custom pipeline definition name when one was selected, else undefined. */
+export function getPipelineSelectorPattern(
+  pipeline: Pipeline
+): string | undefined {
+  const target = (pipeline.target ?? {}) as PipelineTargetLike;
+  return target.selector?.pattern;
+}
+
+/** Trigger name (`PUSH`, `MANUAL`, `SCHEDULE`, ...) from the trigger variant. */
+export function getPipelineTrigger(pipeline: Pipeline): string {
+  const trigger = (pipeline.trigger ?? {}) as { name?: string };
+  return trigger.name ?? '-';
+}
+
+/**
+ * Duration of a single step in seconds, preferring the API-reported value and
+ * falling back to the started/completed timestamp delta.
+ */
+export function getStepDurationSeconds(
+  step: PipelineStepLike
+): number | undefined {
+  if (typeof step.duration_in_seconds === 'number') {
+    return step.duration_in_seconds;
+  }
+  if (step.started_on && step.completed_on) {
+    const delta =
+      (new Date(step.completed_on).getTime() -
+        new Date(step.started_on).getTime()) /
+      1000;
+    return Number.isFinite(delta) ? delta : undefined;
+  }
+  return undefined;
+}

--- a/src/commands/pipeline/stop.command.ts
+++ b/src/commands/pipeline/stop.command.ts
@@ -1,0 +1,74 @@
+/**
+ * Stop pipeline command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { PipelinesApi } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+
+export interface StopPipelineOptions extends GlobalOptions {
+  id: string;
+}
+
+export class StopPipelineCommand extends BaseCommand<
+  StopPipelineOptions,
+  void
+> {
+  public readonly name = 'stop';
+  public readonly description = 'Stop a running pipeline';
+
+  constructor(
+    private readonly pipelinesApi: PipelinesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: StopPipelineOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const id = this.requireOption(options.id, 'id');
+
+    // No --yes gate: stopping CI is reversible (rerun with `bb pipeline run`).
+    // The endpoint accepts a pipeline UUID or a plain build number raw.
+    await this.pipelinesApi
+      .stopPipeline({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipelineUuid: id,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Pipeline ${id} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+        )
+      );
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipelineId: id,
+        stopped: true,
+      });
+      return;
+    }
+
+    this.output.success(`Pipeline ${id} stopped`);
+    this.output.text(
+      this.output.dim(`Check its final state with: bb pipeline view ${id}`)
+    );
+  }
+}

--- a/src/commands/pipeline/view.command.ts
+++ b/src/commands/pipeline/view.command.ts
@@ -1,0 +1,143 @@
+/**
+ * View pipeline command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { PipelinesApi } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+import {
+  colorPipelineStatus,
+  formatDuration,
+  getPipelineRef,
+  getPipelineSelectorPattern,
+  getPipelineStatus,
+  getPipelineTrigger,
+  getStepDurationSeconds,
+  type PipelineStepLike,
+} from './shared.js';
+
+export interface ViewPipelineOptions extends GlobalOptions {
+  id: string;
+}
+
+export class ViewPipelineCommand extends BaseCommand<
+  ViewPipelineOptions,
+  void
+> {
+  public readonly name = 'view';
+  public readonly description = 'View pipeline details';
+
+  constructor(
+    private readonly pipelinesApi: PipelinesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ViewPipelineOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const id = this.requireOption(options.id, 'id');
+
+    // The REST endpoint accepts either a pipeline UUID (curly braces
+    // included) or a plain build number, so the user's value passes through
+    // raw — humans paste build numbers, scripts pass UUIDs.
+    const response = await this.pipelinesApi
+      .getPipelineForRepository({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipelineUuid: id,
+      })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Pipeline ${id} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+        )
+      );
+
+    const pipeline = response.data;
+    const steps = await this.fetchSteps(repoContext, id);
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        pipeline,
+        steps,
+      });
+      return;
+    }
+
+    const status = getPipelineStatus(pipeline.state);
+    const selector = getPipelineSelectorPattern(pipeline);
+
+    this.output.text(
+      `${this.output.bold(`Pipeline #${pipeline.build_number ?? '?'}`)} ${this.output.dim(pipeline.uuid ?? '')}`
+    );
+    this.output.text('');
+    this.output.text(
+      `  ${this.output.dim('Status:')} ${colorPipelineStatus(this.output, status)}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Ref:')} ${getPipelineRef(pipeline)}`
+    );
+    if (selector) {
+      this.output.text(`  ${this.output.dim('Pipeline:')} ${selector}`);
+    }
+    this.output.text(
+      `  ${this.output.dim('Trigger:')} ${getPipelineTrigger(pipeline)}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Creator:')} ${pipeline.creator?.display_name ?? '-'}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Created:')} ${pipeline.created_on ? this.output.formatDate(pipeline.created_on) : '-'}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Completed:')} ${pipeline.completed_on ? this.output.formatDate(pipeline.completed_on) : '-'}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Duration:')} ${formatDuration(pipeline.build_seconds_used)}`
+    );
+
+    if (steps.length > 0) {
+      this.output.text('');
+      this.output.text(this.output.bold('Steps'));
+      this.output.table(
+        ['#', 'NAME', 'STATUS', 'DURATION'],
+        steps.map((step, index) => [
+          String(index + 1),
+          step.name ?? step.uuid ?? '-',
+          colorPipelineStatus(this.output, getPipelineStatus(step.state)),
+          formatDuration(getStepDurationSeconds(step)),
+        ])
+      );
+    }
+  }
+
+  private async fetchSteps(
+    repoContext: { workspace: string; repoSlug: string },
+    id: string
+  ): Promise<PipelineStepLike[]> {
+    const response = await this.pipelinesApi.getPipelineStepsForRepository({
+      workspace: repoContext.workspace,
+      repoSlug: repoContext.repoSlug,
+      pipelineUuid: id,
+    });
+    return response.data.values
+      ? (Array.from(response.data.values) as PipelineStepLike[])
+      : [];
+  }
+}

--- a/src/commands/pipeline/view.command.ts
+++ b/src/commands/pipeline/view.command.ts
@@ -13,13 +13,13 @@ import type { GlobalOptions } from '../../types/config.js';
 import { rethrowWithNotFoundContext } from '../../types/errors.js';
 import {
   colorPipelineStatus,
+  fetchAllPipelineSteps,
   formatDuration,
   getPipelineRef,
   getPipelineSelectorPattern,
   getPipelineStatus,
   getPipelineTrigger,
   getStepDurationSeconds,
-  type PipelineStepLike,
 } from './shared.js';
 
 export interface ViewPipelineOptions extends GlobalOptions {
@@ -68,7 +68,13 @@ export class ViewPipelineCommand extends BaseCommand<
       );
 
     const pipeline = response.data;
-    const steps = await this.fetchSteps(repoContext, id);
+    // The steps endpoint is paginated (default pagelen 10); fetch every page
+    // so the step table and JSON envelope are complete on large pipelines.
+    const steps = await fetchAllPipelineSteps(this.pipelinesApi, {
+      workspace: repoContext.workspace,
+      repoSlug: repoContext.repoSlug,
+      pipelineUuid: id,
+    });
 
     if (context.globalOptions.json) {
       await this.output.json({
@@ -125,19 +131,5 @@ export class ViewPipelineCommand extends BaseCommand<
         ])
       );
     }
-  }
-
-  private async fetchSteps(
-    repoContext: { workspace: string; repoSlug: string },
-    id: string
-  ): Promise<PipelineStepLike[]> {
-    const response = await this.pipelinesApi.getPipelineStepsForRepository({
-      workspace: repoContext.workspace,
-      repoSlug: repoContext.repoSlug,
-      pipelineUuid: id,
-    });
-    return response.data.values
-      ? (Array.from(response.data.values) as PipelineStepLike[])
-      : [];
   }
 }

--- a/src/commands/pr/activity.command.ts
+++ b/src/commands/pr/activity.command.ts
@@ -10,10 +10,6 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { PullrequestsApi } from '../../generated/api.js';
 import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
-import {
   getRawContent,
   getUserDisplayName,
   parsePullrequestActivitiesPage,
@@ -66,11 +62,10 @@ export class ActivityPRCommand extends BaseCommand<
 
     const prId = this.parsePositiveInt(options.id, 'id');
     const filterTypes = this.parseTypeFilter(options.type);
-    const limit = resolveLimit(options);
 
-    const { items: activities, hasMore } =
-      await collectPagesWithMeta<PullrequestActivity>({
-        limit,
+    await this.runList<PullrequestActivity>(
+      {
+        options,
         fetchPage: async (page, pagelen) => {
           const response =
             await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdActivityGet(
@@ -96,47 +91,37 @@ export class ActivityPRCommand extends BaseCommand<
             this.getActivityType(activity)
           );
         },
-      });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pullRequestId: prId,
-        filters: {
-          types: filterTypes,
+        wrapperKey: 'activities',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pullRequestId: prId,
+          filters: {
+            types: filterTypes,
+          },
         },
-        count: activities.length,
-        activities,
-      });
-      return;
-    }
-
-    if (activities.length === 0) {
-      if (filterTypes.length > 0) {
-        this.output.info('No activity entries matched the requested filter');
-      } else {
-        this.output.info('No activity found on this pull request');
-      }
-      return;
-    }
-
-    const rows = activities.map((activity) => {
-      const activityType = this.getActivityType(activity);
-      return [
-        activityType.toUpperCase(),
-        this.getActorName(activity),
-        this.formatActivityDate(activity),
-        this.buildActivityDetails(
-          activity,
-          activityType,
-          context.globalOptions
-        ),
-      ];
-    });
-
-    this.output.table(['TYPE', 'ACTOR', 'DATE', 'DETAILS'], rows);
-    this.printMoreHint(activities.length, hasMore, 'activity entries');
+        emptyMessage: () =>
+          filterTypes.length > 0
+            ? 'No activity entries matched the requested filter'
+            : 'No activity found on this pull request',
+        tableHeaders: ['TYPE', 'ACTOR', 'DATE', 'DETAILS'],
+        mapRow: (activity) => {
+          const activityType = this.getActivityType(activity);
+          return [
+            activityType.toUpperCase(),
+            this.getActorName(activity),
+            this.formatActivityDate(activity),
+            this.buildActivityDetails(
+              activity,
+              activityType,
+              context.globalOptions
+            ),
+          ];
+        },
+        noun: 'activity entries',
+      },
+      context
+    );
   }
 
   private parseTypeFilter(typeOption?: string): ActivityType[] {

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -13,10 +13,6 @@ import type {
   PullrequestsApi,
 } from '../../generated/api.js';
 import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
-import {
   getRawContent,
   getUserDisplayName,
 } from '../../services/response-parsers.js';
@@ -52,11 +48,10 @@ export class ListCommentsPRCommand extends BaseCommand<
     );
 
     const prId = this.parsePositiveInt(options.id, 'id');
-    const limit = resolveLimit(options);
 
-    const { items: values, hasMore } =
-      await collectPagesWithMeta<PullrequestComment>({
-        limit,
+    await this.runList<PullrequestComment>(
+      {
+        options,
         fetchPage: async (page, pagelen) => {
           const response =
             await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
@@ -72,37 +67,28 @@ export class ListCommentsPRCommand extends BaseCommand<
 
           return response.data;
         },
-      });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        pullRequestId: prId,
-        count: values.length,
-        comments: values,
-      });
-      return;
-    }
-
-    if (values.length === 0) {
-      this.output.info('No comments found on this pull request');
-      return;
-    }
-
-    const rows = values.map((comment) => {
-      const content = getRawContent(comment.content) ?? '';
-      return [
-        comment.id?.toString() ?? '',
-        getUserDisplayName(comment.user) ?? 'Unknown',
-        comment.deleted
-          ? '[deleted]'
-          : this.truncateText(content, 60, context.globalOptions),
-        this.output.formatDate(comment.created_on ?? ''),
-      ];
-    });
-
-    this.output.table(['ID', 'Author', 'Content', 'Date'], rows);
-    this.printMoreHint(values.length, hasMore, 'comments');
+        wrapperKey: 'comments',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          pullRequestId: prId,
+        },
+        emptyMessage: 'No comments found on this pull request',
+        tableHeaders: ['ID', 'Author', 'Content', 'Date'],
+        mapRow: (comment) => {
+          const content = getRawContent(comment.content) ?? '';
+          return [
+            comment.id?.toString() ?? '',
+            getUserDisplayName(comment.user) ?? 'Unknown',
+            comment.deleted
+              ? '[deleted]'
+              : this.truncateText(content, 60, context.globalOptions),
+            this.output.formatDate(comment.created_on ?? ''),
+          ];
+        },
+        noun: 'comments',
+      },
+      context
+    );
   }
 }

--- a/src/commands/pr/list.command.ts
+++ b/src/commands/pr/list.command.ts
@@ -13,10 +13,7 @@ import type {
   Pullrequest,
   UsersApi,
 } from '../../generated/api.js';
-import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
+import { resolveLimit } from '../../services/pagination.js';
 import type { GlobalOptions } from '../../types/config.js';
 import { PR_STATES } from '../../types/pr.js';
 
@@ -52,70 +49,66 @@ export class ListPRsCommand extends BaseCommand<ListPRsOptions, void> {
     const state = options.state
       ? this.parseEnumOption(options.state, 'state', PR_STATES)
       : 'OPEN';
-    const limit = resolveLimit(options);
+    // Validate --limit before the --mine user lookup so an invalid limit
+    // fails fast without an API call; runList re-resolves the same value.
+    resolveLimit(options);
     const reviewerQuery = options.mine
       ? await this.buildMineFilter()
       : undefined;
 
-    const { items: values, hasMore } = await collectPagesWithMeta<Pullrequest>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response =
-          await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
-            {
-              workspace: repoContext.workspace,
-              repoSlug: repoContext.repoSlug,
-              state,
-            },
-            {
-              params: {
-                page,
-                pagelen,
-                ...(reviewerQuery ? { q: reviewerQuery } : {}),
-              },
-            }
-          );
-
-        return response.data;
-      },
-    });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace: repoContext.workspace,
-        repoSlug: repoContext.repoSlug,
-        state,
-        filters: {
-          mine: options.mine === true,
-        },
-        count: values.length,
-        pullRequests: values,
-      });
-      return;
-    }
-
-    if (values.length === 0) {
-      this.output.info(`No ${state.toLowerCase()} pull requests found`);
-      return;
-    }
-
     const arrow = this.output.symbol('→', '->');
-    const rows = values.map((pr: Pullrequest) => {
-      const title = pr.draft ? `[DRAFT] ${pr.title}` : pr.title;
-      const source = pr.source as { branch?: { name?: string } } | undefined;
-      const destination = pr.destination as
-        | { branch?: { name?: string } }
-        | undefined;
-      return [
-        `#${pr.id}`,
-        this.truncateText(title ?? '', 50, context.globalOptions),
-        pr.author?.display_name ?? 'Unknown',
-        `${source?.branch?.name ?? 'unknown'} ${arrow} ${destination?.branch?.name ?? 'unknown'}`,
-      ];
-    });
+    await this.runList<Pullrequest>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsGet(
+              {
+                workspace: repoContext.workspace,
+                repoSlug: repoContext.repoSlug,
+                state,
+              },
+              {
+                params: {
+                  page,
+                  pagelen,
+                  ...(reviewerQuery ? { q: reviewerQuery } : {}),
+                },
+              }
+            );
 
-    this.output.table(['ID', 'TITLE', 'AUTHOR', 'BRANCHES'], rows);
-    this.printMoreHint(values.length, hasMore, 'pull requests');
+          return response.data;
+        },
+        wrapperKey: 'pullRequests',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          state,
+          filters: {
+            mine: options.mine === true,
+          },
+        },
+        emptyMessage: `No ${state.toLowerCase()} pull requests found`,
+        tableHeaders: ['ID', 'TITLE', 'AUTHOR', 'BRANCHES'],
+        mapRow: (pr: Pullrequest) => {
+          const title = pr.draft ? `[DRAFT] ${pr.title}` : pr.title;
+          const source = pr.source as
+            | { branch?: { name?: string } }
+            | undefined;
+          const destination = pr.destination as
+            | { branch?: { name?: string } }
+            | undefined;
+          return [
+            `#${pr.id}`,
+            this.truncateText(title ?? '', 50, context.globalOptions),
+            pr.author?.display_name ?? 'Unknown',
+            `${source?.branch?.name ?? 'unknown'} ${arrow} ${destination?.branch?.name ?? 'unknown'}`,
+          ];
+        },
+        noun: 'pull requests',
+      },
+      context
+    );
   }
 
   private async buildMineFilter(): Promise<string | undefined> {

--- a/src/commands/project/create.command.ts
+++ b/src/commands/project/create.command.ts
@@ -1,0 +1,101 @@
+/**
+ * Create project command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { ProjectsApi } from '../../generated/api.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export interface CreateProjectOptions {
+  workspace?: string;
+  key?: string;
+  name?: string;
+  description?: string;
+  private?: boolean;
+  public?: boolean;
+}
+
+export class CreateProjectCommand extends BaseCommand<
+  CreateProjectOptions,
+  void
+> {
+  public readonly name = 'create';
+  public readonly description = 'Create a new project in a workspace';
+
+  constructor(
+    private readonly projectsApi: ProjectsApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: CreateProjectOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const rawKey = this.requireOption(options.key, 'key').trim();
+    const name = this.requireOption(options.name, 'name');
+
+    if (options.private && options.public) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          '--private and --public cannot both be set.'
+        ),
+      });
+    }
+
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(rawKey)) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: this.appendHelpHint(
+          '--key must start with a letter and contain only letters, digits, and underscores (e.g. PROJ).'
+        ),
+        context: { key: rawKey },
+      });
+    }
+
+    // Bitbucket requires uppercase project keys; normalize instead of failing.
+    const key = rawKey.toUpperCase();
+
+    const workspace = await this.contextService.requireWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    const response = await this.projectsApi.workspacesWorkspaceProjectsPost({
+      workspace,
+      project: {
+        type: 'project',
+        key,
+        name,
+        ...(options.description ? { description: options.description } : {}),
+        is_private: options.public !== true,
+      },
+    });
+
+    const project = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({ workspace, project });
+      return;
+    }
+
+    if (key !== rawKey) {
+      this.output.info(
+        `Project keys are uppercase on Bitbucket; using ${key}.`
+      );
+    }
+    this.output.success(
+      `Project ${project.key ?? key} created in ${workspace}`
+    );
+    this.output.text(
+      `  ${this.output.dim('Create a repository in it:')} bb repo create <name> -p ${project.key ?? key}`
+    );
+  }
+}

--- a/src/commands/project/list.command.ts
+++ b/src/commands/project/list.command.ts
@@ -1,0 +1,75 @@
+/**
+ * List projects command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Project, WorkspacesApi } from '../../generated/api.js';
+
+export interface ListProjectsOptions {
+  workspace?: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListProjectsCommand extends BaseCommand<
+  ListProjectsOptions,
+  void
+> {
+  public readonly name = 'list';
+  public readonly description = 'List projects in a workspace';
+
+  constructor(
+    // Project listing lives on the Workspaces API surface in the Bitbucket
+    // OpenAPI spec (GET /workspaces/{workspace}/projects).
+    private readonly workspacesApi: WorkspacesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListProjectsOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.contextService.requireWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+
+    await this.runList<Project>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response =
+            await this.workspacesApi.workspacesWorkspaceProjectsGet(
+              { workspace },
+              { params: { page, pagelen } }
+            );
+          return response.data;
+        },
+        wrapperKey: 'projects',
+        jsonMetadata: { workspace },
+        emptyMessage: `No projects found in workspace ${workspace}`,
+        tableHeaders: ['KEY', 'NAME', 'PRIVACY', 'DESCRIPTION', 'UPDATED'],
+        mapRow: (project) => [
+          this.output.bold(project.key ?? ''),
+          project.name ?? '',
+          project.is_private ? 'private' : 'public',
+          this.truncateText(
+            project.description ?? '',
+            50,
+            context.globalOptions
+          ),
+          this.output.formatDate(project.updated_on ?? ''),
+        ],
+        noun: 'projects',
+      },
+      context
+    );
+  }
+}

--- a/src/commands/project/view.command.ts
+++ b/src/commands/project/view.command.ts
@@ -1,0 +1,101 @@
+/**
+ * View project command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Project, ProjectsApi } from '../../generated/api.js';
+import { getLinkHref } from '../../services/response-parsers.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+
+export interface ViewProjectOptions {
+  key: string;
+  workspace?: string;
+}
+
+export class ViewProjectCommand extends BaseCommand<ViewProjectOptions, void> {
+  public readonly name = 'view';
+  public readonly description = 'View project details';
+
+  constructor(
+    private readonly projectsApi: ProjectsApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ViewProjectOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace = await this.contextService.requireWorkspace(
+      options.workspace ?? context.globalOptions.workspace
+    );
+    // Bitbucket stores project keys uppercased; normalize so lowercase input
+    // from humans and scripts resolves the same project.
+    const projectKey = this.requireOption(options.key, 'key')
+      .trim()
+      .toUpperCase();
+
+    const response = await this.projectsApi
+      .workspacesWorkspaceProjectsProjectKeyGet({ projectKey, workspace })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Project ${projectKey} not found in workspace ${workspace}.`
+        )
+      );
+
+    const project = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({ workspace, project });
+      return;
+    }
+
+    this.renderProject(project);
+  }
+
+  private renderProject(project: Project): void {
+    const visibility = project.is_private ? 'private' : 'public';
+
+    this.output.text('');
+    this.output.text(
+      `${this.output.bold(project.key ?? '')}  ${project.name ?? ''}  ${this.output.gray(`[${visibility}]`)}`
+    );
+    this.output.separator();
+
+    if (project.description) {
+      this.output.text(project.description);
+      this.output.text('');
+    }
+
+    if (project.uuid) {
+      this.output.text(`UUID:        ${project.uuid}`);
+    }
+    if (project.created_on) {
+      this.output.text(
+        `Created:     ${this.output.formatDate(project.created_on)}`
+      );
+    }
+    if (project.updated_on) {
+      this.output.text(
+        `Updated:     ${this.output.formatDate(project.updated_on)}`
+      );
+    }
+
+    const url =
+      getLinkHref(project.links, 'html') ?? getLinkHref(project.links, 'self');
+    if (url) {
+      this.output.text('');
+      this.output.text(this.output.cyan(url));
+    }
+
+    this.output.text('');
+  }
+}

--- a/src/commands/repo/list.command.ts
+++ b/src/commands/repo/list.command.ts
@@ -9,10 +9,6 @@ import type {
   IOutputService,
 } from '../../core/interfaces/services.js';
 import type { RepositoriesApi, Repository } from '../../generated/api.js';
-import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
 
 export interface ListReposOptions {
   workspace?: string;
@@ -39,45 +35,33 @@ export class ListReposCommand extends BaseCommand<ListReposOptions, void> {
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = resolveLimit(options);
+    await this.runList<Repository>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response = await this.repositoriesApi.repositoriesWorkspaceGet(
+            {
+              workspace,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
 
-    const { items: repos, hasMore } = await collectPagesWithMeta<Repository>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response = await this.repositoriesApi.repositoriesWorkspaceGet(
-          {
-            workspace,
-          },
-          {
-            params: { page, pagelen },
-          }
-        );
-
-        return response.data;
+          return response.data;
+        },
+        wrapperKey: 'repositories',
+        jsonMetadata: { workspace },
+        emptyMessage: 'No repositories found',
+        tableHeaders: ['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'],
+        mapRow: (repo) => [
+          repo.full_name ?? '',
+          repo.is_private ? 'private' : 'public',
+          this.truncateText(repo.description ?? '', 50, context.globalOptions),
+        ],
+        noun: 'repositories',
       },
-    });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace,
-        count: repos.length,
-        repositories: repos,
-      });
-      return;
-    }
-
-    if (repos.length === 0) {
-      this.output.info('No repositories found');
-      return;
-    }
-
-    const rows = repos.map((repo) => [
-      repo.full_name ?? '',
-      repo.is_private ? 'private' : 'public',
-      this.truncateText(repo.description ?? '', 50, context.globalOptions),
-    ]);
-
-    this.output.table(['REPOSITORY', 'VISIBILITY', 'DESCRIPTION'], rows);
-    this.printMoreHint(repos.length, hasMore, 'repositories');
+      context
+    );
   }
 }

--- a/src/commands/snippet/comments.list.command.ts
+++ b/src/commands/snippet/comments.list.command.ts
@@ -10,10 +10,6 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { SnippetComment, SnippetsApi } from '../../generated/api.js';
 import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
-import {
   getRawContent,
   getUserDisplayName,
 } from '../../services/response-parsers.js';
@@ -46,11 +42,9 @@ export class ListSnippetCommentsCommand extends BaseCommand<
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = resolveLimit(options);
-
-    const { items: comments, hasMore } =
-      await collectPagesWithMeta<SnippetComment>({
-        limit,
+    await this.runList<SnippetComment>(
+      {
+        options,
         fetchPage: async (page, pagelen) => {
           const response =
             await this.snippetsApi.snippetsWorkspaceEncodedIdCommentsGet(
@@ -65,34 +59,25 @@ export class ListSnippetCommentsCommand extends BaseCommand<
 
           return response.data;
         },
-      });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace,
-        snippetId: options.id,
-        count: comments.length,
-        comments,
-      });
-      return;
-    }
-
-    if (comments.length === 0) {
-      this.output.info('No comments found on this snippet');
-      return;
-    }
-
-    const rows = comments.map((comment) => {
-      const content = getRawContent(comment.content) ?? '';
-      return [
-        String(comment.id ?? ''),
-        getUserDisplayName(comment.user) ?? 'Unknown',
-        this.output.formatDate(comment.created_on ?? ''),
-        this.truncateText(content, 60, context.globalOptions),
-      ];
-    });
-
-    this.output.table(['ID', 'AUTHOR', 'DATE', 'CONTENT'], rows);
-    this.printMoreHint(comments.length, hasMore, 'comments');
+        wrapperKey: 'comments',
+        jsonMetadata: {
+          workspace,
+          snippetId: options.id,
+        },
+        emptyMessage: 'No comments found on this snippet',
+        tableHeaders: ['ID', 'AUTHOR', 'DATE', 'CONTENT'],
+        mapRow: (comment) => {
+          const content = getRawContent(comment.content) ?? '';
+          return [
+            String(comment.id ?? ''),
+            getUserDisplayName(comment.user) ?? 'Unknown',
+            this.output.formatDate(comment.created_on ?? ''),
+            this.truncateText(content, 60, context.globalOptions),
+          ];
+        },
+        noun: 'comments',
+      },
+      context
+    );
   }
 }

--- a/src/commands/snippet/list.command.ts
+++ b/src/commands/snippet/list.command.ts
@@ -10,10 +10,7 @@ import type {
 } from '../../core/interfaces/services.js';
 import type { Snippet, SnippetsApi } from '../../generated/api.js';
 import { SnippetsWorkspaceGetRoleEnum } from '../../generated/api.js';
-import {
-  collectPagesWithMeta,
-  resolveLimit,
-} from '../../services/pagination.js';
+import { resolveLimit } from '../../services/pagination.js';
 import { getUserDisplayName } from '../../services/response-parsers.js';
 
 const VALID_ROLES = Object.values(SnippetsWorkspaceGetRoleEnum) as readonly (
@@ -51,55 +48,44 @@ export class ListSnippetsCommand extends BaseCommand<
     const workspace = await this.contextService.requireWorkspace(
       options.workspace ?? context.globalOptions.workspace
     );
-    const limit = resolveLimit(options);
+    // Validate --limit before --role to preserve the original validation
+    // error precedence; runList re-resolves the same value.
+    resolveLimit(options);
 
     const role = options.role
       ? this.parseEnumOption(options.role, 'role', VALID_ROLES)
       : undefined;
 
-    const { items: snippets, hasMore } = await collectPagesWithMeta<Snippet>({
-      limit,
-      fetchPage: async (page, pagelen) => {
-        const response = await this.snippetsApi.snippetsWorkspaceGet(
-          {
-            workspace,
-            role: role as 'owner' | 'contributor' | 'member' | undefined,
-          },
-          {
-            params: { page, pagelen },
-          }
-        );
+    await this.runList<Snippet>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response = await this.snippetsApi.snippetsWorkspaceGet(
+            {
+              workspace,
+              role: role as 'owner' | 'contributor' | 'member' | undefined,
+            },
+            {
+              params: { page, pagelen },
+            }
+          );
 
-        return response.data;
+          return response.data;
+        },
+        wrapperKey: 'snippets',
+        jsonMetadata: { workspace },
+        emptyMessage: 'No snippets found',
+        tableHeaders: ['ID', 'TITLE', 'VISIBILITY', 'CREATOR', 'UPDATED'],
+        mapRow: (snippet) => [
+          String(snippet.id ?? ''),
+          snippet.title ?? '',
+          snippet.is_private ? 'private' : 'public',
+          getUserDisplayName(snippet.creator) ?? '',
+          this.output.formatDate(snippet.updated_on ?? ''),
+        ],
+        noun: 'snippets',
       },
-    });
-
-    if (context.globalOptions.json) {
-      await this.output.json({
-        workspace,
-        count: snippets.length,
-        snippets,
-      });
-      return;
-    }
-
-    if (snippets.length === 0) {
-      this.output.info('No snippets found');
-      return;
-    }
-
-    const rows = snippets.map((snippet) => [
-      String(snippet.id ?? ''),
-      snippet.title ?? '',
-      snippet.is_private ? 'private' : 'public',
-      getUserDisplayName(snippet.creator) ?? '',
-      this.output.formatDate(snippet.updated_on ?? ''),
-    ]);
-
-    this.output.table(
-      ['ID', 'TITLE', 'VISIBILITY', 'CREATOR', 'UPDATED'],
-      rows
+      context
     );
-    this.printMoreHint(snippets.length, hasMore, 'snippets');
   }
 }

--- a/src/commands/status/list.command.ts
+++ b/src/commands/status/list.command.ts
@@ -1,0 +1,96 @@
+/**
+ * List commit statuses command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { CommitStatusesApi, Commitstatus } from '../../generated/api.js';
+import { resolveLimit } from '../../services/pagination.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+import { colorStatusState } from './shared.js';
+
+export interface ListCommitStatusesOptions extends GlobalOptions {
+  sha: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListCommitStatusesCommand extends BaseCommand<
+  ListCommitStatusesOptions,
+  void
+> {
+  public readonly name = 'list';
+  public readonly description = 'List commit statuses (build results)';
+
+  constructor(
+    private readonly commitStatusesApi: CommitStatusesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListCommitStatusesOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const sha = this.requireOption(options.sha, 'sha');
+
+    // Validate --limit before any network call; runList re-resolves it.
+    resolveLimit(options);
+
+    await this.runList<Commitstatus>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          const response = await this.commitStatusesApi
+            .repositoriesWorkspaceRepoSlugCommitCommitStatusesGet(
+              {
+                commit: sha,
+                repoSlug: repoContext.repoSlug,
+                workspace: repoContext.workspace,
+              },
+              { params: { page, pagelen } }
+            )
+            .catch((error: unknown) =>
+              rethrowWithNotFoundContext(
+                error,
+                `Commit ${sha} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+              )
+            );
+          return response.data;
+        },
+        wrapperKey: 'statuses',
+        jsonMetadata: {
+          workspace: repoContext.workspace,
+          repoSlug: repoContext.repoSlug,
+          commit: sha,
+        },
+        emptyMessage: `No statuses found for commit ${sha}`,
+        tableHeaders: ['KEY', 'STATE', 'NAME', 'DESCRIPTION', 'URL'],
+        mapRow: (status) => [
+          status.key ?? '-',
+          colorStatusState(this.output, status.state),
+          status.name ?? '-',
+          this.truncateText(
+            status.description ?? '-',
+            40,
+            context.globalOptions
+          ),
+          status.url ?? '-',
+        ],
+        noun: 'statuses',
+      },
+      context
+    );
+  }
+}

--- a/src/commands/status/set.command.ts
+++ b/src/commands/status/set.command.ts
@@ -1,0 +1,146 @@
+/**
+ * Set commit status command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { CommitStatusesApi, Commitstatus } from '../../generated/api.js';
+import type { CommitstatusStateEnum } from '../../generated/api.js';
+import type { GlobalOptions } from '../../types/config.js';
+import { APIError, rethrowWithNotFoundContext } from '../../types/errors.js';
+import { COMMIT_STATUS_STATES } from './shared.js';
+
+export interface SetCommitStatusOptions extends GlobalOptions {
+  sha: string;
+  key?: string;
+  state?: string;
+  url?: string;
+  name?: string;
+  description?: string;
+  refname?: string;
+}
+
+export class SetCommitStatusCommand extends BaseCommand<
+  SetCommitStatusOptions,
+  void
+> {
+  public readonly name = 'set';
+  public readonly description = 'Create or update a build status on a commit';
+
+  constructor(
+    private readonly commitStatusesApi: CommitStatusesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: SetCommitStatusOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const repoContext = await this.contextService.requireRepoContextFor(
+      options,
+      context
+    );
+    const sha = this.requireOption(options.sha, 'sha');
+    const key = this.requireOption(options.key, 'key');
+    const state = this.parseEnumOption(
+      this.requireOption(options.state, 'state').toUpperCase(),
+      'state',
+      COMMIT_STATUS_STATES
+    ) as CommitstatusStateEnum;
+
+    const commitstatus: Commitstatus = {
+      // 'type' is the ModelObject discriminator; 'build' is the only
+      // commit-status type Bitbucket supports.
+      type: 'build',
+      key,
+      state,
+      ...(options.url ? { url: options.url } : {}),
+      ...(options.name ? { name: options.name } : {}),
+      ...(options.description ? { description: options.description } : {}),
+      ...(options.refname ? { refname: options.refname } : {}),
+    };
+
+    const status = await this.createOrUpdateStatus(
+      repoContext,
+      sha,
+      key,
+      commitstatus
+    );
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        workspace: repoContext.workspace,
+        repoSlug: repoContext.repoSlug,
+        commit: sha,
+        status,
+      });
+      return;
+    }
+
+    this.output.success(`Status ${key} set to ${state} on ${sha.slice(0, 7)}`);
+  }
+
+  /**
+   * CI-friendly idempotent "set": POST creates the status, but Bitbucket
+   * rejects the POST when a status with the same key already exists on the
+   * commit (CI re-runs hit this constantly). On that rejection, fall back to
+   * the PUT endpoint which updates the existing status in place. Auth and
+   * not-found failures are rethrown immediately — only the POST-specific
+   * duplicate-key rejection is retried as an update.
+   */
+  private async createOrUpdateStatus(
+    repoContext: { workspace: string; repoSlug: string },
+    sha: string,
+    key: string,
+    commitstatus: Commitstatus
+  ): Promise<Commitstatus> {
+    try {
+      const response =
+        await this.commitStatusesApi.repositoriesWorkspaceRepoSlugCommitCommitStatusesBuildPost(
+          {
+            commit: sha,
+            repoSlug: repoContext.repoSlug,
+            workspace: repoContext.workspace,
+            commitstatus,
+          }
+        );
+      return response.data;
+    } catch (error) {
+      if (
+        !(error instanceof APIError) ||
+        error.statusCode === 401 ||
+        error.statusCode === 403 ||
+        error.statusCode === 404
+      ) {
+        if (error instanceof APIError && error.statusCode === 404) {
+          rethrowWithNotFoundContext(
+            error,
+            `Commit ${sha} not found in ${repoContext.workspace}/${repoContext.repoSlug}.`
+          );
+        }
+        throw error;
+      }
+
+      // Duplicate key (or other POST-only rejection): update the existing
+      // status under the same key instead, making `bb status set` idempotent.
+      const response =
+        await this.commitStatusesApi.repositoriesWorkspaceRepoSlugCommitCommitStatusesBuildKeyPut(
+          {
+            commit: sha,
+            key,
+            repoSlug: repoContext.repoSlug,
+            workspace: repoContext.workspace,
+            commitstatus,
+          }
+        );
+      return response.data;
+    }
+  }
+}

--- a/src/commands/status/shared.ts
+++ b/src/commands/status/shared.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared helpers for commit-status commands
+ */
+
+import type { IOutputService } from '../../core/interfaces/services.js';
+import { CommitstatusStateEnum } from '../../generated/api.js';
+
+/** All valid commit-status states, single-sourced from the generated enum. */
+export const COMMIT_STATUS_STATES = Object.values(
+  CommitstatusStateEnum
+) as readonly string[];
+
+/**
+ * Color a commit-status state the same way `bb pr checks` renders build
+ * states: green for success, red for failure, yellow for in-progress, gray
+ * for stopped/unknown.
+ */
+export function colorStatusState(
+  output: IOutputService,
+  state: string | undefined
+): string {
+  switch (state?.toUpperCase()) {
+    case 'SUCCESSFUL':
+      return output.green(state ?? '');
+    case 'FAILED':
+      return output.red(state ?? '');
+    case 'INPROGRESS':
+      return output.yellow(state ?? '');
+    case 'STOPPED':
+      return output.gray(state ?? '');
+    default:
+      return output.gray(state ?? '-');
+  }
+}

--- a/src/commands/workspace/list.command.ts
+++ b/src/commands/workspace/list.command.ts
@@ -1,0 +1,88 @@
+/**
+ * List workspaces command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type { IOutputService } from '../../core/interfaces/services.js';
+import type { Workspace, WorkspacesApi } from '../../generated/api.js';
+import { WorkspacesGetRoleEnum } from '../../generated/api.js';
+import { resolveLimit } from '../../services/pagination.js';
+
+export const WORKSPACE_ROLES = Object.values(
+  WorkspacesGetRoleEnum
+) as readonly ('owner' | 'collaborator' | 'member')[];
+
+export interface ListWorkspacesOptions {
+  role?: string;
+  limit?: string;
+  all?: boolean;
+}
+
+export class ListWorkspacesCommand extends BaseCommand<
+  ListWorkspacesOptions,
+  void
+> {
+  public readonly name = 'list';
+  public readonly description = 'List workspaces you have access to';
+
+  constructor(
+    private readonly workspacesApi: WorkspacesApi,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ListWorkspacesOptions,
+    context: CommandContext
+  ): Promise<void> {
+    // Validate --limit before --role to keep validation error precedence
+    // consistent with the other list commands; runList re-resolves the value.
+    resolveLimit(options);
+
+    const role = options.role
+      ? this.parseEnumOption(options.role, 'role', WORKSPACE_ROLES)
+      : undefined;
+
+    await this.runList<Workspace>(
+      {
+        options,
+        fetchPage: async (page, pagelen) => {
+          // The generated request interface models role/q/sort, while page
+          // and pagelen go through raw axios params.
+          const response = await this.workspacesApi.workspacesGet(
+            { role },
+            { params: { page, pagelen } }
+          );
+          return response.data;
+        },
+        wrapperKey: 'workspaces',
+        jsonMetadata: {
+          filters: { ...(role ? { role } : {}) },
+        },
+        emptyMessage: () =>
+          role
+            ? `No workspaces found for role "${role}"`
+            : 'No workspaces found',
+        tableHeaders: ['SLUG', 'NAME', 'PRIVACY', 'UUID'],
+        mapRow: (workspace) => [
+          this.output.bold(workspace.slug ?? ''),
+          workspace.name ?? '',
+          workspace.is_private ? 'private' : 'public',
+          workspace.uuid ?? '',
+        ],
+        noun: 'workspaces',
+      },
+      context
+    );
+
+    if (!context.globalOptions.json) {
+      this.output.text(
+        this.output.dim(
+          'Use a slug with -w <slug> or set a default: bb config set defaultWorkspace <slug>'
+        )
+      );
+    }
+  }
+}

--- a/src/commands/workspace/view.command.ts
+++ b/src/commands/workspace/view.command.ts
@@ -1,0 +1,106 @@
+/**
+ * View workspace command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IContextService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import type { Workspace, WorkspacesApi } from '../../generated/api.js';
+import { getLinkHref } from '../../services/response-parsers.js';
+import { rethrowWithNotFoundContext } from '../../types/errors.js';
+
+export interface ViewWorkspaceOptions {
+  /** Optional positional slug; falls back to the resolved workspace context */
+  slug?: string;
+  workspace?: string;
+}
+
+export class ViewWorkspaceCommand extends BaseCommand<
+  ViewWorkspaceOptions,
+  void
+> {
+  public readonly name = 'view';
+  public readonly description = 'View workspace details';
+
+  constructor(
+    private readonly workspacesApi: WorkspacesApi,
+    private readonly contextService: IContextService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: ViewWorkspaceOptions,
+    context: CommandContext
+  ): Promise<void> {
+    const workspace =
+      options.slug ??
+      (await this.contextService.requireWorkspace(
+        options.workspace ?? context.globalOptions.workspace
+      ));
+
+    const response = await this.workspacesApi
+      .workspacesWorkspaceGet({ workspace })
+      .catch((error: unknown) =>
+        rethrowWithNotFoundContext(
+          error,
+          `Workspace ${workspace} not found (or you do not have access to it).`
+        )
+      );
+
+    const data = response.data;
+
+    if (context.globalOptions.json) {
+      await this.output.json({ workspace: data });
+      return;
+    }
+
+    this.renderWorkspace(data);
+  }
+
+  private renderWorkspace(workspace: Workspace): void {
+    const visibility = workspace.is_private ? 'private' : 'public';
+
+    this.output.text('');
+    this.output.text(
+      `${this.output.bold(workspace.slug ?? '')}  ${workspace.name ?? ''}  ${this.output.gray(`[${visibility}]`)}`
+    );
+    this.output.separator();
+
+    if (workspace.uuid) {
+      this.output.text(`UUID:        ${workspace.uuid}`);
+    }
+    if (workspace.forking_mode) {
+      this.output.text(`Forking:     ${workspace.forking_mode}`);
+    }
+    if (workspace.is_privacy_enforced !== undefined) {
+      this.output.text(
+        `Privacy:     ${workspace.is_privacy_enforced ? 'enforced' : 'not enforced'}`
+      );
+    }
+    if (workspace.created_on) {
+      this.output.text(
+        `Created:     ${this.output.formatDate(workspace.created_on)}`
+      );
+    }
+    if (workspace.updated_on) {
+      this.output.text(
+        `Updated:     ${this.output.formatDate(workspace.updated_on)}`
+      );
+    }
+
+    const url =
+      getLinkHref(workspace.links, 'html') ??
+      getLinkHref(workspace.links, 'self');
+    if (url) {
+      this.output.text('');
+      this.output.text(this.output.cyan(url));
+    }
+
+    this.output.text('');
+  }
+}

--- a/src/commands/workspace/view.command.ts
+++ b/src/commands/workspace/view.command.ts
@@ -13,7 +13,10 @@ import { getLinkHref } from '../../services/response-parsers.js';
 import { rethrowWithNotFoundContext } from '../../types/errors.js';
 
 export interface ViewWorkspaceOptions {
-  /** Optional positional slug; falls back to the resolved workspace context */
+  /**
+   * Optional positional slug; falls back to `-w`, the current repository's
+   * git remote, then `BB_WORKSPACE` / `config.defaultWorkspace`.
+   */
   slug?: string;
   workspace?: string;
 }
@@ -37,11 +40,15 @@ export class ViewWorkspaceCommand extends BaseCommand<
     options: ViewWorkspaceOptions,
     context: CommandContext
   ): Promise<void> {
+    // Resolution order matches repo-scoped commands: explicit slug / -w flag,
+    // then the current repository's Bitbucket remote, then BB_WORKSPACE /
+    // config.defaultWorkspace (requireWorkspace throws when nothing resolves).
     const workspace =
       options.slug ??
-      (await this.contextService.requireWorkspace(
-        options.workspace ?? context.globalOptions.workspace
-      ));
+      options.workspace ??
+      context.globalOptions.workspace ??
+      (await this.contextService.getRepoContextFromGit())?.workspace ??
+      (await this.contextService.requireWorkspace());
 
     const response = await this.workspacesApi
       .workspacesWorkspaceGet({ workspace })

--- a/src/core/base-command.ts
+++ b/src/core/base-command.ts
@@ -4,7 +4,59 @@
 
 import type { ICommand, CommandContext } from './interfaces/commands.js';
 import type { IOutputService } from './interfaces/services.js';
+import { WRAPPER_ARRAY_KEYS } from '../services/output.service.js';
+import {
+  collectPagesWithMeta,
+  resolveLimit,
+  type PaginatedCollection,
+} from '../services/pagination.js';
 import { BBError, ErrorCode } from '../types/errors.js';
+
+/**
+ * Declarative spec for {@link BaseCommand.runList}. Captures everything that
+ * varies between paginated list commands once context resolution and filter
+ * construction (which stay in each command) are done.
+ */
+export interface RunListSpec<TItem> {
+  /**
+   * The command options carrying `--limit` / `--all`; resolved via
+   * `resolveLimit()` (defaulting to 25, `Infinity` for `--all`).
+   */
+  options: { limit?: string; all?: boolean };
+  /** Fetch one page from the API (1-based page number). */
+  fetchPage: (
+    page: number,
+    pagelen: number
+  ) => Promise<PaginatedCollection<TItem>>;
+  /** Optional client-side filter applied to each fetched item. */
+  shouldInclude?: (item: TItem) => boolean;
+  /**
+   * Key under which the collected items array is emitted in the JSON
+   * envelope (e.g. `pullRequests`, `comments`). MUST be registered in
+   * `WRAPPER_ARRAY_KEYS` (src/services/output.service.ts) so `--json
+   * fields` / `--jq` projection unwraps the array; `runList()` throws if it
+   * is not, so drift is caught by any test exercising the command.
+   */
+  wrapperKey: string;
+  /**
+   * Extra envelope keys (workspace, repoSlug, filters, ...) spread BEFORE
+   * `count` so the serialized JSON keeps the metadata-first key order that
+   * tests and docs rely on.
+   */
+  jsonMetadata?: Record<string, unknown>;
+  /**
+   * Empty-state message for table mode (JSON mode still emits the full
+   * envelope with `count: 0`). Pass a function when the message depends on
+   * runtime state such as active filters.
+   */
+  emptyMessage: string | (() => string);
+  /** Table column headers. */
+  tableHeaders: string[];
+  /** Maps one item to its table row. */
+  mapRow: (item: TItem) => string[];
+  /** Noun for the "Showing N <noun>..." more-results footer. */
+  noun: string;
+}
 
 export abstract class BaseCommand<
   TOptions = unknown,
@@ -210,6 +262,59 @@ export abstract class BaseCommand<
       code: ErrorCode.VALIDATION_REQUIRED,
       message: `${warning}\nUse --yes to confirm.`,
     });
+  }
+
+  /**
+   * Shared driver for paginated list commands. Runs the common tail of every
+   * `bb ... list`-style command: resolve `--limit`/`--all`, collect pages via
+   * `collectPagesWithMeta`, then either emit the JSON envelope
+   * (`{ ...jsonMetadata, count, [wrapperKey]: items }`), print the
+   * empty-state message, or render the table followed by the more-results
+   * hint. Context resolution and filter construction remain the caller's
+   * responsibility — build those first, then delegate here.
+   */
+  protected async runList<TItem>(
+    spec: RunListSpec<TItem>,
+    context: CommandContext
+  ): Promise<void> {
+    if (!WRAPPER_ARRAY_KEYS.includes(spec.wrapperKey)) {
+      throw new Error(
+        `runList wrapperKey "${spec.wrapperKey}" is not registered in ` +
+          'WRAPPER_ARRAY_KEYS (src/services/output.service.ts). Register it ' +
+          'there so --json fields/--jq projection unwraps the items array.'
+      );
+    }
+
+    const limit = resolveLimit(spec.options);
+    const { items, hasMore } = await collectPagesWithMeta<TItem>({
+      limit,
+      fetchPage: spec.fetchPage,
+      shouldInclude: spec.shouldInclude,
+    });
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        ...(spec.jsonMetadata ?? {}),
+        count: items.length,
+        [spec.wrapperKey]: items,
+      });
+      return;
+    }
+
+    if (items.length === 0) {
+      this.output.info(
+        typeof spec.emptyMessage === 'function'
+          ? spec.emptyMessage()
+          : spec.emptyMessage
+      );
+      return;
+    }
+
+    this.output.table(
+      spec.tableHeaders,
+      items.map((item) => spec.mapRow(item))
+    );
+    this.printMoreHint(items.length, hasMore, spec.noun);
   }
 
   /**

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -141,6 +141,8 @@ export const ServiceTokens = {
   CommitsApi: 'CommitsApi',
   PipelinesApi: 'PipelinesApi',
   IssueTrackerApi: 'IssueTrackerApi',
+  WorkspacesApi: 'WorkspacesApi',
+  ProjectsApi: 'ProjectsApi',
 
   // Commands - Auth
   LoginCommand: 'LoginCommand',
@@ -228,6 +230,15 @@ export const ServiceTokens = {
   EditIssueCommand: 'EditIssueCommand',
   CloseIssueCommand: 'CloseIssueCommand',
   CommentIssueCommand: 'CommentIssueCommand',
+
+  // Commands - Workspace
+  ListWorkspacesCommand: 'ListWorkspacesCommand',
+  ViewWorkspaceCommand: 'ViewWorkspaceCommand',
+
+  // Commands - Project
+  ListProjectsCommand: 'ListProjectsCommand',
+  ViewProjectCommand: 'ViewProjectCommand',
+  CreateProjectCommand: 'CreateProjectCommand',
 
   // Commands - Config
   GetConfigCommand: 'GetConfigCommand',

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -138,6 +138,7 @@ export const ServiceTokens = {
   RepositoriesApi: 'RepositoriesApi',
   UsersApi: 'UsersApi',
   CommitStatusesApi: 'CommitStatusesApi',
+  PipelinesApi: 'PipelinesApi',
 
   // Commands - Auth
   LoginCommand: 'LoginCommand',
@@ -202,6 +203,13 @@ export const ServiceTokens = {
   AddSnippetCommentCommand: 'AddSnippetCommentCommand',
   EditSnippetCommentCommand: 'EditSnippetCommentCommand',
   DeleteSnippetCommentCommand: 'DeleteSnippetCommentCommand',
+
+  // Commands - Pipeline
+  ListPipelinesCommand: 'ListPipelinesCommand',
+  ViewPipelineCommand: 'ViewPipelineCommand',
+  RunPipelineCommand: 'RunPipelineCommand',
+  StopPipelineCommand: 'StopPipelineCommand',
+  LogsPipelineCommand: 'LogsPipelineCommand',
 
   // Commands - Config
   GetConfigCommand: 'GetConfigCommand',

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -138,6 +138,7 @@ export const ServiceTokens = {
   RepositoriesApi: 'RepositoriesApi',
   UsersApi: 'UsersApi',
   CommitStatusesApi: 'CommitStatusesApi',
+  CommitsApi: 'CommitsApi',
   PipelinesApi: 'PipelinesApi',
 
   // Commands - Auth
@@ -210,6 +211,14 @@ export const ServiceTokens = {
   RunPipelineCommand: 'RunPipelineCommand',
   StopPipelineCommand: 'StopPipelineCommand',
   LogsPipelineCommand: 'LogsPipelineCommand',
+
+  // Commands - Commit
+  ListCommitsCommand: 'ListCommitsCommand',
+  ViewCommitCommand: 'ViewCommitCommand',
+
+  // Commands - Status (commit build statuses)
+  ListCommitStatusesCommand: 'ListCommitStatusesCommand',
+  SetCommitStatusCommand: 'SetCommitStatusCommand',
 
   // Commands - Config
   GetConfigCommand: 'GetConfigCommand',

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -140,6 +140,7 @@ export const ServiceTokens = {
   CommitStatusesApi: 'CommitStatusesApi',
   CommitsApi: 'CommitsApi',
   PipelinesApi: 'PipelinesApi',
+  IssueTrackerApi: 'IssueTrackerApi',
 
   // Commands - Auth
   LoginCommand: 'LoginCommand',
@@ -219,6 +220,14 @@ export const ServiceTokens = {
   // Commands - Status (commit build statuses)
   ListCommitStatusesCommand: 'ListCommitStatusesCommand',
   SetCommitStatusCommand: 'SetCommitStatusCommand',
+
+  // Commands - Issue
+  ListIssuesCommand: 'ListIssuesCommand',
+  ViewIssueCommand: 'ViewIssueCommand',
+  CreateIssueCommand: 'CreateIssueCommand',
+  EditIssueCommand: 'EditIssueCommand',
+  CloseIssueCommand: 'CloseIssueCommand',
+  CommentIssueCommand: 'CommentIssueCommand',
 
   // Commands - Config
   GetConfigCommand: 'GetConfigCommand',

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -133,6 +133,7 @@ export const ServiceTokens = {
   VersionService: 'VersionService',
 
   // API Clients
+  SharedApiAxios: 'SharedApiAxios',
   PullrequestsApi: 'PullrequestsApi',
   RepositoriesApi: 'RepositoriesApi',
   UsersApi: 'UsersApi',
@@ -159,9 +160,6 @@ export const ServiceTokens = {
 
   // Services - URL builder (Bitbucket web URL construction)
   UrlBuilderService: 'UrlBuilderService',
-
-  // Raw API passthrough (bb api)
-  ApiAxios: 'ApiAxios',
 
   // Commands - Top level
   BrowseCommand: 'BrowseCommand',
@@ -190,7 +188,6 @@ export const ServiceTokens = {
 
   // API Clients - Snippets
   SnippetsApi: 'SnippetsApi',
-  SnippetsAxios: 'SnippetsAxios',
   SnippetFilesService: 'SnippetFilesService',
 
   // Commands - Snippet

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -44,6 +44,52 @@ function resolveTimeoutMs(): number {
 
 const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
 
+/**
+ * Network-level error codes (no HTTP response received) considered transient
+ * and worth retrying. Rationale per code:
+ *
+ * - ECONNRESET:   the peer (or an intermediary proxy/LB) dropped an
+ *                 established socket mid-flight — classic transient blip.
+ * - ETIMEDOUT:    OS-level connect/read timeout, or axios's own timeout when
+ *                 `transitional.clarifyTimeoutError` is enabled.
+ * - ECONNABORTED: axios's default code for its own request timeout; a slow or
+ *                 momentarily overloaded server may answer on a fresh attempt.
+ * - EAI_AGAIN:    DNS resolver returned a *temporary* failure — by definition
+ *                 retryable (transient resolver/upstream hiccup).
+ * - EPIPE:        write on a socket the peer already closed (e.g. keep-alive
+ *                 connection reaped by a proxy); a new connection usually works.
+ *
+ * Deliberately excluded as (almost always) permanent until the user fixes
+ * something:
+ * - ENOTFOUND:    DNS says the host does not exist — misconfiguration/offline,
+ *                 not a blip; retrying just delays the actionable error.
+ * - ECONNREFUSED: the host actively rejected the connection (service down,
+ *                 wrong port, proxy misconfig) — unlikely to recover within
+ *                 our seconds-scale backoff window.
+ * - CERT/TLS errors (e.g. UNABLE_TO_VERIFY_LEAF_SIGNATURE): configuration
+ *                 problems, never transient.
+ */
+const RETRYABLE_NETWORK_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNABORTED',
+  'EAI_AGAIN',
+  'EPIPE',
+]);
+
+/**
+ * Methods safe to retry after a network failure where we cannot know whether
+ * the server processed the request (the socket died before any response).
+ * Only RFC 9110 "safe" methods qualify: replaying them can never duplicate a
+ * side effect. Bitbucket's PUT/DELETE endpoints are *semantically* idempotent,
+ * but we stay conservative and exclude them: some trigger side effects beyond
+ * the resource itself (webhooks, notifications, pipeline runs), and a replay
+ * after partial server-side processing can surface confusing secondary errors
+ * (e.g. 404 on a DELETE that actually succeeded). Non-idempotent methods
+ * (POST/PATCH) keep the existing fail-fast behavior.
+ */
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
 const SENSITIVE_KEYS = new Set([
   'access_token',
   'refresh_token',
@@ -229,6 +275,38 @@ export function createApiClient(
             if (!output.isJsonMode()) {
               output.warning(
                 `${label}, retrying in ${(delay / 1000).toFixed(1)}s (attempt ${config.__retryCount}/${MAX_RETRIES})...`
+              );
+            }
+            await sleep(delay);
+            return instance(config);
+          }
+        }
+      }
+
+      // Retry transient network errors (request sent, no response received:
+      // dropped sockets, DNS hiccups, timeouts) — but only for idempotent
+      // methods, since without a response we cannot tell whether the server
+      // already processed the request. Shares __retryCount with the
+      // status-code path above so combined attempts stay bounded by
+      // MAX_RETRIES, and uses the same exponential backoff (no response means
+      // getRetryDelay never sees a Retry-After header).
+      if (
+        !error.response &&
+        error.request &&
+        error.code !== undefined &&
+        RETRYABLE_NETWORK_CODES.has(error.code)
+      ) {
+        const config = error.config as RetryableConfig | undefined;
+        const method = config?.method?.toUpperCase() ?? '';
+        if (config && IDEMPOTENT_METHODS.has(method)) {
+          const retryCount = config.__retryCount ?? 0;
+          if (retryCount < MAX_RETRIES) {
+            config.__retryCount = retryCount + 1;
+            const delay = getRetryDelay(error, config.__retryCount);
+            // Same JSON-mode suppression rationale as the status-code path.
+            if (!output.isJsonMode()) {
+              output.warning(
+                `Network error (${error.code}), retrying in ${(delay / 1000).toFixed(1)}s (attempt ${config.__retryCount}/${MAX_RETRIES})...`
               );
             }
             await sleep(delay);

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -103,6 +103,18 @@ function extractOAuthErrorDescription(body: string): string | undefined {
 }
 
 export class OAuthService {
+  /**
+   * In-flight refresh lock. Bitbucket ROTATES the refresh_token on every
+   * refresh, so two concurrent POSTs to the token endpoint race: the trailing
+   * one sends an already-invalidated refresh_token, fails, and silently logs
+   * the user out. While a refresh is running, every caller — both the
+   * proactive path ({@link getValidAccessToken}) and the reactive 401 path in
+   * the api-client interceptor — awaits this same promise instead of starting
+   * a second POST. Cleared on settle (success or failure) so a later expiry
+   * can refresh again.
+   */
+  private refreshInFlight: Promise<string> | null = null;
+
   constructor(
     private readonly configService: IConfigService,
     private readonly credentialStore: ICredentialStore
@@ -158,9 +170,25 @@ export class OAuthService {
   }
 
   /**
-   * Refresh the access token using the refresh token
+   * Refresh the access token using the refresh token.
+   *
+   * Concurrent calls are deduplicated: only the first starts a POST to the
+   * token endpoint; the rest await the same promise and resolve to the same
+   * new access token. A failed refresh clears the lock on settle so the next
+   * call can retry with a fresh POST.
    */
-  public async refreshAccessToken(): Promise<string> {
+  public refreshAccessToken(): Promise<string> {
+    if (this.refreshInFlight) {
+      return this.refreshInFlight;
+    }
+    const refresh = this.performTokenRefresh().finally(() => {
+      this.refreshInFlight = null;
+    });
+    this.refreshInFlight = refresh;
+    return refresh;
+  }
+
+  private async performTokenRefresh(): Promise<string> {
     const credentials = await this.credentialStore.getOAuthCredentials();
     const clientId = await this.getClientId();
 

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -54,6 +54,7 @@ export const WRAPPER_ARRAY_KEYS: readonly string[] = [
   'activities', // pr activity
   'statuses', // pr checks
   'files', // pr diff --stat / --name-only
+  'pipelines', // pipeline list
   'values', // generic fallback for paginated payloads
 ];
 

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -55,6 +55,7 @@ export const WRAPPER_ARRAY_KEYS: readonly string[] = [
   'statuses', // pr checks
   'files', // pr diff --stat / --name-only
   'pipelines', // pipeline list
+  'commits', // commit list
   'values', // generic fallback for paginated payloads
 ];
 

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -56,6 +56,7 @@ export const WRAPPER_ARRAY_KEYS: readonly string[] = [
   'files', // pr diff --stat / --name-only
   'pipelines', // pipeline list
   'commits', // commit list
+  'issues', // issue list
   'values', // generic fallback for paginated payloads
 ];
 

--- a/src/services/output.service.ts
+++ b/src/services/output.service.ts
@@ -57,6 +57,8 @@ export const WRAPPER_ARRAY_KEYS: readonly string[] = [
   'pipelines', // pipeline list
   'commits', // commit list
   'issues', // issue list
+  'workspaces', // workspace list
+  'projects', // project list
   'values', // generic fallback for paginated payloads
 ];
 

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -35,6 +35,7 @@ describe('CLI completion drift (issue #255)', () => {
       'statuses',
       'files',
       'pipelines',
+      'commits',
       'values',
     ];
 
@@ -54,6 +55,8 @@ describe('CLI completion drift (issue #255)', () => {
       'pr diff --stat': 'files',
       'pr diff --name-only': 'files',
       'pipeline list': 'pipelines',
+      'commit list': 'commits',
+      'status list': 'statuses',
     };
 
     it('WRAPPER_ARRAY_KEYS matches the expected set, in order', () => {

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -37,6 +37,8 @@ describe('CLI completion drift (issue #255)', () => {
       'pipelines',
       'commits',
       'issues',
+      'workspaces',
+      'projects',
       'values',
     ];
 
@@ -59,6 +61,8 @@ describe('CLI completion drift (issue #255)', () => {
       'commit list': 'commits',
       'status list': 'statuses',
       'issue list': 'issues',
+      'workspace list': 'workspaces',
+      'project list': 'projects',
     };
 
     it('WRAPPER_ARRAY_KEYS matches the expected set, in order', () => {

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -36,6 +36,7 @@ describe('CLI completion drift (issue #255)', () => {
       'files',
       'pipelines',
       'commits',
+      'issues',
       'values',
     ];
 
@@ -57,6 +58,7 @@ describe('CLI completion drift (issue #255)', () => {
       'pipeline list': 'pipelines',
       'commit list': 'commits',
       'status list': 'statuses',
+      'issue list': 'issues',
     };
 
     it('WRAPPER_ARRAY_KEYS matches the expected set, in order', () => {

--- a/tests/cli-completion-drift.test.ts
+++ b/tests/cli-completion-drift.test.ts
@@ -34,6 +34,7 @@ describe('CLI completion drift (issue #255)', () => {
       'activities',
       'statuses',
       'files',
+      'pipelines',
       'values',
     ];
 
@@ -52,6 +53,7 @@ describe('CLI completion drift (issue #255)', () => {
       'pr checks': 'statuses',
       'pr diff --stat': 'files',
       'pr diff --name-only': 'files',
+      'pipeline list': 'pipelines',
     };
 
     it('WRAPPER_ARRAY_KEYS matches the expected set, in order', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -481,12 +481,14 @@ describe('CLI command registration', () => {
       'api',
       'auth',
       'browse',
+      'commit',
       'completion',
       'config',
       'pipeline',
       'pr',
       'repo',
       'snippet',
+      'status',
     ]);
   });
 
@@ -603,6 +605,22 @@ describe('CLI command registration', () => {
       'run',
       'stop',
       'view',
+    ]);
+  });
+
+  it('should register all commit subcommands', () => {
+    const commitCmd = requireCommand('commit');
+    expect(commitCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'list',
+      'view',
+    ]);
+  });
+
+  it('should register all status subcommands', () => {
+    const statusCmd = requireCommand('status');
+    expect(statusCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'list',
+      'set',
     ]);
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -487,9 +487,11 @@ describe('CLI command registration', () => {
       'issue',
       'pipeline',
       'pr',
+      'project',
       'repo',
       'snippet',
       'status',
+      'workspace',
     ]);
   });
 
@@ -632,6 +634,23 @@ describe('CLI command registration', () => {
       'comment',
       'create',
       'edit',
+      'list',
+      'view',
+    ]);
+  });
+
+  it('should register all workspace subcommands', () => {
+    const workspaceCmd = requireCommand('workspace');
+    expect(workspaceCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'list',
+      'view',
+    ]);
+  });
+
+  it('should register all project subcommands', () => {
+    const projectCmd = requireCommand('project');
+    expect(projectCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'create',
       'list',
       'view',
     ]);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -484,6 +484,7 @@ describe('CLI command registration', () => {
       'commit',
       'completion',
       'config',
+      'issue',
       'pipeline',
       'pr',
       'repo',
@@ -621,6 +622,18 @@ describe('CLI command registration', () => {
     expect(statusCmd.commands.map((c) => c.name()).sort()).toEqual([
       'list',
       'set',
+    ]);
+  });
+
+  it('should register all issue subcommands', () => {
+    const issueCmd = requireCommand('issue');
+    expect(issueCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'close',
+      'comment',
+      'create',
+      'edit',
+      'list',
+      'view',
     ]);
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -483,6 +483,7 @@ describe('CLI command registration', () => {
       'browse',
       'completion',
       'config',
+      'pipeline',
       'pr',
       'repo',
       'snippet',
@@ -591,6 +592,17 @@ describe('CLI command registration', () => {
       'delete',
       'edit',
       'list',
+    ]);
+  });
+
+  it('should register all pipeline subcommands', () => {
+    const pipelineCmd = requireCommand('pipeline');
+    expect(pipelineCmd.commands.map((c) => c.name()).sort()).toEqual([
+      'list',
+      'logs',
+      'run',
+      'stop',
+      'view',
     ]);
   });
 

--- a/tests/commands/commit.test.ts
+++ b/tests/commands/commit.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Commit command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListCommitsCommand } from '../../src/commands/commit/list.command.js';
+import { ViewCommitCommand } from '../../src/commands/commit/view.command.js';
+import {
+  createMockContextService,
+  createMockGitService,
+  createMockOutputService,
+} from '../setup.js';
+import { APIError } from '../../src/types/errors.js';
+import type { Commit, CommitsApi } from '../../src/generated/api.js';
+
+const mockCommit: Commit = {
+  type: 'commit',
+  hash: 'abc1234def5678900000000000000000000000000',
+  date: '2024-01-01T00:00:00.000Z',
+  message: 'feat: add the thing\n\nLonger body explaining the thing.',
+  author: {
+    type: 'author',
+    raw: 'Test User <test@example.com>',
+    user: { type: 'user', display_name: 'Test User' },
+  },
+  parents: [
+    {
+      type: 'commit',
+      hash: '1112223334445556667778889990001112223334',
+    },
+  ],
+};
+
+const mockRawAuthorCommit: Commit = {
+  type: 'commit',
+  hash: 'fff111222333444555666777888999000aaabbbc',
+  date: '2024-01-02T00:00:00.000Z',
+  message: 'fix: another thing',
+  author: {
+    type: 'author',
+    raw: 'Raw Person <raw@example.com>',
+  },
+  parents: [],
+};
+
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  const params = (
+    axiosOptions as { params?: { page?: number; pagelen?: number } }
+  )?.params;
+  return { page: params?.page ?? 1, pagelen: params?.pagelen ?? 25 };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockCommitsApi(
+  options: {
+    commits?: Commit[];
+    commitNotFound?: boolean;
+    revisionNotFound?: boolean;
+    onRevisionList?: (request: unknown, axiosOptions?: unknown) => void;
+    onDefaultList?: (request: unknown, axiosOptions?: unknown) => void;
+  } = {}
+): CommitsApi {
+  const commits = options.commits ?? [mockCommit];
+
+  const paginate = (page: number, pagelen: number) => {
+    const start = (page - 1) * pagelen;
+    const end = start + pagelen;
+    return {
+      values: commits.slice(start, end),
+      page,
+      pagelen,
+      size: commits.length,
+      next:
+        end < commits.length
+          ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/commits?page=${page + 1}`
+          : undefined,
+    };
+  };
+
+  return {
+    repositoriesWorkspaceRepoSlugCommitsRevisionGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      if (options.revisionNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onRevisionList?.(request, axiosOptions);
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      return { data: paginate(page, pagelen) };
+    },
+    repositoriesWorkspaceRepoSlugCommitsGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      options.onDefaultList?.(request, axiosOptions);
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      return { data: paginate(page, pagelen) };
+    },
+    repositoriesWorkspaceRepoSlugCommitCommitGet: async ({
+      commit,
+    }: {
+      commit: string;
+    }) => {
+      if (options.commitNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      return {
+        data: commits.find((c) => c.hash?.startsWith(commit)) ?? mockCommit,
+      };
+    },
+  } as unknown as CommitsApi;
+}
+
+function repoContextService() {
+  return createMockContextService({ workspace: 'workspace', repoSlug: 'repo' });
+}
+
+describe('ListCommitsCommand', () => {
+  it('should render the commits table with short hash, first message line, author, and date', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi(),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('table:HASH,MESSAGE,AUTHOR,DATE')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]![0]).toBe('abc1234');
+    expect(rows[0]![1]).toBe('feat: add the thing');
+    expect(rows[0]![2]).toBe('Test User');
+    expect(rows[0]![3]).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('should default to the current git branch as the revision', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({
+        onRevisionList: (request) => {
+          captured = request;
+        },
+      }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'feature/login' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      revision: 'feature/login',
+    });
+  });
+
+  it('should fall back to the default commit listing when branch detection fails', async () => {
+    let revisionCalled = false;
+    let defaultCalled = false;
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({
+        onRevisionList: () => {
+          revisionCalled = true;
+        },
+        onDefaultList: () => {
+          defaultCalled = true;
+        },
+      }),
+      repoContextService(),
+      createMockGitService({ throwOnGetCurrentBranch: true }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(revisionCalled).toBe(false);
+    expect(defaultCalled).toBe(true);
+  });
+
+  it('should prefer an explicit --ref over the current git branch', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({
+        onRevisionList: (request) => {
+          captured = request;
+        },
+      }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({ ref: 'v1.0.0' }, { globalOptions: {} });
+
+    expect((captured as { revision?: string }).revision).toBe('v1.0.0');
+  });
+
+  it('should emit the JSON envelope with metadata-first key order', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi(),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'ref',
+      'count',
+      'commits',
+    ]);
+    expect(payload.workspace).toBe('workspace');
+    expect(payload.repoSlug).toBe('repo');
+    expect(payload.ref).toBe('main');
+    expect(payload.count).toBe(1);
+    expect(payload.commits).toHaveLength(1);
+  });
+
+  it('should omit ref from the JSON envelope when listing the repository default', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi(),
+      repoContextService(),
+      createMockGitService({ throwOnGetCurrentBranch: true }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'count',
+      'commits',
+    ]);
+  });
+
+  it('should show the empty-state message when no commits exist', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({ commits: [] }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs).toContain("info:No commits found on 'main'");
+  });
+
+  it('should respect --limit and print the more-results hint', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({
+      ...mockCommit,
+      hash: `${i}aaabbbcccdddeeefff00011122233344455566`,
+    }));
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({ commits: many }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({ limit: '2' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+    expect(
+      output.logs.some((log) =>
+        log.includes('Showing 2 commits. Use --limit <n> or --all to see more.')
+      )
+    ).toBe(true);
+  });
+
+  it('should fall back to parsing the raw author when no Bitbucket account matched', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({ commits: [mockRawAuthorCommit] }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows[0]![2]).toBe('Raw Person');
+  });
+
+  it('should surface a contextual error when the ref does not exist', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitsCommand(
+      createMockCommitsApi({ revisionNotFound: true }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'gone-branch' }),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      "Ref 'gone-branch' not found in workspace/repo."
+    );
+  });
+});
+
+describe('ViewCommitCommand', () => {
+  it('should render hash, author, date, parents, and the full message', async () => {
+    const output = createMockOutputService();
+    const command = new ViewCommitCommand(
+      createMockCommitsApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ sha: 'abc1234' }, { globalOptions: {} });
+
+    const text = output.logs.join('\n');
+    expect(text).toContain('abc1234def5678900000000000000000000000000');
+    expect(text).toContain('Test User <test@example.com>');
+    expect(text).toContain('1112223');
+    expect(text).toContain('feat: add the thing');
+    expect(text).toContain('Longer body explaining the thing.');
+  });
+
+  it('should emit the JSON envelope with the raw commit resource', async () => {
+    const output = createMockOutputService();
+    const command = new ViewCommitCommand(
+      createMockCommitsApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { sha: 'abc1234' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'commit']);
+    expect((payload.commit as Commit).hash).toBe(
+      'abc1234def5678900000000000000000000000000'
+    );
+  });
+
+  it('should surface a contextual 404 error for unknown commits', async () => {
+    const output = createMockOutputService();
+    const command = new ViewCommitCommand(
+      createMockCommitsApi({ commitNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ sha: 'deadbee' }, { globalOptions: {} })
+    ).rejects.toThrow('Commit deadbee not found in workspace/repo.');
+  });
+});

--- a/tests/commands/issue.test.ts
+++ b/tests/commands/issue.test.ts
@@ -1,0 +1,746 @@
+/**
+ * Issue command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListIssuesCommand } from '../../src/commands/issue/list.command.js';
+import { ViewIssueCommand } from '../../src/commands/issue/view.command.js';
+import { CreateIssueCommand } from '../../src/commands/issue/create.command.js';
+import { EditIssueCommand } from '../../src/commands/issue/edit.command.js';
+import { CloseIssueCommand } from '../../src/commands/issue/close.command.js';
+import { CommentIssueCommand } from '../../src/commands/issue/comment.command.js';
+import { createMockContextService, createMockOutputService } from '../setup.js';
+import { APIError, BBError } from '../../src/types/errors.js';
+import type { Issue, IssueTrackerApi } from '../../src/generated/api.js';
+
+const mockIssue: Issue = {
+  type: 'issue',
+  id: 42,
+  title: 'Crash on login',
+  state: 'new',
+  kind: 'bug',
+  priority: 'major',
+  votes: 3,
+  reporter: { type: 'user', display_name: 'Reporter Person' },
+  assignee: { type: 'user', display_name: 'Assignee Person' },
+  created_on: '2024-01-01T00:00:00.000Z',
+  updated_on: '2024-01-02T00:00:00.000Z',
+  content: { raw: 'Steps to reproduce: open the app.' },
+  links: {
+    html: { href: 'https://bitbucket.org/workspace/repo/issues/42' },
+  },
+};
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockIssueTrackerApi(
+  options: {
+    issues?: Issue[];
+    trackerDisabled?: boolean;
+    issueNotFound?: boolean;
+    onListCall?: (request: unknown, axiosOptions?: unknown) => void;
+    onCreateCall?: (request: unknown) => void;
+    onUpdateCall?: (request: unknown, axiosOptions?: unknown) => void;
+    onCommentCall?: (request: unknown) => void;
+    callOrder?: string[];
+  } = {}
+): IssueTrackerApi {
+  const issues = options.issues ?? [mockIssue];
+
+  const paginate = (page: number, pagelen: number) => {
+    const start = (page - 1) * pagelen;
+    const end = start + pagelen;
+    return {
+      values: issues.slice(start, end),
+      page,
+      pagelen,
+      size: issues.length,
+      next:
+        end < issues.length
+          ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/issues?page=${page + 1}`
+          : undefined,
+    };
+  };
+
+  return {
+    repositoriesWorkspaceRepoSlugIssuesGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      if (options.trackerDisabled) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onListCall?.(request, axiosOptions);
+      const params = (
+        axiosOptions as { params?: { page?: number; pagelen?: number } }
+      )?.params;
+      return { data: paginate(params?.page ?? 1, params?.pagelen ?? 25) };
+    },
+    repositoriesWorkspaceRepoSlugIssuesIssueIdGet: async () => {
+      if (options.issueNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      return { data: mockIssue };
+    },
+    repositoriesWorkspaceRepoSlugIssuesPost: async (request: unknown) => {
+      if (options.trackerDisabled) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onCreateCall?.(request);
+      const issue = (request as { issue: Issue }).issue;
+      return { data: { ...mockIssue, ...issue, id: 43 } };
+    },
+    repositoriesWorkspaceRepoSlugIssuesIssueIdPut: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      if (options.issueNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.callOrder?.push('update');
+      options.onUpdateCall?.(request, axiosOptions);
+      const changes = (axiosOptions as { data?: Partial<Issue> })?.data ?? {};
+      return { data: { ...mockIssue, ...changes } };
+    },
+    repositoriesWorkspaceRepoSlugIssuesIssueIdCommentsPost: async (
+      request: unknown
+    ) => {
+      if (options.issueNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.callOrder?.push('comment');
+      options.onCommentCall?.(request);
+      return {
+        data: {
+          type: 'issue_comment',
+          id: 9001,
+          content: (request as { issueComment: { content: { raw: string } } })
+            .issueComment.content,
+        },
+      };
+    },
+  } as unknown as IssueTrackerApi;
+}
+
+function repoContextService() {
+  return createMockContextService({ workspace: 'workspace', repoSlug: 'repo' });
+}
+
+describe('ListIssuesCommand', () => {
+  it('should render the issues table with id, title, kind, priority, state, assignee, and date', async () => {
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('table:#,TITLE,KIND,PRIORITY,STATE,ASSIGNEE,UPDATED')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual([
+      '#42',
+      'Crash on login',
+      'bug',
+      'major',
+      'new',
+      'Assignee Person',
+      '2024-01-02T00:00:00.000Z',
+    ]);
+  });
+
+  it('should default to the open-ish state filter and the -updated_on sort', async () => {
+    let captured: { params?: Record<string, unknown> } | undefined;
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({
+        onListCall: (_request, axiosOptions) => {
+          captured = axiosOptions as { params?: Record<string, unknown> };
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(captured?.params?.q).toBe('(state="new" OR state="open")');
+    expect(captured?.params?.sort).toBe('-updated_on');
+  });
+
+  it('should map --state on-hold to the API spelling "on hold"', async () => {
+    let captured: { params?: Record<string, unknown> } | undefined;
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({
+        onListCall: (_request, axiosOptions) => {
+          captured = axiosOptions as { params?: Record<string, unknown> };
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ state: 'on-hold' }, { globalOptions: {} });
+
+    expect(captured?.params?.q).toBe('state="on hold"');
+  });
+
+  it('should AND --kind, --assignee, and --reporter clauses onto the state filter', async () => {
+    let captured: { params?: Record<string, unknown> } | undefined;
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({
+        onListCall: (_request, axiosOptions) => {
+          captured = axiosOptions as { params?: Record<string, unknown> };
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { kind: 'bug', assignee: 'alice', reporter: 'bob' },
+      { globalOptions: {} }
+    );
+
+    expect(captured?.params?.q).toBe(
+      '(state="new" OR state="open") AND kind="bug" AND assignee.username="alice" AND reporter.username="bob"'
+    );
+  });
+
+  it('should use --query verbatim and suppress the default state filter', async () => {
+    let captured: { params?: Record<string, unknown> } | undefined;
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({
+        onListCall: (_request, axiosOptions) => {
+          captured = axiosOptions as { params?: Record<string, unknown> };
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { query: 'priority="blocker"', kind: 'bug' },
+      { globalOptions: {} }
+    );
+
+    expect(captured?.params?.q).toBe('(priority="blocker") AND kind="bug"');
+  });
+
+  it('should reject an invalid --state value', async () => {
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ state: 'nonsense' }, { globalOptions: {} })
+    ).rejects.toThrow('--state must be one of:');
+  });
+
+  it('should emit the JSON envelope with metadata-first key order', async () => {
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ state: 'new' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'filters',
+      'count',
+      'issues',
+    ]);
+    expect(payload.workspace).toBe('workspace');
+    expect(payload.repoSlug).toBe('repo');
+    expect(payload.filters).toEqual({ state: 'new', q: 'state="new"' });
+    expect(payload.count).toBe(1);
+    expect(payload.issues).toHaveLength(1);
+  });
+
+  it('should show the empty-state message when no issues match', async () => {
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({ issues: [] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs).toContain(
+      'info:No open issues found (try --state <state> or --query)'
+    );
+  });
+
+  it('should respect --limit and print the more-results hint', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({
+      ...mockIssue,
+      id: i + 1,
+    }));
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({ issues: many }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ limit: '2' }, { globalOptions: {} });
+
+    expect(getTableRows(output.logs)).toHaveLength(2);
+    expect(
+      output.logs.some((log) =>
+        log.includes('Showing 2 issues. Use --limit <n> or --all to see more.')
+      )
+    ).toBe(true);
+  });
+
+  it('should explain that the tracker may be disabled when the list endpoint 404s', async () => {
+    const output = createMockOutputService();
+    const command = new ListIssuesCommand(
+      createMockIssueTrackerApi({ trackerDisabled: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      "This repository's issue tracker is disabled (or the repo was not found)."
+    );
+  });
+});
+
+describe('ViewIssueCommand', () => {
+  it('should render issue details including reporter, votes, body, and url', async () => {
+    const output = createMockOutputService();
+    const command = new ViewIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: {} });
+
+    const text = output.logs.join('\n');
+    expect(text).toContain('#42');
+    expect(text).toContain('Crash on login');
+    expect(text).toContain('Kind:       bug');
+    expect(text).toContain('Priority:   major');
+    expect(text).toContain('Reporter:   Reporter Person');
+    expect(text).toContain('Assignee:   Assignee Person');
+    expect(text).toContain('Votes:      3');
+    expect(text).toContain('Steps to reproduce: open the app.');
+    expect(text).toContain('https://bitbucket.org/workspace/repo/issues/42');
+  });
+
+  it('should emit the { workspace, repoSlug, issue } JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new ViewIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'issue']);
+    expect((payload.issue as Issue).id).toBe(42);
+  });
+
+  it('should report a contextual not-found message that mentions the tracker', async () => {
+    const output = createMockOutputService();
+    const command = new ViewIssueCommand(
+      createMockIssueTrackerApi({ issueNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '7' }, { globalOptions: {} })
+    ).rejects.toThrow('Issue #7 not found in workspace/repo.');
+    await expect(
+      command.execute({ id: '7' }, { globalOptions: {} })
+    ).rejects.toThrow('issue tracker may be disabled');
+  });
+});
+
+describe('CreateIssueCommand', () => {
+  it('should require --title', async () => {
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      'Option --title is required'
+    );
+  });
+
+  it('should POST the issue body with discriminator, content, kind, priority, and assignee', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi({
+        onCreateCall: (request) => {
+          captured = request;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      {
+        title: 'New bug',
+        body: 'It broke.',
+        kind: 'bug',
+        priority: 'critical',
+        assignee: 'alice',
+      },
+      { globalOptions: {} }
+    );
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      issue: {
+        type: 'issue',
+        title: 'New bug',
+        content: { raw: 'It broke.' },
+        kind: 'bug',
+        priority: 'critical',
+        assignee: { type: 'user', username: 'alice' },
+      },
+    });
+    expect(output.logs).toContain('success:Issue #43 created');
+    expect(
+      output.logs.some((log) =>
+        log.includes('https://bitbucket.org/workspace/repo/issues/42')
+      )
+    ).toBe(true);
+  });
+
+  it('should reject --body together with --body-file', async () => {
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { title: 'x', body: 'a', bodyFile: 'b.md' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('--body and --body-file cannot both be set.');
+  });
+
+  it('should fail with FILE_NOT_FOUND when --body-file does not exist', async () => {
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { title: 'x', bodyFile: '/nonexistent/issue-body.md' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('Could not read --body-file');
+  });
+
+  it('should emit the created issue in the JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { title: 'New bug' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'issue']);
+    expect((payload.issue as Issue).id).toBe(43);
+  });
+
+  it('should explain that the tracker may be disabled when the create endpoint 404s', async () => {
+    const output = createMockOutputService();
+    const command = new CreateIssueCommand(
+      createMockIssueTrackerApi({ trackerDisabled: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ title: 'New bug' }, { globalOptions: {} })
+    ).rejects.toThrow("This repository's issue tracker is disabled");
+  });
+});
+
+describe('EditIssueCommand', () => {
+  it('should require at least one change flag', async () => {
+    const output = createMockOutputService();
+    const command = new EditIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    const promise = command.execute({ id: '42' }, { globalOptions: {} });
+    await expect(promise).rejects.toBeInstanceOf(BBError);
+    await expect(
+      command.execute({ id: '42' }, { globalOptions: {} })
+    ).rejects.toThrow(
+      'At least one of --title, --body, --kind, --priority, --assignee, or --state is required.'
+    );
+  });
+
+  it('should send the partial update through the raw axios data option', async () => {
+    let capturedRequest: unknown;
+    let capturedAxiosOptions: unknown;
+    const output = createMockOutputService();
+    const command = new EditIssueCommand(
+      createMockIssueTrackerApi({
+        onUpdateCall: (request, axiosOptions) => {
+          capturedRequest = request;
+          capturedAxiosOptions = axiosOptions;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { id: '42', title: 'Renamed', state: 'on-hold', assignee: 'alice' },
+      { globalOptions: {} }
+    );
+
+    expect(capturedRequest).toEqual({
+      issueId: '42',
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    expect((capturedAxiosOptions as { data?: unknown }).data).toEqual({
+      type: 'issue',
+      title: 'Renamed',
+      assignee: { type: 'user', username: 'alice' },
+      state: 'on hold',
+    });
+    expect(output.logs).toContain('success:Issue #42 updated');
+  });
+
+  it('should report a contextual not-found message on a 404', async () => {
+    const output = createMockOutputService();
+    const command = new EditIssueCommand(
+      createMockIssueTrackerApi({ issueNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '9', title: 'x' }, { globalOptions: {} })
+    ).rejects.toThrow('Issue #9 not found in workspace/repo.');
+  });
+});
+
+describe('CloseIssueCommand', () => {
+  it('should PUT state closed through the raw axios data option', async () => {
+    let capturedAxiosOptions: unknown;
+    const output = createMockOutputService();
+    const command = new CloseIssueCommand(
+      createMockIssueTrackerApi({
+        onUpdateCall: (_request, axiosOptions) => {
+          capturedAxiosOptions = axiosOptions;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: {} });
+
+    expect((capturedAxiosOptions as { data?: unknown }).data).toEqual({
+      type: 'issue',
+      state: 'closed',
+    });
+    expect(output.logs).toContain('success:Issue #42 closed');
+  });
+
+  it('should post the --comment before closing', async () => {
+    const callOrder: string[] = [];
+    let capturedComment: unknown;
+    const output = createMockOutputService();
+    const command = new CloseIssueCommand(
+      createMockIssueTrackerApi({
+        callOrder,
+        onCommentCall: (request) => {
+          capturedComment = request;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { id: '42', comment: 'Fixed in 1.4.2' },
+      { globalOptions: {} }
+    );
+
+    expect(callOrder).toEqual(['comment', 'update']);
+    expect(capturedComment).toEqual({
+      issueId: '42',
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      issueComment: {
+        type: 'issue_comment',
+        content: { raw: 'Fixed in 1.4.2' },
+      },
+    });
+  });
+
+  it('should emit the closed issue in the JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new CloseIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'issue']);
+    expect((payload.issue as Issue).state).toBe('closed');
+  });
+
+  it('should report a contextual not-found message on a 404', async () => {
+    const output = createMockOutputService();
+    const command = new CloseIssueCommand(
+      createMockIssueTrackerApi({ issueNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '9' }, { globalOptions: {} })
+    ).rejects.toThrow('Issue #9 not found in workspace/repo.');
+  });
+});
+
+describe('CommentIssueCommand', () => {
+  it('should require --body', async () => {
+    const output = createMockOutputService();
+    const command = new CommentIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '42' }, { globalOptions: {} })
+    ).rejects.toThrow('Option --body is required');
+  });
+
+  it('should POST the issue comment body with the discriminator', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new CommentIssueCommand(
+      createMockIssueTrackerApi({
+        onCommentCall: (request) => {
+          captured = request;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { id: '42', body: 'Reproduced on main' },
+      { globalOptions: {} }
+    );
+
+    expect(captured).toEqual({
+      issueId: '42',
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      issueComment: {
+        type: 'issue_comment',
+        content: { raw: 'Reproduced on main' },
+      },
+    });
+    expect(output.logs).toContain('success:Comment added to issue #42');
+  });
+
+  it('should emit the created comment in the JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new CommentIssueCommand(
+      createMockIssueTrackerApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { id: '42', body: 'Reproduced on main' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'comment']);
+    expect((payload.comment as { content: { raw: string } }).content.raw).toBe(
+      'Reproduced on main'
+    );
+  });
+
+  it('should report a contextual not-found message on a 404', async () => {
+    const output = createMockOutputService();
+    const command = new CommentIssueCommand(
+      createMockIssueTrackerApi({ issueNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '9', body: 'x' }, { globalOptions: {} })
+    ).rejects.toThrow('Issue #9 not found in workspace/repo.');
+  });
+});

--- a/tests/commands/pipeline.test.ts
+++ b/tests/commands/pipeline.test.ts
@@ -1,0 +1,772 @@
+/**
+ * Pipeline command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListPipelinesCommand } from '../../src/commands/pipeline/list.command.js';
+import { ViewPipelineCommand } from '../../src/commands/pipeline/view.command.js';
+import { RunPipelineCommand } from '../../src/commands/pipeline/run.command.js';
+import { StopPipelineCommand } from '../../src/commands/pipeline/stop.command.js';
+import { LogsPipelineCommand } from '../../src/commands/pipeline/logs.command.js';
+import {
+  createMockContextService,
+  createMockGitService,
+  createMockOutputService,
+} from '../setup.js';
+import { APIError } from '../../src/types/errors.js';
+import type { Pipeline, PipelinesApi } from '../../src/generated/api.js';
+
+const mockPipeline: Pipeline = {
+  type: 'pipeline',
+  uuid: '{pipeline-uuid-1}',
+  build_number: 42,
+  state: {
+    type: 'pipeline_state_completed',
+    name: 'COMPLETED',
+    result: { type: 'pipeline_state_completed_passed', name: 'PASSED' },
+  } as unknown as Pipeline['state'],
+  target: {
+    type: 'pipeline_ref_target',
+    ref_type: 'branch',
+    ref_name: 'main',
+  } as unknown as Pipeline['target'],
+  trigger: {
+    type: 'pipeline_trigger_push',
+    name: 'PUSH',
+  } as unknown as Pipeline['trigger'],
+  creator: { type: 'user', display_name: 'Test User' },
+  created_on: '2024-01-01T00:00:00.000Z',
+  completed_on: '2024-01-01T00:02:03.000Z',
+  build_seconds_used: 123,
+};
+
+const mockStepOne = {
+  type: 'pipeline_step',
+  uuid: '{step-uuid-1}',
+  name: 'Build',
+  state: {
+    type: 'pipeline_step_state_completed',
+    name: 'COMPLETED',
+    result: {
+      type: 'pipeline_step_state_completed_successful',
+      name: 'SUCCESSFUL',
+    },
+  },
+  started_on: '2024-01-01T00:00:10.000Z',
+  completed_on: '2024-01-01T00:01:10.000Z',
+  duration_in_seconds: 60,
+};
+
+const mockStepTwo = {
+  type: 'pipeline_step',
+  uuid: '{step-uuid-2}',
+  name: 'Deploy',
+  state: {
+    type: 'pipeline_step_state_completed',
+    name: 'COMPLETED',
+    result: { type: 'pipeline_step_state_completed_failed', name: 'FAILED' },
+  },
+  started_on: '2024-01-01T00:01:10.000Z',
+  completed_on: '2024-01-01T00:02:00.000Z',
+  duration_in_seconds: 50,
+};
+
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  const params = (
+    axiosOptions as { params?: { page?: number; pagelen?: number } }
+  )?.params;
+  return { page: params?.page ?? 1, pagelen: params?.pagelen ?? 25 };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockPipelinesApi(
+  options: {
+    pipelines?: Pipeline[];
+    steps?: unknown[];
+    log?: string;
+    pipelineNotFound?: boolean;
+    onList?: (request: unknown, axiosOptions?: unknown) => void;
+    onCreate?: (request: unknown) => void;
+    onStop?: (request: unknown) => void;
+    onLog?: (request: unknown, axiosOptions?: unknown) => void;
+    createdPipeline?: Pipeline;
+  } = {}
+): PipelinesApi {
+  const pipelines = options.pipelines ?? [mockPipeline];
+  const steps = options.steps ?? [mockStepOne];
+
+  return {
+    getPipelinesForRepository: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      options.onList?.(request, axiosOptions);
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      return {
+        data: {
+          values: pipelines.slice(start, end),
+          page,
+          pagelen,
+          size: pipelines.length,
+          next:
+            end < pipelines.length
+              ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines/?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
+    getPipelineForRepository: async ({
+      pipelineUuid,
+    }: {
+      pipelineUuid: string;
+    }) => {
+      if (options.pipelineNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      return {
+        data:
+          pipelines.find(
+            (p) =>
+              p.uuid === pipelineUuid || String(p.build_number) === pipelineUuid
+          ) ?? mockPipeline,
+      };
+    },
+    getPipelineStepsForRepository: async () => {
+      if (options.pipelineNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      return { data: { values: steps } };
+    },
+    getPipelineStepLogForRepository: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      options.onLog?.(request, axiosOptions);
+      return { data: options.log ?? 'log line 1\nlog line 2' };
+    },
+    createPipelineForRepository: async (request: unknown) => {
+      options.onCreate?.(request);
+      return { data: options.createdPipeline ?? mockPipeline };
+    },
+    stopPipeline: async (request: unknown) => {
+      if (options.pipelineNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onStop?.(request);
+      return { data: undefined };
+    },
+  } as unknown as PipelinesApi;
+}
+
+function repoContextService() {
+  return createMockContextService({ workspace: 'workspace', repoSlug: 'repo' });
+}
+
+describe('ListPipelinesCommand', () => {
+  it('should render the pipelines table', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('table:ID,STATUS,REF,TRIGGER,CREATED,DURATION')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]![0]).toBe('#42');
+    expect(rows[0]![1]).toBe('PASSED');
+    expect(rows[0]![2]).toBe('main');
+    expect(rows[0]![3]).toBe('PUSH');
+    expect(rows[0]![5]).toBe('2m 3s');
+  });
+
+  it('should emit the JSON envelope with metadata-first key order', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'sort',
+      'count',
+      'pipelines',
+    ]);
+    expect(payload.workspace).toBe('workspace');
+    expect(payload.repoSlug).toBe('repo');
+    expect(payload.sort).toBe('-created_on');
+    expect(payload.count).toBe(1);
+    expect(payload.pipelines).toHaveLength(1);
+  });
+
+  it('should pass status and branch filters to the API (status normalized to uppercase)', async () => {
+    let captured: unknown;
+    let capturedAxios: unknown;
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi({
+        onList: (request, axiosOptions) => {
+          captured = request;
+          capturedAxios = axiosOptions;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { status: 'failed', branch: 'main' },
+      { globalOptions: { json: true } }
+    );
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      status: 'FAILED',
+      targetBranch: 'main',
+    });
+    expect((capturedAxios as { params: { sort: string } }).params.sort).toBe(
+      '-created_on'
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(payload.status).toBe('FAILED');
+    expect(payload.branch).toBe('main');
+  });
+
+  it('should reject an invalid --status value', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ status: 'bogus' }, { globalOptions: {} })
+    ).rejects.toThrow('--status must be one of');
+  });
+
+  it('should reject an invalid --sort value', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ sort: 'name' }, { globalOptions: {} })
+    ).rejects.toThrow('--sort must be one of');
+  });
+
+  it('should show empty state when no pipelines exist', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi({ pipelines: [] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs).toContain('info:No pipelines found');
+  });
+
+  it('should mention filters in the empty state when filtering', async () => {
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi({ pipelines: [] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ status: 'FAILED' }, { globalOptions: {} });
+
+    expect(output.logs).toContain(
+      'info:No pipelines found matching the given filters'
+    );
+  });
+
+  it('should respect --limit and print the more-results hint', async () => {
+    const pipelines = [
+      { ...mockPipeline, build_number: 42 },
+      { ...mockPipeline, uuid: '{pipeline-uuid-2}', build_number: 43 },
+    ];
+    const output = createMockOutputService();
+    const command = new ListPipelinesCommand(
+      createMockPipelinesApi({ pipelines }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ limit: '1' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(
+      output.logs.some((log) =>
+        log.includes(
+          'Showing 1 pipelines. Use --limit <n> or --all to see more.'
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe('ViewPipelineCommand', () => {
+  it('should render pipeline details with a step summary', async () => {
+    const output = createMockOutputService();
+    const command = new ViewPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne, mockStepTwo] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: {} });
+
+    expect(output.logs.some((log) => log.includes('Pipeline #42'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('Status: PASSED'))).toBe(
+      true
+    );
+    expect(output.logs.some((log) => log.includes('Ref: main'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('Trigger: PUSH'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('Duration: 2m 3s'))).toBe(
+      true
+    );
+    const rows = getTableRows(output.logs);
+    expect(rows).toEqual([
+      ['1', 'Build', 'SUCCESSFUL', '1m 0s'],
+      ['2', 'Deploy', 'FAILED', '50s'],
+    ]);
+  });
+
+  it('should emit the documented JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new ViewPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'pipeline',
+      'steps',
+    ]);
+    expect((payload.pipeline as Pipeline).build_number).toBe(42);
+    expect(payload.steps).toHaveLength(1);
+  });
+
+  it('should add contextual message on 404', async () => {
+    const output = createMockOutputService();
+    const command = new ViewPipelineCommand(
+      createMockPipelinesApi({ pipelineNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '999' }, { globalOptions: {} })
+    ).rejects.toThrow('Pipeline 999 not found in workspace/repo.');
+  });
+});
+
+describe('RunPipelineCommand', () => {
+  it('should construct the exact pipeline body from flags', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new RunPipelineCommand(
+      createMockPipelinesApi({ onCreate: (request) => (captured = request) }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute(
+      {
+        branch: 'release/1.0',
+        commit: 'abc123def456',
+        pipeline: 'deploy-prod',
+        var: ['ENV=prod', 'FLAGS=a=b'],
+      },
+      { globalOptions: {} }
+    );
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipeline: {
+        type: 'pipeline',
+        target: {
+          type: 'pipeline_ref_target',
+          ref_type: 'branch',
+          ref_name: 'release/1.0',
+          commit: { type: 'commit', hash: 'abc123def456' },
+          selector: { type: 'custom', pattern: 'deploy-prod' },
+        },
+        variables: [
+          {
+            type: 'pipeline_variable',
+            key: 'ENV',
+            value: 'prod',
+            secured: false,
+          },
+          {
+            type: 'pipeline_variable',
+            key: 'FLAGS',
+            value: 'a=b',
+            secured: false,
+          },
+        ],
+      },
+    });
+    expect(
+      output.logs.some((log) =>
+        log.includes('Pipeline #42 started on branch release/1.0')
+      )
+    ).toBe(true);
+    expect(output.logs.some((log) => log.includes('bb pipeline view 42'))).toBe(
+      true
+    );
+  });
+
+  it('should default to the current git branch and omit commit/selector/variables', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new RunPipelineCommand(
+      createMockPipelinesApi({ onCreate: (request) => (captured = request) }),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'feature/x' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipeline: {
+        type: 'pipeline',
+        target: {
+          type: 'pipeline_ref_target',
+          ref_type: 'branch',
+          ref_name: 'feature/x',
+        },
+      },
+    });
+  });
+
+  it('should fail with an actionable error when not in a git repo and no --branch', async () => {
+    const output = createMockOutputService();
+    const command = new RunPipelineCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      createMockGitService({ throwOnGetCurrentBranch: true }),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      'Pass --branch <branch>'
+    );
+  });
+
+  it('should reject malformed --var entries', async () => {
+    const output = createMockOutputService();
+    const command = new RunPipelineCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await expect(
+      command.execute({ var: ['NOVALUE'] }, { globalOptions: {} })
+    ).rejects.toThrow('--var must be in key=value format');
+  });
+
+  it('should output the created pipeline in JSON mode', async () => {
+    const output = createMockOutputService();
+    const command = new RunPipelineCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      createMockGitService({ isRepo: true, currentBranch: 'main' }),
+      output
+    );
+
+    await command.execute(
+      { branch: 'main' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(payload.build_number).toBe(42);
+    expect(payload.uuid).toBe('{pipeline-uuid-1}');
+  });
+});
+
+describe('StopPipelineCommand', () => {
+  it('should stop a pipeline by raw id and print a success message', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new StopPipelineCommand(
+      createMockPipelinesApi({ onStop: (request) => (captured = request) }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '{pipeline-uuid-1}' }, { globalOptions: {} });
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipelineUuid: '{pipeline-uuid-1}',
+    });
+    expect(output.logs).toContain('success:Pipeline {pipeline-uuid-1} stopped');
+  });
+
+  it('should emit the documented JSON envelope', async () => {
+    const output = createMockOutputService();
+    const command = new StopPipelineCommand(
+      createMockPipelinesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    expect(getJsonPayload(output.logs)).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipelineId: '42',
+      stopped: true,
+    });
+  });
+
+  it('should add contextual message on 404', async () => {
+    const output = createMockOutputService();
+    const command = new StopPipelineCommand(
+      createMockPipelinesApi({ pipelineNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '999' }, { globalOptions: {} })
+    ).rejects.toThrow('Pipeline 999 not found in workspace/repo.');
+  });
+});
+
+describe('LogsPipelineCommand', () => {
+  it('should auto-pick the only step and print the raw log', async () => {
+    let captured: unknown;
+    let capturedAxios: unknown;
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({
+        steps: [mockStepOne],
+        log: 'building...\ndone.',
+        onLog: (request, axiosOptions) => {
+          captured = request;
+          capturedAxios = axiosOptions;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: {} });
+
+    expect(captured).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipelineUuid: '42',
+      stepUuid: '{step-uuid-1}',
+    });
+    expect(capturedAxios).toEqual({ responseType: 'text' });
+    expect(output.logs).toContain('text:building...\ndone.');
+  });
+
+  it('should pick a step by 1-based index', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({
+        steps: [mockStepOne, mockStepTwo],
+        onLog: (request) => (captured = request),
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42', step: '2' }, { globalOptions: {} });
+
+    expect((captured as { stepUuid: string }).stepUuid).toBe('{step-uuid-2}');
+  });
+
+  it('should pick a step by UUID (braces optional)', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({
+        steps: [mockStepOne, mockStepTwo],
+        onLog: (request) => (captured = request),
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { id: '42', step: 'step-uuid-2' },
+      { globalOptions: {} }
+    );
+
+    expect((captured as { stepUuid: string }).stepUuid).toBe('{step-uuid-2}');
+  });
+
+  it('should error when --step matches no step', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne, mockStepTwo] }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '42', step: '{nope-uuid}' }, { globalOptions: {} })
+    ).rejects.toThrow("No step matching '{nope-uuid}' found");
+  });
+
+  it('should error when --step index is out of range', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne, mockStepTwo] }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '42', step: '5' }, { globalOptions: {} })
+    ).rejects.toThrow('--step index 5 is out of range');
+  });
+
+  it('should list steps instead of guessing when several exist and no --step', async () => {
+    let logFetched = false;
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({
+        steps: [mockStepOne, mockStepTwo],
+        onLog: () => {
+          logFetched = true;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: {} });
+
+    expect(logFetched).toBe(false);
+    expect(
+      output.logs.some((log) =>
+        log.includes('Pass --step <uuid-or-index> to pick one')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows.map((row) => row[3])).toEqual([
+      '{step-uuid-1}',
+      '{step-uuid-2}',
+    ]);
+  });
+
+  it('should return the steps in JSON mode when several exist and no --step', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne, mockStepTwo] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'pipelineId',
+      'count',
+      'steps',
+    ]);
+    expect(payload.count).toBe(2);
+  });
+
+  it('should emit the documented JSON log envelope', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: [mockStepOne], log: 'the log' }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    expect(getJsonPayload(output.logs)).toEqual({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+      pipelineId: '42',
+      stepUuid: '{step-uuid-1}',
+      log: 'the log',
+    });
+  });
+
+  it('should error when the pipeline has no steps yet', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: [] }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ id: '42' }, { globalOptions: {} })
+    ).rejects.toThrow('Pipeline 42 has no steps yet');
+  });
+});

--- a/tests/commands/pipeline.test.ts
+++ b/tests/commands/pipeline.test.ts
@@ -14,6 +14,11 @@ import {
   createMockOutputService,
 } from '../setup.js';
 import { APIError } from '../../src/types/errors.js';
+import {
+  colorPipelineStatus,
+  formatDuration,
+  getStepDurationSeconds,
+} from '../../src/commands/pipeline/shared.js';
 import type { Pipeline, PipelinesApi } from '../../src/generated/api.js';
 
 const mockPipeline: Pipeline = {
@@ -852,5 +857,85 @@ describe('LogsPipelineCommand', () => {
     await expect(
       command.execute({ id: '42' }, { globalOptions: {} })
     ).rejects.toThrow('Pipeline 42 has no steps yet');
+  });
+});
+
+describe('pipeline shared helpers', () => {
+  const taggingOutput = {
+    ...createMockOutputService(),
+    green: (text: string) => `green(${text})`,
+    red: (text: string) => `red(${text})`,
+    yellow: (text: string) => `yellow(${text})`,
+    gray: (text: string) => `gray(${text})`,
+  };
+
+  it('colors every in-progress status yellow', () => {
+    for (const status of [
+      'PENDING',
+      'BUILDING',
+      'IN_PROGRESS',
+      'RUNNING',
+      'PARSING',
+      'PAUSED',
+      'READY',
+    ]) {
+      expect(colorPipelineStatus(taggingOutput, status)).toBe(
+        `yellow(${status})`
+      );
+    }
+  });
+
+  it('colors every terminal-neutral status gray', () => {
+    for (const status of ['STOPPED', 'HALTED', 'EXPIRED', 'NOT_RUN']) {
+      expect(colorPipelineStatus(taggingOutput, status)).toBe(
+        `gray(${status})`
+      );
+    }
+  });
+
+  it('passes unknown statuses through uncolored', () => {
+    expect(colorPipelineStatus(taggingOutput, 'SOMETHING_NEW')).toBe(
+      'SOMETHING_NEW'
+    );
+  });
+
+  it('formats durations with hours, minutes, and bare seconds', () => {
+    expect(formatDuration(3723)).toBe('1h 2m 3s');
+    expect(formatDuration(125)).toBe('2m 5s');
+    expect(formatDuration(42)).toBe('42s');
+  });
+
+  it('formats missing or non-finite durations as a dash', () => {
+    expect(formatDuration(undefined)).toBe('-');
+    expect(formatDuration(Number.NaN)).toBe('-');
+  });
+
+  it('prefers the API-reported step duration over timestamps', () => {
+    expect(
+      getStepDurationSeconds({
+        duration_in_seconds: 17,
+        started_on: '2026-01-01T00:00:00Z',
+        completed_on: '2026-01-01T01:00:00Z',
+      })
+    ).toBe(17);
+  });
+
+  it('falls back to the started/completed timestamp delta', () => {
+    expect(
+      getStepDurationSeconds({
+        started_on: '2026-01-01T00:00:00Z',
+        completed_on: '2026-01-01T00:01:30Z',
+      })
+    ).toBe(90);
+  });
+
+  it('returns undefined when timestamps are missing or unparsable', () => {
+    expect(getStepDurationSeconds({})).toBeUndefined();
+    expect(
+      getStepDurationSeconds({
+        started_on: 'not-a-date',
+        completed_on: 'also-not-a-date',
+      })
+    ).toBeUndefined();
   });
 });

--- a/tests/commands/pipeline.test.ts
+++ b/tests/commands/pipeline.test.ts
@@ -152,11 +152,35 @@ function createMockPipelinesApi(
           ) ?? mockPipeline,
       };
     },
-    getPipelineStepsForRepository: async () => {
+    getPipelineStepsForRepository: async (
+      _request: unknown,
+      axiosOptions?: unknown
+    ) => {
       if (options.pipelineNotFound) {
         throw new APIError('Resource not found', 404);
       }
-      return { data: { values: steps } };
+      // Mirror the live API: the steps collection is paginated with a
+      // server-side default pagelen of 10, so callers that don't paginate
+      // only ever see the first 10 steps.
+      const params = (
+        axiosOptions as { params?: { page?: number; pagelen?: number } }
+      )?.params;
+      const page = params?.page ?? 1;
+      const pagelen = params?.pagelen ?? 10;
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      return {
+        data: {
+          values: steps.slice(start, end),
+          page,
+          pagelen,
+          size: steps.length,
+          next:
+            end < steps.length
+              ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines/42/steps/?page=${page + 1}`
+              : undefined,
+        },
+      };
     },
     getPipelineStepLogForRepository: async (
       request: unknown,
@@ -181,6 +205,14 @@ function createMockPipelinesApi(
 
 function repoContextService() {
   return createMockContextService({ workspace: 'workspace', repoSlug: 'repo' });
+}
+
+function makeSteps(count: number): unknown[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ...mockStepOne,
+    uuid: `{step-uuid-${index + 1}}`,
+    name: `Step ${index + 1}`,
+  }));
 }
 
 describe('ListPipelinesCommand', () => {
@@ -408,6 +440,23 @@ describe('ViewPipelineCommand', () => {
       command.execute({ id: '999' }, { globalOptions: {} })
     ).rejects.toThrow('Pipeline 999 not found in workspace/repo.');
   });
+
+  it('should collect every step across paginated responses', async () => {
+    const output = createMockOutputService();
+    const command = new ViewPipelineCommand(
+      createMockPipelinesApi({ steps: makeSteps(60) }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(payload.steps).toHaveLength(60);
+    expect(
+      (payload.steps as { name: string }[]).map((step) => step.name)
+    ).toContain('Step 60');
+  });
 });
 
 describe('RunPipelineCommand', () => {
@@ -523,7 +572,7 @@ describe('RunPipelineCommand', () => {
     ).rejects.toThrow('--var must be in key=value format');
   });
 
-  it('should output the created pipeline in JSON mode', async () => {
+  it('should emit the documented JSON envelope with the created pipeline', async () => {
     const output = createMockOutputService();
     const command = new RunPipelineCommand(
       createMockPipelinesApi(),
@@ -538,8 +587,11 @@ describe('RunPipelineCommand', () => {
     );
 
     const payload = getJsonPayload(output.logs);
-    expect(payload.build_number).toBe(42);
-    expect(payload.uuid).toBe('{pipeline-uuid-1}');
+    expect(Object.keys(payload)).toEqual(['workspace', 'repoSlug', 'pipeline']);
+    expect(payload.workspace).toBe('workspace');
+    expect(payload.repoSlug).toBe('repo');
+    expect((payload.pipeline as Pipeline).build_number).toBe(42);
+    expect((payload.pipeline as Pipeline).uuid).toBe('{pipeline-uuid-1}');
   });
 });
 
@@ -755,6 +807,38 @@ describe('LogsPipelineCommand', () => {
       stepUuid: '{step-uuid-1}',
       log: 'the log',
     });
+  });
+
+  it('should select a step beyond the first API page by index', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({
+        steps: makeSteps(60),
+        onLog: (request) => (captured = request),
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42', step: '55' }, { globalOptions: {} });
+
+    expect((captured as { stepUuid: string }).stepUuid).toBe('{step-uuid-55}');
+  });
+
+  it('should count and list every step across pages when no --step', async () => {
+    const output = createMockOutputService();
+    const command = new LogsPipelineCommand(
+      createMockPipelinesApi({ steps: makeSteps(60) }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ id: '42' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(payload.count).toBe(60);
+    expect(payload.steps).toHaveLength(60);
   });
 
   it('should error when the pipeline has no steps yet', async () => {

--- a/tests/commands/project.test.ts
+++ b/tests/commands/project.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Project command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListProjectsCommand } from '../../src/commands/project/list.command.js';
+import { ViewProjectCommand } from '../../src/commands/project/view.command.js';
+import { CreateProjectCommand } from '../../src/commands/project/create.command.js';
+import { createMockContextService, createMockOutputService } from '../setup.js';
+import { APIError } from '../../src/types/errors.js';
+import type {
+  Project,
+  ProjectsApi,
+  WorkspacesApi,
+} from '../../src/generated/api.js';
+
+const mockProject: Project = {
+  type: 'project',
+  uuid: '{proj-uuid}',
+  key: 'PROJ',
+  name: 'My Project',
+  description: 'Internal tooling project',
+  is_private: true,
+  created_on: '2024-01-01T00:00:00.000Z',
+  updated_on: '2024-01-02T00:00:00.000Z',
+  links: {
+    html: { href: 'https://bitbucket.org/acme/workspace/projects/PROJ' },
+  },
+};
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockWorkspacesApi(
+  options: {
+    projects?: Project[];
+    onListCall?: (request: unknown, axiosOptions?: unknown) => void;
+  } = {}
+): WorkspacesApi {
+  const projects = options.projects ?? [mockProject];
+
+  return {
+    workspacesWorkspaceProjectsGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      options.onListCall?.(request, axiosOptions);
+      const params = (
+        axiosOptions as { params?: { page?: number; pagelen?: number } }
+      )?.params;
+      const page = params?.page ?? 1;
+      const pagelen = params?.pagelen ?? 25;
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      return {
+        data: {
+          values: projects.slice(start, end),
+          page,
+          pagelen,
+          size: projects.length,
+          next:
+            end < projects.length
+              ? `https://api.bitbucket.org/2.0/workspaces/acme/projects?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
+  } as unknown as WorkspacesApi;
+}
+
+function createMockProjectsApi(
+  options: {
+    projectNotFound?: boolean;
+    onViewCall?: (request: unknown) => void;
+    onCreateCall?: (request: unknown) => void;
+  } = {}
+): ProjectsApi {
+  return {
+    workspacesWorkspaceProjectsProjectKeyGet: async (request: unknown) => {
+      if (options.projectNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onViewCall?.(request);
+      return { data: mockProject };
+    },
+    workspacesWorkspaceProjectsPost: async (request: unknown) => {
+      options.onCreateCall?.(request);
+      const project = (request as { project: Project }).project;
+      return { data: { ...mockProject, ...project } };
+    },
+  } as unknown as ProjectsApi;
+}
+
+function workspaceContextService() {
+  return createMockContextService({ defaultWorkspace: 'acme' });
+}
+
+describe('ListProjectsCommand', () => {
+  it('should render the projects table with key, name, privacy, description, and date', async () => {
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('table:KEY,NAME,PRIVACY,DESCRIPTION,UPDATED')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual([
+      'PROJ',
+      'My Project',
+      'private',
+      'Internal tooling project',
+      '2024-01-02T00:00:00.000Z',
+    ]);
+  });
+
+  it('should resolve the workspace and pass pagination params through axios options', async () => {
+    let capturedRequest: { workspace?: string } | undefined;
+    let capturedParams: Record<string, unknown> | undefined;
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi({
+        onListCall: (request, axiosOptions) => {
+          capturedRequest = request as { workspace?: string };
+          capturedParams = (
+            axiosOptions as { params?: Record<string, unknown> }
+          )?.params;
+        },
+      }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({ workspace: 'other-ws' }, { globalOptions: {} });
+
+    expect(capturedRequest?.workspace).toBe('other-ws');
+    expect(capturedParams?.page).toBe(1);
+    expect(capturedParams?.pagelen).toBeDefined();
+  });
+
+  it('should emit the JSON envelope with workspace, count, and projects', async () => {
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'count', 'projects']);
+    expect(payload.workspace).toBe('acme');
+    expect(payload.count).toBe(1);
+    expect(payload.projects).toEqual([JSON.parse(JSON.stringify(mockProject))]);
+  });
+
+  it('should show the empty state with the workspace name', async () => {
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi({ projects: [] }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs).toContain('info:No projects found in workspace acme');
+  });
+
+  it('should cap results at --limit and print the more-results hint', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({
+      ...mockProject,
+      key: `PROJ${i + 1}`,
+    }));
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi({ projects: many }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({ limit: '3' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(3);
+    expect(output.logs.some((log) => log.includes('Showing 3 projects'))).toBe(
+      true
+    );
+  });
+
+  it('should fail without a resolvable workspace', async () => {
+    const output = createMockOutputService();
+    const command = new ListProjectsCommand(
+      createMockWorkspacesApi(),
+      createMockContextService(),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      'No workspace specified'
+    );
+  });
+});
+
+describe('ViewProjectCommand', () => {
+  it('should render project details', async () => {
+    const output = createMockOutputService();
+    const command = new ViewProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({ key: 'PROJ' }, { globalOptions: {} });
+
+    expect(output.logs.some((log) => log.includes('PROJ'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('My Project'))).toBe(true);
+    expect(
+      output.logs.some((log) => log.includes('Internal tooling project'))
+    ).toBe(true);
+  });
+
+  it('should uppercase the key before calling the API', async () => {
+    let captured: { projectKey?: string; workspace?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ViewProjectCommand(
+      createMockProjectsApi({
+        onViewCall: (request) => {
+          captured = request as { projectKey?: string; workspace?: string };
+        },
+      }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({ key: 'proj' }, { globalOptions: {} });
+
+    expect(captured?.projectKey).toBe('PROJ');
+    expect(captured?.workspace).toBe('acme');
+  });
+
+  it('should emit the JSON envelope { workspace, project }', async () => {
+    const output = createMockOutputService();
+    const command = new ViewProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute({ key: 'PROJ' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'project']);
+    expect(payload.workspace).toBe('acme');
+    expect(payload.project).toEqual(JSON.parse(JSON.stringify(mockProject)));
+  });
+
+  it('should add a friendly message to a 404', async () => {
+    const output = createMockOutputService();
+    const command = new ViewProjectCommand(
+      createMockProjectsApi({ projectNotFound: true }),
+      workspaceContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ key: 'GHOST' }, { globalOptions: {} })
+    ).rejects.toThrow('Project GHOST not found in workspace acme.');
+  });
+});
+
+describe('CreateProjectCommand', () => {
+  it('should POST a typed project body (private by default)', async () => {
+    let captured:
+      | { workspace?: string; project?: Record<string, unknown> }
+      | undefined;
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi({
+        onCreateCall: (request) => {
+          captured = request as {
+            workspace?: string;
+            project?: Record<string, unknown>;
+          };
+        },
+      }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute(
+      { key: 'PROJ', name: 'My Project', description: 'Team things' },
+      { globalOptions: {} }
+    );
+
+    expect(captured?.workspace).toBe('acme');
+    expect(captured?.project).toEqual({
+      type: 'project',
+      key: 'PROJ',
+      name: 'My Project',
+      description: 'Team things',
+      is_private: true,
+    });
+    expect(output.logs).toContain('success:Project PROJ created in acme');
+    expect(
+      output.logs.some((log) => log.includes('bb repo create <name> -p PROJ'))
+    ).toBe(true);
+  });
+
+  it('should omit description when not given and honor --public', async () => {
+    let captured: { project?: Record<string, unknown> } | undefined;
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi({
+        onCreateCall: (request) => {
+          captured = request as { project?: Record<string, unknown> };
+        },
+      }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute(
+      { key: 'PROJ', name: 'My Project', public: true },
+      { globalOptions: {} }
+    );
+
+    expect(captured?.project).toEqual({
+      type: 'project',
+      key: 'PROJ',
+      name: 'My Project',
+      is_private: false,
+    });
+  });
+
+  it('should uppercase a lowercase key and mention the normalization', async () => {
+    let captured: { project?: { key?: string } } | undefined;
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi({
+        onCreateCall: (request) => {
+          captured = request as { project?: { key?: string } };
+        },
+      }),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute(
+      { key: 'proj', name: 'My Project' },
+      { globalOptions: {} }
+    );
+
+    expect(captured?.project?.key).toBe('PROJ');
+    expect(output.logs).toContain(
+      'info:Project keys are uppercase on Bitbucket; using PROJ.'
+    );
+  });
+
+  it('should reject a key that is not a valid project key', async () => {
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { key: '1-bad key', name: 'My Project' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('--key must start with a letter');
+  });
+
+  it('should reject --private together with --public', async () => {
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { key: 'PROJ', name: 'My Project', private: true, public: true },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('--private and --public cannot both be set.');
+  });
+
+  it('should require --key and --name', async () => {
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ name: 'My Project' }, { globalOptions: {} })
+    ).rejects.toThrow('Option --key is required');
+    await expect(
+      command.execute({ key: 'PROJ' }, { globalOptions: {} })
+    ).rejects.toThrow('Option --name is required');
+  });
+
+  it('should emit the JSON envelope { workspace, project }', async () => {
+    const output = createMockOutputService();
+    const command = new CreateProjectCommand(
+      createMockProjectsApi(),
+      workspaceContextService(),
+      output
+    );
+
+    await command.execute(
+      { key: 'PROJ', name: 'My Project' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace', 'project']);
+    expect(payload.workspace).toBe('acme');
+    expect((payload.project as { key?: string }).key).toBe('PROJ');
+  });
+});

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Status (commit build status) command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListCommitStatusesCommand } from '../../src/commands/status/list.command.js';
+import { SetCommitStatusCommand } from '../../src/commands/status/set.command.js';
+import { createMockContextService, createMockOutputService } from '../setup.js';
+import { APIError } from '../../src/types/errors.js';
+import type {
+  CommitStatusesApi,
+  Commitstatus,
+} from '../../src/generated/api.js';
+
+const mockStatus: Commitstatus = {
+  type: 'build',
+  key: 'CI',
+  state: 'SUCCESSFUL',
+  name: 'CI Build #7',
+  description: 'All tests passed',
+  url: 'https://ci.example.com/builds/7',
+  refname: 'main',
+  created_on: '2024-01-01T00:00:00.000Z',
+  updated_on: '2024-01-01T00:05:00.000Z',
+};
+
+function extractPaginationParams(axiosOptions: unknown): {
+  page: number;
+  pagelen: number;
+} {
+  const params = (
+    axiosOptions as { params?: { page?: number; pagelen?: number } }
+  )?.params;
+  return { page: params?.page ?? 1, pagelen: params?.pagelen ?? 25 };
+}
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockCommitStatusesApi(
+  options: {
+    statuses?: Commitstatus[];
+    commitNotFound?: boolean;
+    postError?: APIError;
+    onList?: (request: unknown, axiosOptions?: unknown) => void;
+    onPost?: (request: unknown) => void;
+    onPut?: (request: unknown) => void;
+  } = {}
+): CommitStatusesApi {
+  const statuses = options.statuses ?? [mockStatus];
+
+  return {
+    repositoriesWorkspaceRepoSlugCommitCommitStatusesGet: async (
+      request: unknown,
+      axiosOptions?: unknown
+    ) => {
+      if (options.commitNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onList?.(request, axiosOptions);
+      const { page, pagelen } = extractPaginationParams(axiosOptions);
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      return {
+        data: {
+          values: statuses.slice(start, end),
+          page,
+          pagelen,
+          size: statuses.length,
+          next:
+            end < statuses.length
+              ? `https://api.bitbucket.org/2.0/repositories/workspace/repo/commit/abc/statuses?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
+    repositoriesWorkspaceRepoSlugCommitCommitStatusesBuildPost: async (
+      request: unknown
+    ) => {
+      if (options.commitNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      if (options.postError) {
+        throw options.postError;
+      }
+      options.onPost?.(request);
+      const { commitstatus } = request as { commitstatus: Commitstatus };
+      return { data: { ...mockStatus, ...commitstatus } };
+    },
+    repositoriesWorkspaceRepoSlugCommitCommitStatusesBuildKeyPut: async (
+      request: unknown
+    ) => {
+      options.onPut?.(request);
+      const { commitstatus } = request as { commitstatus: Commitstatus };
+      return { data: { ...mockStatus, ...commitstatus } };
+    },
+  } as unknown as CommitStatusesApi;
+}
+
+function repoContextService() {
+  return createMockContextService({ workspace: 'workspace', repoSlug: 'repo' });
+}
+
+describe('ListCommitStatusesCommand', () => {
+  it('should render the statuses table with key, state, name, description, and url', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitStatusesCommand(
+      createMockCommitStatusesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ sha: 'abc1234' }, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.startsWith('table:KEY,STATE,NAME,DESCRIPTION,URL')
+      )
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual([
+      'CI',
+      'SUCCESSFUL',
+      'CI Build #7',
+      'All tests passed',
+      'https://ci.example.com/builds/7',
+    ]);
+  });
+
+  it('should emit the JSON envelope with metadata-first key order', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitStatusesCommand(
+      createMockCommitStatusesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { sha: 'abc1234' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'commit',
+      'count',
+      'statuses',
+    ]);
+    expect(payload.commit).toBe('abc1234');
+    expect(payload.count).toBe(1);
+    expect(payload.statuses).toHaveLength(1);
+  });
+
+  it('should pass pagination params through axios options', async () => {
+    let capturedAxios: unknown;
+    const output = createMockOutputService();
+    const command = new ListCommitStatusesCommand(
+      createMockCommitStatusesApi({
+        onList: (_request, axiosOptions) => {
+          capturedAxios = axiosOptions;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { sha: 'abc1234', limit: '10' },
+      { globalOptions: {} }
+    );
+
+    expect(extractPaginationParams(capturedAxios)).toEqual({
+      page: 1,
+      pagelen: 10,
+    });
+  });
+
+  it('should show the empty-state message when the commit has no statuses', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitStatusesCommand(
+      createMockCommitStatusesApi({ statuses: [] }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute({ sha: 'abc1234' }, { globalOptions: {} });
+
+    expect(output.logs).toContain('info:No statuses found for commit abc1234');
+  });
+
+  it('should surface a contextual 404 error for unknown commits', async () => {
+    const output = createMockOutputService();
+    const command = new ListCommitStatusesCommand(
+      createMockCommitStatusesApi({ commitNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ sha: 'deadbee' }, { globalOptions: {} })
+    ).rejects.toThrow('Commit deadbee not found in workspace/repo.');
+  });
+});
+
+describe('SetCommitStatusCommand', () => {
+  it('should POST a typed build status and print a success message', async () => {
+    let captured: unknown;
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi({
+        onPost: (request) => {
+          captured = request;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      {
+        sha: 'abc1234def567890',
+        key: 'CI',
+        state: 'SUCCESSFUL',
+        url: 'https://ci.example.com/builds/8',
+        name: 'CI Build #8',
+        description: 'All green',
+        refname: 'main',
+      },
+      { globalOptions: {} }
+    );
+
+    expect(captured).toEqual({
+      commit: 'abc1234def567890',
+      repoSlug: 'repo',
+      workspace: 'workspace',
+      commitstatus: {
+        type: 'build',
+        key: 'CI',
+        state: 'SUCCESSFUL',
+        url: 'https://ci.example.com/builds/8',
+        name: 'CI Build #8',
+        description: 'All green',
+        refname: 'main',
+      },
+    });
+    expect(output.logs).toContain(
+      'success:Status CI set to SUCCESSFUL on abc1234'
+    );
+  });
+
+  it('should fall back to PUT when the POST is rejected (duplicate key), making set idempotent', async () => {
+    let putCaptured: unknown;
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi({
+        postError: new APIError(
+          'Status with key CI already exists on this commit',
+          400
+        ),
+        onPut: (request) => {
+          putCaptured = request;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { sha: 'abc1234def567890', key: 'CI', state: 'failed' },
+      { globalOptions: {} }
+    );
+
+    expect(putCaptured).toEqual({
+      commit: 'abc1234def567890',
+      key: 'CI',
+      repoSlug: 'repo',
+      workspace: 'workspace',
+      commitstatus: { type: 'build', key: 'CI', state: 'FAILED' },
+    });
+    expect(output.logs).toContain('success:Status CI set to FAILED on abc1234');
+  });
+
+  it('should not fall back to PUT on auth errors', async () => {
+    let putCalled = false;
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi({
+        postError: new APIError('Token is invalid or not supported', 401),
+        onPut: () => {
+          putCalled = true;
+        },
+      }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { sha: 'abc1234', key: 'CI', state: 'SUCCESSFUL' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('Token is invalid or not supported');
+    expect(putCalled).toBe(false);
+  });
+
+  it('should emit the JSON envelope wrapping the resulting status', async () => {
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi(),
+      repoContextService(),
+      output
+    );
+
+    await command.execute(
+      { sha: 'abc1234', key: 'CI', state: 'INPROGRESS' },
+      { globalOptions: { json: true } }
+    );
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual([
+      'workspace',
+      'repoSlug',
+      'commit',
+      'status',
+    ]);
+    expect((payload.status as Commitstatus).key).toBe('CI');
+    expect((payload.status as Commitstatus).state).toBe('INPROGRESS');
+  });
+
+  it('should reject an invalid --state value with the allowed list', async () => {
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { sha: 'abc1234', key: 'CI', state: 'GREENISH' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('--state must be one of');
+  });
+
+  it('should require --key', async () => {
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi(),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { sha: 'abc1234', state: 'SUCCESSFUL' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('Option --key is required');
+  });
+
+  it('should surface a contextual 404 error for unknown commits', async () => {
+    const output = createMockOutputService();
+    const command = new SetCommitStatusCommand(
+      createMockCommitStatusesApi({ commitNotFound: true }),
+      repoContextService(),
+      output
+    );
+
+    await expect(
+      command.execute(
+        { sha: 'deadbee', key: 'CI', state: 'SUCCESSFUL' },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('Commit deadbee not found in workspace/repo.');
+  });
+});

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'bun:test';
 import { ListCommitStatusesCommand } from '../../src/commands/status/list.command.js';
 import { SetCommitStatusCommand } from '../../src/commands/status/set.command.js';
 import { createMockContextService, createMockOutputService } from '../setup.js';
+import { colorStatusState } from '../../src/commands/status/shared.js';
 import { APIError } from '../../src/types/errors.js';
 import type {
   CommitStatusesApi,
@@ -390,5 +391,35 @@ describe('SetCommitStatusCommand', () => {
         { globalOptions: {} }
       )
     ).rejects.toThrow('Commit deadbee not found in workspace/repo.');
+  });
+});
+
+describe('colorStatusState', () => {
+  const taggingOutput = {
+    ...createMockOutputService(),
+    green: (text: string) => `green(${text})`,
+    red: (text: string) => `red(${text})`,
+    yellow: (text: string) => `yellow(${text})`,
+    gray: (text: string) => `gray(${text})`,
+  };
+
+  it('colors each known state with its severity color', () => {
+    expect(colorStatusState(taggingOutput, 'SUCCESSFUL')).toBe(
+      'green(SUCCESSFUL)'
+    );
+    expect(colorStatusState(taggingOutput, 'FAILED')).toBe('red(FAILED)');
+    expect(colorStatusState(taggingOutput, 'INPROGRESS')).toBe(
+      'yellow(INPROGRESS)'
+    );
+    expect(colorStatusState(taggingOutput, 'STOPPED')).toBe('gray(STOPPED)');
+  });
+
+  it('matches states case-insensitively', () => {
+    expect(colorStatusState(taggingOutput, 'failed')).toBe('red(failed)');
+  });
+
+  it('renders unknown or missing states as a gray dash', () => {
+    expect(colorStatusState(taggingOutput, 'MYSTERY')).toBe('gray(MYSTERY)');
+    expect(colorStatusState(taggingOutput, undefined)).toBe('gray(-)');
   });
 });

--- a/tests/commands/workspace.test.ts
+++ b/tests/commands/workspace.test.ts
@@ -270,6 +270,42 @@ describe('ViewWorkspaceCommand', () => {
     expect(captured?.workspace).toBe('default-ws');
   });
 
+  it("should derive the slug from the current repository's git remote", async () => {
+    let captured: { workspace?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi({
+        onViewCall: (request) => {
+          captured = request as { workspace?: string };
+        },
+      }),
+      createMockContextService({ workspace: 'remote-ws', repoSlug: 'repo' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(captured?.workspace).toBe('remote-ws');
+  });
+
+  it('should prefer the -w flag over the git remote', async () => {
+    let captured: { workspace?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi({
+        onViewCall: (request) => {
+          captured = request as { workspace?: string };
+        },
+      }),
+      createMockContextService({ workspace: 'remote-ws', repoSlug: 'repo' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { workspace: 'flag-ws' } });
+
+    expect(captured?.workspace).toBe('flag-ws');
+  });
+
   it('should emit the JSON envelope { workspace }', async () => {
     const output = createMockOutputService();
     const command = new ViewWorkspaceCommand(

--- a/tests/commands/workspace.test.ts
+++ b/tests/commands/workspace.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Workspace command tests
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ListWorkspacesCommand } from '../../src/commands/workspace/list.command.js';
+import { ViewWorkspaceCommand } from '../../src/commands/workspace/view.command.js';
+import { createMockContextService, createMockOutputService } from '../setup.js';
+import { APIError } from '../../src/types/errors.js';
+import type { Workspace, WorkspacesApi } from '../../src/generated/api.js';
+
+const mockWorkspace: Workspace = {
+  type: 'workspace',
+  uuid: '{ws-uuid}',
+  name: 'Acme Inc',
+  slug: 'acme',
+  is_private: true,
+  is_privacy_enforced: false,
+  forking_mode: 'allow_forks',
+  created_on: '2024-01-01T00:00:00.000Z',
+  updated_on: '2024-01-02T00:00:00.000Z',
+  links: {
+    html: { href: 'https://bitbucket.org/acme/' },
+  },
+};
+
+function getTableRows(logs: string[]): string[][] {
+  const rowsLog = logs.find((log) => log.startsWith('table-rows:'));
+  if (!rowsLog) {
+    return [];
+  }
+  return JSON.parse(rowsLog.substring('table-rows:'.length)) as string[][];
+}
+
+function getJsonPayload(logs: string[]): Record<string, unknown> {
+  const jsonLog = logs.find((log) => log.startsWith('json:'));
+  expect(jsonLog).toBeDefined();
+  return JSON.parse(jsonLog!.substring('json:'.length)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function createMockWorkspacesApi(
+  options: {
+    workspaces?: Workspace[];
+    workspaceNotFound?: boolean;
+    onListCall?: (request: unknown, axiosOptions?: unknown) => void;
+    onViewCall?: (request: unknown) => void;
+  } = {}
+): WorkspacesApi {
+  const workspaces = options.workspaces ?? [mockWorkspace];
+
+  return {
+    workspacesGet: async (request: unknown, axiosOptions?: unknown) => {
+      options.onListCall?.(request, axiosOptions);
+      const params = (
+        axiosOptions as { params?: { page?: number; pagelen?: number } }
+      )?.params;
+      const page = params?.page ?? 1;
+      const pagelen = params?.pagelen ?? 25;
+      const start = (page - 1) * pagelen;
+      const end = start + pagelen;
+      return {
+        data: {
+          values: workspaces.slice(start, end),
+          page,
+          pagelen,
+          size: workspaces.length,
+          next:
+            end < workspaces.length
+              ? `https://api.bitbucket.org/2.0/workspaces?page=${page + 1}`
+              : undefined,
+        },
+      };
+    },
+    workspacesWorkspaceGet: async (request: unknown) => {
+      if (options.workspaceNotFound) {
+        throw new APIError('Resource not found', 404);
+      }
+      options.onViewCall?.(request);
+      return { data: mockWorkspace };
+    },
+  } as unknown as WorkspacesApi;
+}
+
+describe('ListWorkspacesCommand', () => {
+  it('should render the workspaces table with slug, name, privacy, and uuid', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) => log.startsWith('table:SLUG,NAME,PRIVACY,UUID'))
+    ).toBe(true);
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(['acme', 'Acme Inc', 'private', '{ws-uuid}']);
+  });
+
+  it('should print a defaultWorkspace hint after the table', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.includes('bb config set defaultWorkspace <slug>')
+      )
+    ).toBe(true);
+  });
+
+  it('should emit the JSON envelope with filters, count, and workspaces (and no hint)', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi(),
+      output
+    );
+
+    await command.execute({}, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['filters', 'count', 'workspaces']);
+    expect(payload.count).toBe(1);
+    expect(payload.workspaces).toEqual([
+      JSON.parse(JSON.stringify(mockWorkspace)),
+    ]);
+    expect(output.logs.some((log) => log.includes('defaultWorkspace'))).toBe(
+      false
+    );
+  });
+
+  it('should pass --role through to the API and into the JSON filters', async () => {
+    let captured: { role?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi({
+        onListCall: (request) => {
+          captured = request as { role?: string };
+        },
+      }),
+      output
+    );
+
+    await command.execute({ role: 'owner' }, { globalOptions: { json: true } });
+
+    expect(captured?.role).toBe('owner');
+    const payload = getJsonPayload(output.logs);
+    expect(payload.filters).toEqual({ role: 'owner' });
+  });
+
+  it('should reject an invalid --role', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi(),
+      output
+    );
+
+    await expect(
+      command.execute({ role: 'admin' }, { globalOptions: {} })
+    ).rejects.toThrow('--role must be one of: owner, collaborator, member');
+  });
+
+  it('should show the empty state when no workspaces exist', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi({ workspaces: [] }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(output.logs).toContain('info:No workspaces found');
+  });
+
+  it('should mention the role in the empty state when --role filtered', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi({ workspaces: [] }),
+      output
+    );
+
+    await command.execute({ role: 'collaborator' }, { globalOptions: {} });
+
+    expect(output.logs).toContain(
+      'info:No workspaces found for role "collaborator"'
+    );
+  });
+
+  it('should cap results at --limit and print the more-results hint', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({
+      ...mockWorkspace,
+      slug: `ws-${i + 1}`,
+    }));
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi({ workspaces: many }),
+      output
+    );
+
+    await command.execute({ limit: '2' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(2);
+    expect(
+      output.logs.some((log) => log.includes('Showing 2 workspaces'))
+    ).toBe(true);
+  });
+
+  it('should reject an invalid --limit', async () => {
+    const output = createMockOutputService();
+    const command = new ListWorkspacesCommand(
+      createMockWorkspacesApi(),
+      output
+    );
+
+    await expect(
+      command.execute({ limit: 'abc' }, { globalOptions: {} })
+    ).rejects.toThrow('--limit must be a positive integer');
+  });
+});
+
+describe('ViewWorkspaceCommand', () => {
+  it('should view an explicitly passed slug without any workspace context', async () => {
+    let captured: { workspace?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi({
+        onViewCall: (request) => {
+          captured = request as { workspace?: string };
+        },
+      }),
+      createMockContextService(),
+      output
+    );
+
+    await command.execute({ slug: 'acme' }, { globalOptions: {} });
+
+    expect(captured?.workspace).toBe('acme');
+    expect(output.logs.some((log) => log.includes('acme'))).toBe(true);
+    expect(output.logs.some((log) => log.includes('Acme Inc'))).toBe(true);
+    expect(
+      output.logs.some((log) => log.includes('https://bitbucket.org/acme/'))
+    ).toBe(true);
+  });
+
+  it('should default the slug from the resolved workspace context', async () => {
+    let captured: { workspace?: string } | undefined;
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi({
+        onViewCall: (request) => {
+          captured = request as { workspace?: string };
+        },
+      }),
+      createMockContextService({ defaultWorkspace: 'default-ws' }),
+      output
+    );
+
+    await command.execute({}, { globalOptions: {} });
+
+    expect(captured?.workspace).toBe('default-ws');
+  });
+
+  it('should emit the JSON envelope { workspace }', async () => {
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi(),
+      createMockContextService(),
+      output
+    );
+
+    await command.execute({ slug: 'acme' }, { globalOptions: { json: true } });
+
+    const payload = getJsonPayload(output.logs);
+    expect(Object.keys(payload)).toEqual(['workspace']);
+    expect(payload.workspace).toEqual(
+      JSON.parse(JSON.stringify(mockWorkspace))
+    );
+  });
+
+  it('should add a friendly message to a 404', async () => {
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi({ workspaceNotFound: true }),
+      createMockContextService(),
+      output
+    );
+
+    await expect(
+      command.execute({ slug: 'ghost' }, { globalOptions: {} })
+    ).rejects.toThrow(
+      'Workspace ghost not found (or you do not have access to it).'
+    );
+  });
+
+  it('should fail with the standard workspace-context error when nothing resolves', async () => {
+    const output = createMockOutputService();
+    const command = new ViewWorkspaceCommand(
+      createMockWorkspacesApi(),
+      createMockContextService(),
+      output
+    );
+
+    await expect(command.execute({}, { globalOptions: {} })).rejects.toThrow(
+      'No workspace specified'
+    );
+  });
+});

--- a/tests/core/bootstrap.test.ts
+++ b/tests/core/bootstrap.test.ts
@@ -15,6 +15,7 @@ import { BaseCommand } from '../../src/core/base-command.js';
 import { OutputService } from '../../src/services/output.service.js';
 import { ViewRepoCommand } from '../../src/commands/repo/view.command.js';
 import { CreatePRCommand } from '../../src/commands/pr/create.command.js';
+import type { AxiosInstance } from 'axios';
 
 describe('bootstrap()', () => {
   it('returns a Container with every registered service token wired up', () => {
@@ -117,6 +118,42 @@ describe('bootstrap()', () => {
     const output = container.resolve(ServiceTokens.OutputService);
     expect((viewRepo as unknown as { output: unknown }).output).toBe(output);
     expect((createPR as unknown as { output: unknown }).output).toBe(output);
+  });
+
+  it('constructs every generated API client on the single shared axios instance', () => {
+    Container.reset();
+    const container = bootstrap();
+
+    const shared = container.resolve<AxiosInstance>(
+      ServiceTokens.SharedApiAxios
+    );
+    // The shared instance is a singleton: resolving twice yields one object.
+    expect(container.resolve(ServiceTokens.SharedApiAxios)).toBe(shared);
+
+    // Generated typescript-axios clients store the constructor's axios arg on
+    // a protected `axios` property — assert identity through a cast.
+    const generatedClientTokens = [
+      ServiceTokens.PullrequestsApi,
+      ServiceTokens.RepositoriesApi,
+      ServiceTokens.UsersApi,
+      ServiceTokens.CommitStatusesApi,
+      ServiceTokens.SnippetsApi,
+    ];
+    for (const token of generatedClientTokens) {
+      const client = container.resolve<{ axios: AxiosInstance }>(token);
+      expect(client.axios).toBe(shared);
+    }
+
+    // Non-generated consumers of the raw axios instance share it too.
+    const snippetFiles = container.resolve<{ axios: AxiosInstance }>(
+      ServiceTokens.SnippetFilesService
+    );
+    expect(snippetFiles.axios).toBe(shared);
+
+    const apiCommand = container.resolve<{ axios: AxiosInstance }>(
+      ServiceTokens.ApiCommand
+    );
+    expect(apiCommand.axios).toBe(shared);
   });
 
   it('every command exposes the required public shape (name, description, run)', () => {

--- a/tests/core/run-list.test.ts
+++ b/tests/core/run-list.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for the shared `BaseCommand.runList()` paginated list helper.
+ *
+ * Covers the common tail of all list-style commands: limit resolution,
+ * page collection, the JSON envelope shape (metadata-first key order,
+ * `count`, wrapper array key), empty-state messaging, table rendering,
+ * the more-results hint, and the WRAPPER_ARRAY_KEYS drift guard.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { BaseCommand, type RunListSpec } from '../../src/core/base-command.js';
+import type { CommandContext } from '../../src/core/interfaces/commands.js';
+import { BBError, ErrorCode } from '../../src/types/errors.js';
+import { createMockOutputService } from '../setup.js';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+class ListHarnessCommand extends BaseCommand<Record<string, unknown>, void> {
+  public readonly name = 'list-harness';
+  public readonly description = 'Test harness for runList';
+
+  async execute(): Promise<void> {
+    // Not used; tests drive callRunList directly.
+  }
+
+  public async callRunList(
+    spec: RunListSpec<Item>,
+    context: CommandContext
+  ): Promise<void> {
+    return this.runList(spec, context);
+  }
+}
+
+function makeContext(json = false): CommandContext {
+  return { globalOptions: json ? { json: true } : {} } as CommandContext;
+}
+
+function makeHarness() {
+  const output = createMockOutputService();
+  const command = new ListHarnessCommand(output);
+  return { output, command };
+}
+
+/** A single-page fetcher returning the given items with no `next` link. */
+function singlePage(items: Item[]) {
+  return async () => ({ values: items, next: undefined });
+}
+
+const ITEMS: Item[] = [
+  { id: 1, name: 'alpha' },
+  { id: 2, name: 'beta' },
+];
+
+function baseSpec(
+  overrides: Partial<RunListSpec<Item>> = {}
+): RunListSpec<Item> {
+  return {
+    options: {},
+    fetchPage: singlePage(ITEMS),
+    wrapperKey: 'values',
+    emptyMessage: 'No items found',
+    tableHeaders: ['ID', 'NAME'],
+    mapRow: (item) => [String(item.id), item.name],
+    noun: 'items',
+    ...overrides,
+  };
+}
+
+describe('BaseCommand.runList', () => {
+  describe('JSON mode', () => {
+    it('emits the envelope with metadata keys first, then count, then the wrapper array', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(
+        baseSpec({
+          jsonMetadata: { workspace: 'acme', repoSlug: 'site' },
+        }),
+        makeContext(true)
+      );
+
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(jsonLog).toBeDefined();
+      const payload = JSON.parse(jsonLog!.slice('json:'.length));
+      expect(payload).toEqual({
+        workspace: 'acme',
+        repoSlug: 'site',
+        count: 2,
+        values: ITEMS,
+      });
+      // Key order is part of the observable API surface (metadata-first).
+      expect(Object.keys(payload)).toEqual([
+        'workspace',
+        'repoSlug',
+        'count',
+        'values',
+      ]);
+    });
+
+    it('emits the full envelope with count: 0 when there are no items', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(
+        baseSpec({
+          fetchPage: singlePage([]),
+          jsonMetadata: { workspace: 'acme' },
+        }),
+        makeContext(true)
+      );
+
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(jsonLog).toBeDefined();
+      expect(JSON.parse(jsonLog!.slice('json:'.length))).toEqual({
+        workspace: 'acme',
+        count: 0,
+        values: [],
+      });
+      // JSON mode never prints the table-mode empty-state message.
+      expect(output.logs.some((log) => log.startsWith('info:'))).toBe(false);
+    });
+
+    it('omits metadata when jsonMetadata is not provided', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(baseSpec(), makeContext(true));
+
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(JSON.parse(jsonLog!.slice('json:'.length))).toEqual({
+        count: 2,
+        values: ITEMS,
+      });
+    });
+  });
+
+  describe('table mode', () => {
+    it('renders headers and mapped rows', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(baseSpec(), makeContext());
+
+      expect(output.logs).toContain('table:ID,NAME');
+      expect(output.logs).toContain(
+        `table-rows:${JSON.stringify([
+          ['1', 'alpha'],
+          ['2', 'beta'],
+        ])}`
+      );
+      expect(output.logs.some((log) => log.startsWith('json:'))).toBe(false);
+    });
+
+    it('prints a string empty-state message and no table when there are no items', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(
+        baseSpec({ fetchPage: singlePage([]) }),
+        makeContext()
+      );
+
+      expect(output.logs).toContain('info:No items found');
+      expect(output.logs.some((log) => log.startsWith('table:'))).toBe(false);
+      expect(output.logs.some((log) => log.startsWith('text:'))).toBe(false);
+    });
+
+    it('evaluates a function empty-state message lazily', async () => {
+      const { output, command } = makeHarness();
+      let evaluated = false;
+
+      await command.callRunList(
+        baseSpec({
+          fetchPage: singlePage([]),
+          emptyMessage: () => {
+            evaluated = true;
+            return 'No items matched the filter';
+          },
+        }),
+        makeContext()
+      );
+
+      expect(evaluated).toBe(true);
+      expect(output.logs).toContain('info:No items matched the filter');
+    });
+
+    it('does not evaluate the empty-state message when items exist', async () => {
+      const { command } = makeHarness();
+      let evaluated = false;
+
+      await command.callRunList(
+        baseSpec({
+          emptyMessage: () => {
+            evaluated = true;
+            return 'unused';
+          },
+        }),
+        makeContext()
+      );
+
+      expect(evaluated).toBe(false);
+    });
+
+    it('prints the more-results hint when the limit truncates the listing', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(
+        baseSpec({ options: { limit: '1' } }),
+        makeContext()
+      );
+
+      expect(output.logs).toContain(
+        'text:Showing 1 items. Use --limit <n> or --all to see more.'
+      );
+    });
+
+    it('omits the more-results hint when everything was shown', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(baseSpec(), makeContext());
+
+      expect(output.logs.some((log) => log.includes('Use --limit'))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('pagination and filtering', () => {
+    it('applies shouldInclude to filter fetched items', async () => {
+      const { output, command } = makeHarness();
+
+      await command.callRunList(
+        baseSpec({ shouldInclude: (item) => item.id !== 1 }),
+        makeContext(true)
+      );
+
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(JSON.parse(jsonLog!.slice('json:'.length))).toEqual({
+        count: 1,
+        values: [{ id: 2, name: 'beta' }],
+      });
+    });
+
+    it('fetches every page when --all is set', async () => {
+      const { output, command } = makeHarness();
+      const pages: Item[][] = [
+        [{ id: 1, name: 'alpha' }],
+        [{ id: 2, name: 'beta' }],
+      ];
+      const requestedPages: number[] = [];
+
+      await command.callRunList(
+        baseSpec({
+          options: { all: true },
+          fetchPage: async (page) => {
+            requestedPages.push(page);
+            return {
+              values: pages[page - 1] ?? [],
+              next: page < pages.length ? 'next-url' : undefined,
+            };
+          },
+        }),
+        makeContext(true)
+      );
+
+      expect(requestedPages).toEqual([1, 2]);
+      const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+      expect(JSON.parse(jsonLog!.slice('json:'.length)).count).toBe(2);
+    });
+
+    it('rejects an invalid --limit with a BBError before fetching', async () => {
+      const { command } = makeHarness();
+      let fetched = false;
+
+      const promise = command.callRunList(
+        baseSpec({
+          options: { limit: 'abc' },
+          fetchPage: async () => {
+            fetched = true;
+            return { values: [] };
+          },
+        }),
+        makeContext()
+      );
+
+      await expect(promise).rejects.toBeInstanceOf(BBError);
+      await promise.catch((error: BBError) => {
+        expect(error.code).toBe(ErrorCode.VALIDATION_INVALID);
+      });
+      expect(fetched).toBe(false);
+    });
+  });
+
+  describe('wrapperKey drift guard', () => {
+    it('throws when wrapperKey is not registered in WRAPPER_ARRAY_KEYS', async () => {
+      const { command } = makeHarness();
+
+      await expect(
+        command.callRunList(
+          baseSpec({ wrapperKey: 'unregisteredKey' }),
+          makeContext()
+        )
+      ).rejects.toThrow(/WRAPPER_ARRAY_KEYS/);
+    });
+
+    it('accepts every wrapper key used by the refactored list commands', async () => {
+      // The six commands using runList and their JSON wrapper keys.
+      const usedKeys = [
+        'pullRequests', // pr list
+        'repositories', // repo list
+        'snippets', // snippet list
+        'activities', // pr activity
+        'comments', // pr comments list, snippet comments list
+      ];
+
+      for (const wrapperKey of usedKeys) {
+        const { command } = makeHarness();
+        await expect(
+          command.callRunList(baseSpec({ wrapperKey }), makeContext())
+        ).resolves.toBeUndefined();
+      }
+    });
+  });
+});

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -12,6 +12,7 @@ import {
   mock,
 } from 'bun:test';
 import { createApiClient } from '../../src/services/api-client.service.js';
+import { OAuthService } from '../../src/services/oauth.service.js';
 import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
 import { createMockConfigService, createMockOutputService } from '../setup.js';
 import type { AxiosInstance } from 'axios';
@@ -415,7 +416,94 @@ describe('createApiClient - shared instance concurrency', () => {
     expect(mockAdapter.getCallCount('/b')).toBe(2);
     // The one-shot guard lives on each request's config, so each request
     // refreshed once — one request's guard did not suppress the other's.
+    // (With the real OAuthService both calls collapse into one token POST via
+    // the in-flight lock — see the parallel-401 test below.)
     expect(oauthMock.getRefreshCallCount()).toBe(2);
+  });
+
+  it('collapses parallel 401 refreshes into a single token POST (#259)', async () => {
+    // Real OAuthService (not a mock) so the in-flight refresh lock is
+    // exercised end-to-end: two requests on the shared axios instance both
+    // hit 401, both enter the reactive refresh path, and exactly one POST
+    // reaches the token endpoint. Bitbucket rotates refresh tokens, so a
+    // second POST would carry an invalidated refresh_token and log the
+    // user out.
+    const configService = createMockConfigService({
+      authMethod: 'oauth',
+      oauthAccessToken: 'revoked-server-side', // not expired locally, but 401s
+      oauthRefreshToken: 'the-refresh-token',
+      oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const oauthService = new OAuthService(configService, configService);
+
+    // OAuthService talks to the token endpoint via global fetch (axios is
+    // only used for API calls). Gate the response so the refresh stays
+    // in-flight until both 401s have entered the interceptor.
+    const originalFetch = globalThis.fetch;
+    let tokenPostCount = 0;
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    globalThis.fetch = (async () => {
+      tokenPostCount++;
+      await refreshGate;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: 'fresh-token',
+          refresh_token: 'rotated-refresh',
+          expires_in: 7200,
+          token_type: 'bearer',
+          scopes: '',
+        }),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    try {
+      const mockAdapter = createUrlKeyedAdapter({
+        '/a': [
+          { status: 401, data: { error: { message: 'Unauthorized' } } },
+          { status: 200, data: { route: 'a' } },
+        ],
+        '/b': [
+          { status: 401, data: { error: { message: 'Unauthorized' } } },
+          { status: 200, data: { route: 'b' } },
+        ],
+      });
+      const client = createApiClient(
+        configService,
+        createMockOutputService(),
+        oauthService
+      );
+      client.defaults.adapter = mockAdapter.adapter as any;
+
+      const inFlight = Promise.all([client.get('/a'), client.get('/b')]);
+
+      // Give both requests real time to hit 401 and reach the refresh path
+      // while the first refresh is still pending (setTimeout is stubbed to
+      // run callbacks synchronously in this suite, so use the original).
+      await new Promise((resolve) => originalSetTimeout(resolve, 20));
+      releaseRefresh();
+
+      const [respA, respB] = await inFlight;
+
+      expect(respA.status).toBe(200);
+      expect(respB.status).toBe(200);
+      expect(mockAdapter.getCallCount('/a')).toBe(2);
+      expect(mockAdapter.getCallCount('/b')).toBe(2);
+      // Acceptance criterion: parallel 401s produce a single token POST.
+      expect(tokenPostCount).toBe(1);
+
+      // Both replays used the single refreshed token, and the rotated
+      // refresh token was persisted once.
+      const creds = await configService.getOAuthCredentials();
+      expect(creds.accessToken).toBe('fresh-token');
+      expect(creds.refreshToken).toBe('rotated-refresh');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('gives concurrent requests on one instance independent __retryCount budgets', async () => {

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -90,12 +90,25 @@ function createMockAdapter(
  * `code` is what lets the client emit a timeout-specific message.
  */
 function createTimeoutErrorAdapter(
-  code: 'ECONNABORTED' | 'ETIMEDOUT' = 'ECONNABORTED'
+  code: 'ECONNABORTED' | 'ETIMEDOUT' = 'ECONNABORTED',
+  options: { succeedAfter?: number } = {}
 ) {
   let callCount = 0;
   let lastError: unknown;
   const adapter = (_config: unknown) => {
     callCount++;
+    if (
+      options.succeedAfter !== undefined &&
+      callCount > options.succeedAfter
+    ) {
+      return Promise.resolve({
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: _config,
+      });
+    }
     const error = new Error(`timeout of 30000ms exceeded`);
     (error as any).code = code;
     (error as any).request = {}; // request was sent...
@@ -114,12 +127,31 @@ function createTimeoutErrorAdapter(
 
 /**
  * Helper: creates an adapter that simulates a network error (no response).
+ * Optionally tags the error with a `code` (e.g. 'ECONNRESET') and/or starts
+ * succeeding after the first `succeedAfter` calls have failed.
  */
-function createNetworkErrorAdapter() {
+function createNetworkErrorAdapter(
+  options: { code?: string; succeedAfter?: number } = {}
+) {
   let callCount = 0;
   const adapter = (_config: unknown) => {
     callCount++;
+    if (
+      options.succeedAfter !== undefined &&
+      callCount > options.succeedAfter
+    ) {
+      return Promise.resolve({
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: _config,
+      });
+    }
     const error = new Error('Network Error');
+    if (options.code !== undefined) {
+      (error as any).code = options.code;
+    }
     (error as any).request = {}; // has request but no response
     (error as any).config = _config;
     (error as any).isAxiosError = true;
@@ -718,7 +750,7 @@ describe('createApiClient - retry/backoff', () => {
       expect(bbErr.message).toContain('DEBUG=true');
     }
 
-    // Network errors are not retried (no response object)
+    // Network errors without a recognized transient `code` are not retried
     expect(networkMock.getCallCount()).toBe(1);
   });
 });
@@ -1386,8 +1418,9 @@ describe('createApiClient - request timeout (#249)', () => {
       expect((err as BBError).code).toBe(ErrorCode.NETWORK_ERROR);
     }
 
-    // Timeouts have no `response`, so they are never retried.
-    expect(timeoutMock.getCallCount()).toBe(1);
+    // Timeouts on idempotent requests are retried (issue #267):
+    // 1 initial + 3 retries = 4 attempts before the error surfaces.
+    expect(timeoutMock.getCallCount()).toBe(4);
   });
 
   it('also maps ETIMEDOUT timeouts to NETWORK_ERROR', async () => {
@@ -1403,7 +1436,8 @@ describe('createApiClient - request timeout (#249)', () => {
       expect(err).toBeInstanceOf(BBError);
       expect((err as BBError).code).toBe(ErrorCode.NETWORK_ERROR);
     }
-    expect(timeoutMock.getCallCount()).toBe(1);
+    // 1 initial + 3 network-error retries (issue #267)
+    expect(timeoutMock.getCallCount()).toBe(4);
   });
 
   it('surfaces a timeout-specific message distinct from the generic network error', async () => {
@@ -1443,5 +1477,160 @@ describe('createApiClient - request timeout (#249)', () => {
       expect(bbErr.message).toContain('Unable to reach Bitbucket API');
       expect(bbErr.message.toLowerCase()).not.toContain('timed out');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #267: retry transient network errors (no response received) on
+// idempotent requests.
+// ---------------------------------------------------------------------------
+
+describe('createApiClient - transient network error retry (#267)', () => {
+  let client: AxiosInstance;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Make sleep() instant so retries don't slow down the suite.
+    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+      fn();
+      return 0 as any;
+    }) as any;
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('retries GET on ECONNRESET and succeeds once the connection recovers', async () => {
+    const networkMock = createNetworkErrorAdapter({
+      code: 'ECONNRESET',
+      succeedAfter: 1,
+    });
+    const output = createMockOutputService();
+    client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = networkMock.adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ ok: true });
+    expect(networkMock.getCallCount()).toBe(2);
+    expect(
+      output.logs.some((l) =>
+        l.startsWith('warning:Network error (ECONNRESET)')
+      )
+    ).toBe(true);
+  });
+
+  it('retries GET on EAI_AGAIN (temporary DNS failure) and succeeds', async () => {
+    const networkMock = createNetworkErrorAdapter({
+      code: 'EAI_AGAIN',
+      succeedAfter: 2,
+    });
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = networkMock.adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    // 2 failures + 1 success
+    expect(networkMock.getCallCount()).toBe(3);
+  });
+
+  it('retries ETIMEDOUT up to MAX_RETRIES then throws NETWORK_ERROR with the timeout message', async () => {
+    const timeoutMock = createTimeoutErrorAdapter('ETIMEDOUT');
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = timeoutMock.adapter as never;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BBError);
+      const bbErr = err as BBError;
+      expect(bbErr.code).toBe(ErrorCode.NETWORK_ERROR);
+      // Final-failure mapping is preserved: timeout-specific copy with the
+      // BB_HTTP_TIMEOUT hint.
+      expect(bbErr.message.toLowerCase()).toContain('timed out');
+      expect(bbErr.message).toContain('BB_HTTP_TIMEOUT');
+    }
+
+    // 1 initial attempt + MAX_RETRIES (3) retries = 4 attempts total.
+    expect(timeoutMock.getCallCount()).toBe(4);
+  });
+
+  it('does NOT retry POST on ECONNRESET (non-idempotent method)', async () => {
+    const networkMock = createNetworkErrorAdapter({ code: 'ECONNRESET' });
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = networkMock.adapter as never;
+
+    try {
+      await client.post('/test', { body: true });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BBError);
+      expect((err as BBError).code).toBe(ErrorCode.NETWORK_ERROR);
+    }
+
+    expect(networkMock.getCallCount()).toBe(1);
+  });
+
+  it('does NOT retry GET on ECONNREFUSED (permanent until fixed)', async () => {
+    const networkMock = createNetworkErrorAdapter({ code: 'ECONNREFUSED' });
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = networkMock.adapter as never;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BBError);
+      expect((err as BBError).code).toBe(ErrorCode.NETWORK_ERROR);
+    }
+
+    expect(networkMock.getCallCount()).toBe(1);
+  });
+
+  it('uses exponential backoff delays (1s/2s/4s) for network retries', async () => {
+    const setTimeoutCalls: number[] = [];
+    globalThis.setTimeout = ((fn: Function, ms?: number) => {
+      setTimeoutCalls.push(ms ?? 0);
+      fn();
+      return 0 as any;
+    }) as any;
+
+    const networkMock = createNetworkErrorAdapter({ code: 'ECONNRESET' });
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = networkMock.adapter as never;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect((err as BBError).code).toBe(ErrorCode.NETWORK_ERROR);
+    }
+
+    expect(setTimeoutCalls).toContain(1000);
+    expect(setTimeoutCalls).toContain(2000);
+    expect(setTimeoutCalls).toContain(4000);
+  });
+
+  it('suppresses network retry warnings in --json mode', async () => {
+    const networkMock = createNetworkErrorAdapter({
+      code: 'ECONNRESET',
+      succeedAfter: 1,
+    });
+    const output = createMockOutputService();
+    output.setJsonFormatOptions({ json: true });
+    client = createApiClient(mockConfigService(), output);
+    client.defaults.adapter = networkMock.adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(networkMock.getCallCount()).toBe(2);
+    expect(output.logs.filter((l) => l.startsWith('warning:'))).toHaveLength(0);
   });
 });

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -318,6 +318,139 @@ describe('createApiClient - OAuth auth', () => {
   });
 });
 
+/**
+ * Helper: creates an axios adapter with a per-URL response queue, so
+ * concurrent requests to different paths each consume their own sequence.
+ * Used to prove interceptor state is per-request, not per-instance.
+ */
+function createUrlKeyedAdapter(
+  routes: Record<
+    string,
+    Array<{ status: number; data?: unknown; headers?: Record<string, string> }>
+  >
+) {
+  const callCounts: Record<string, number> = {};
+  const adapter = (config: { url?: string }) => {
+    const url = config.url ?? '';
+    const idx = callCounts[url] ?? 0;
+    callCounts[url] = idx + 1;
+    const queue = routes[url] ?? [];
+    const resp = queue[idx] ?? queue[queue.length - 1];
+    if (resp.status >= 200 && resp.status < 300) {
+      return Promise.resolve({
+        data: resp.data ?? {},
+        status: resp.status,
+        statusText: 'OK',
+        headers: resp.headers ?? {},
+        config,
+      });
+    }
+    const error = new Error(`Request failed with status code ${resp.status}`);
+    (error as any).response = {
+      data: resp.data ?? {},
+      status: resp.status,
+      statusText: resp.status.toString(),
+      headers: resp.headers ?? {},
+      config,
+    };
+    (error as any).config = config;
+    (error as any).isAxiosError = true;
+    return Promise.reject(error);
+  };
+  return {
+    adapter,
+    getCallCount: (url: string) => callCounts[url] ?? 0,
+  };
+}
+
+describe('createApiClient - shared instance concurrency', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+      fn();
+      return 0 as any;
+    }) as any;
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('gives concurrent requests on one instance independent __tokenRefreshed guards (both 401 once, both replay)', async () => {
+    const oauthMock = createMockOAuthService({
+      validToken: 'expired-token',
+      refreshedToken: 'new-token',
+    });
+    const mockAdapter = createUrlKeyedAdapter({
+      '/a': [
+        { status: 401, data: { error: { message: 'Unauthorized' } } },
+        { status: 200, data: { route: 'a' } },
+      ],
+      '/b': [
+        { status: 401, data: { error: { message: 'Unauthorized' } } },
+        { status: 200, data: { route: 'b' } },
+      ],
+    });
+    const client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const [respA, respB] = await Promise.all([
+      client.get('/a'),
+      client.get('/b'),
+    ]);
+
+    // Both requests recovered: each hit 401 once and replayed successfully.
+    expect(respA.status).toBe(200);
+    expect(respA.data).toEqual({ route: 'a' });
+    expect(respB.status).toBe(200);
+    expect(respB.data).toEqual({ route: 'b' });
+    expect(mockAdapter.getCallCount('/a')).toBe(2);
+    expect(mockAdapter.getCallCount('/b')).toBe(2);
+    // The one-shot guard lives on each request's config, so each request
+    // refreshed once — one request's guard did not suppress the other's.
+    expect(oauthMock.getRefreshCallCount()).toBe(2);
+  });
+
+  it('gives concurrent requests on one instance independent __retryCount budgets', async () => {
+    const mockAdapter = createUrlKeyedAdapter({
+      '/a': [
+        { status: 503, data: {} },
+        { status: 503, data: {} },
+        { status: 503, data: {} },
+        { status: 200, data: { route: 'a' } },
+      ],
+      '/b': [
+        { status: 503, data: {} },
+        { status: 200, data: { route: 'b' } },
+      ],
+    });
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as any;
+
+    const [respA, respB] = await Promise.all([
+      client.get('/a'),
+      client.get('/b'),
+    ]);
+
+    // /a needed all 3 retries; /b only 1. If the counter were shared on the
+    // instance, /a's failures would have exhausted /b's budget (or vice versa).
+    expect(respA.status).toBe(200);
+    expect(respB.status).toBe(200);
+    expect(mockAdapter.getCallCount('/a')).toBe(4);
+    expect(mockAdapter.getCallCount('/b')).toBe(2);
+  });
+});
+
 describe('createApiClient - retry/backoff', () => {
   let client: AxiosInstance;
   let consoleErrorSpy: ReturnType<typeof spyOn>;

--- a/tests/services/oauth.service.test.ts
+++ b/tests/services/oauth.service.test.ts
@@ -393,6 +393,132 @@ describe('OAuthService', () => {
       expect(decoded).toBe('custom-id:custom-secret');
     });
 
+    it('should dedupe concurrent refresh calls into a single token POST', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'the-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
+      });
+      const service = new OAuthService(configService, configService);
+
+      const fetchMock = mockFetch([
+        {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'deduped-token',
+            refresh_token: 'rotated-refresh',
+            expires_in: 7200,
+            token_type: 'bearer',
+            scopes: '',
+          }),
+        },
+      ]);
+
+      const tokens = await Promise.all([
+        service.refreshAccessToken(),
+        service.refreshAccessToken(),
+        service.refreshAccessToken(),
+      ]);
+
+      // Bitbucket rotates the refresh token on every refresh, so a second
+      // concurrent POST would send an invalidated refresh_token and fail.
+      expect(fetchMock.getCallCount()).toBe(1);
+      expect(tokens).toEqual([
+        'deduped-token',
+        'deduped-token',
+        'deduped-token',
+      ]);
+
+      const creds = await configService.getOAuthCredentials();
+      expect(creds.refreshToken).toBe('rotated-refresh');
+    });
+
+    it('should dedupe concurrent getValidAccessToken calls when the token is expired', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'the-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100, // expired
+      });
+      const service = new OAuthService(configService, configService);
+
+      const fetchMock = mockFetch([
+        {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'shared-fresh-token',
+            refresh_token: 'rotated-refresh',
+            expires_in: 7200,
+            token_type: 'bearer',
+            scopes: '',
+          }),
+        },
+      ]);
+
+      const tokens = await Promise.all([
+        service.getValidAccessToken(),
+        service.getValidAccessToken(),
+        service.getValidAccessToken(),
+      ]);
+
+      expect(fetchMock.getCallCount()).toBe(1);
+      expect(tokens).toEqual([
+        'shared-fresh-token',
+        'shared-fresh-token',
+        'shared-fresh-token',
+      ]);
+    });
+
+    it('should clear the in-flight lock after a failed refresh so the next call retries', async () => {
+      const configService = createMockConfigService({
+        authMethod: 'oauth',
+        oauthAccessToken: 'old-token',
+        oauthRefreshToken: 'the-refresh-token',
+        oauthExpiresAt: Math.floor(Date.now() / 1000) - 100,
+      });
+      const service = new OAuthService(configService, configService);
+
+      const fetchMock = mockFetch([
+        {
+          ok: false,
+          status: 503,
+          text: async () => 'service unavailable',
+        },
+        {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'second-attempt-token',
+            refresh_token: 'rotated-refresh',
+            expires_in: 7200,
+            token_type: 'bearer',
+            scopes: '',
+          }),
+        },
+      ]);
+
+      // Both concurrent waiters receive the failure from the single POST.
+      const [first, second] = await Promise.all([
+        outcome(service.refreshAccessToken()),
+        outcome(service.refreshAccessToken()),
+      ]);
+      expect(fetchMock.getCallCount()).toBe(1);
+      expect((first.error as { code: number }).code).toBe(
+        ErrorCode.AUTH_EXPIRED
+      );
+      expect((second.error as { code: number }).code).toBe(
+        ErrorCode.AUTH_EXPIRED
+      );
+
+      // The rejection is not cached: a later call starts a fresh POST.
+      const token = await service.refreshAccessToken();
+      expect(token).toBe('second-attempt-token');
+      expect(fetchMock.getCallCount()).toBe(2);
+    });
+
     it('should persist updated expiresAt as a unix timestamp in seconds', async () => {
       const configService = createMockConfigService({
         authMethod: 'oauth',


### PR DESCRIPTION
Lands the foundation work and all four feature families from the **Next — 1–2 quarters** milestone in one PR, in dependency order: HTTP-stack debt first, then the command groups built on top of it.

Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262
Closes #263
Closes #267

## Foundations

- **One shared axios instance** (#258) — all generated API clients (plus the snippet raw-file helper and `bb api` passthrough) are constructed on a single `createApiClient` instance, so timeout/retry/refresh behavior is uniform and future interceptor changes are one-place edits. The per-request `__retryCount`/`__tokenRefreshed` guards are covered by new concurrency tests.
- **OAuth refresh in-flight lock** (#259) — concurrent requests that hit an expired token now share a single token POST. Bitbucket rotates the refresh token on every refresh, so the previous race could invalidate the stored refresh token and silently log the user out. A test simulates parallel 401s and asserts exactly one token-endpoint POST.
- **Transient network retry** (#267) — ECONNRESET / ETIMEDOUT / ECONNABORTED / EAI_AGAIN / EPIPE on GET/HEAD/OPTIONS now retry with the same exponential backoff and `MAX_RETRIES` cap as 429/5xx. Non-idempotent methods keep failing fast to avoid duplicate side effects.
- **`runList` abstraction** (#257) — the repeated 7-step list skeleton (`resolveLimit` → `collectPagesWithMeta` → JSON envelope → empty state → table → more-hint) is now one `BaseCommand.runList()` helper used by all list commands. The `WRAPPER_ARRAY_KEYS` contract is enforced at runtime (unregistered wrapper keys throw). Zero behavior change — the pre-existing suite passed unmodified.

## New command groups

| Group | Commands | Notes |
|---|---|---|
| `bb pipeline` (#260) | `list`, `view`, `run`, `stop`, `logs` | Accepts build numbers or UUIDs; `run` supports `--branch` (defaults to current git branch), `--commit`, `--pipeline <custom>`, repeatable `--var k=v`. `watch` deferred. |
| `bb commit` / `bb status` (#261) | `commit list`, `commit view`, `status list`, `status set` | `commit list` defaults to the current git branch; `status set` falls back to PUT on duplicate keys, so CI re-runs are idempotent. |
| `bb issue` (#262) | `list`, `view`, `create`, `edit`, `close`, `comment` | gh-style filters (`--state`, `--kind`, `--assignee`, `--reporter`, raw `--query`); clear error when the repo's issue tracker is disabled; Jira caveat documented. |
| `bb workspace` / `bb project` (#263) | `workspace list`, `workspace view`, `project list`, `project view`, `project create` | Discovery for the slugs/keys that `-w`, `defaultWorkspace`, and `repo create -p` expect. |

Every command works non-interactively, ships a stable documented `--json` envelope (metadata keys, `count`, wrapper array — `--jq`/field projection compatible), tab completion, and help text with copy-pasteable examples.

## Review pass

A multi-agent review of the branch confirmed and fixed six issues before this PR: pipeline step pagination beyond the default page size of 10 (`view`/`logs`), the `workspace view` current-repo fallback that docs promised but code lacked, token-scopes and JSON-output reference pages missing the new groups, and `pipeline run --json` envelope consistency.

## Docs

New reference pages for all six groups (`commands/{pipeline,commit,status,issue,workspace,project}.mdx`) with sidebar entries, an updated home-page card grid, and updates to `token-scopes.mdx`, `json-output.mdx`, and `error-codes.mdx`. Docs-lint (error-code + env-var sync) passes.

## Out of scope (left open)

The remaining milestone items were deliberately not started: #264 (mock-server integration layer), #265 (interceptor test suite), #266 (OpenAPI contract test), #268 (did-you-mean suggestions), #269 (hermetic/thin test suites).

## Verification

`bun test` — 1332 pass / 0 fail across 44 files. `tsc --noEmit`, docs-lint, and Prettier all clean. 7 changesets included (3 patch for reliability work, 4 minor for the new command groups).

## Suggested manual checks against a real workspace

1. `bb workspace list` and `bb workspace view` inside and outside a cloned repo (the current-repo fallback).
2. `bb pipeline run --branch <b>` on a repo with Pipelines enabled, then `bb pipeline view <build#>` and `bb pipeline logs <build#>` on a pipeline with more than 10 steps.
3. `bb status set <sha> --key ci --state INPROGRESS` twice (second run should update, not fail), then `bb status list <sha>`.
4. `bb issue list` on a repo with the tracker disabled (expect the actionable tracker-disabled message) and on one with it enabled.
5. `bb commit list` with no flags inside a repo (current-branch default) and with `--ref`.
6. One OAuth-authenticated fan-out command after letting the token expire (e.g. `bb pr checks`), to see the refresh lock in the wild.
7. `--json | jq` piping on a couple of the new list commands to confirm envelope stability.
