### PR TITLE
fix(tests): isolate test runs from real BB_* environment variables

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,8 @@
 [test]
+# Strip real BB_* env vars before any suite loads, so a developer's working
+# `bb` setup can't leak into tests (issue #294).
+preload = ["./tests/preload.ts"]
+
 # Coverage is opt-in via the --coverage flag (see the `test:coverage` script in
 # package.json). We deliberately do NOT set `coverage = true` here so that a
 # plain `bun test` (local dev + the macOS/Windows CI legs) stays fast.

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,0 +1,7 @@
+// Tests must not see the developer's real BB_* environment (see issue #294):
+// LoginCommand, ContextService, and ApiClientService all read process.env
+// fallbacks, so an exported BB_API_TOKEN silently reroutes the auth tests.
+// Tests that need one of these variables set it explicitly.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('BB_')) delete process.env[key];
+}


### PR DESCRIPTION
Fixes #294.

Adds a bun test preload that deletes all `BB_*` env vars before any suite loads, so a developer's working `bb` setup can't leak into tests. Tests that need one of these vars already set it explicitly and restore it.

Verified: with `BB_USERNAME`/`BB_API_TOKEN`/`BB_WORKSPACE` exported, `tests/commands/auth.test.ts` went from 8 fail / 33 pass to 41/41, and the full suite is 1343/1343. No changeset: test-only, nothing user-facing.