### PR TITLE
feat(pr): resolution filters and status column for comments list

### DIFF
--- a/.changeset/pr-comments-list-resolution.md
+++ b/.changeset/pr-comments-list-resolution.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+`bb pr comments list` now shows a `Status` column (`resolved`, `pending`, or `open`) and supports `--resolved` / `--unresolved` flags to filter comments by resolution state, closing the remaining part of #292. The active filter is echoed under `filters.resolution` in `--json` output.

--- a/docs/src/content/docs/commands/pr/comments.mdx
+++ b/docs/src/content/docs/commands/pr/comments.mdx
@@ -51,6 +51,8 @@ bb pr comments list <id>
 | `-r, --repo <repo>` | Repository |
 | `--limit <number>` | Maximum number of comments (default: 25) |
 | `--all` | List all comments (overrides `--limit`) |
+| `--resolved` | Only show resolved comments |
+| `--unresolved` | Only show unresolved comments |
 | `--no-truncate` | Show full comment content without truncation |
 | `--json` | Output as JSON |
 
@@ -59,6 +61,9 @@ bb pr comments list <id>
 ```bash
 # List comments on PR #42
 bb pr comments list 42
+
+# Only comments that still need attention
+bb pr comments list 42 --unresolved
 
 # List more comments
 bb pr comments list 42 --limit 50
@@ -80,6 +85,8 @@ bb pr comments list 42 --json
 
 - By default, comment content is truncated to 60 characters in the table view
 - Use `--no-truncate` to display the full comment text
+- The `Status` column shows `resolved`, `pending`, or `open`; Bitbucket records resolution on the thread root, so replies always show `open`
+- `--resolved` and `--unresolved` filter on the same resolution state and cannot be combined
 - `--limit` is enforced across paginated comment responses
 - When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
 

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -170,7 +170,7 @@ Returns an envelope with metadata and a named array:
 | `repoSlug` | string | Repository-scoped collections (PR, pipeline, commit, status, issue) |
 | `count` | number | All collections |
 | `state` | string | `pr list` |
-| `filters` | object | `pr list` (when `--mine` is used), `pr activity`, `issue list`, `workspace list` |
+| `filters` | object | `pr list` (when `--mine` is used), `pr activity`, `pr comments list`, `issue list`, `workspace list` |
 | `commit` | string | `status list` |
 | `sort` | string | `pipeline list` |
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1145,12 +1145,15 @@ prCommentsCmd
   .description('List comments on a pull request')
   .option('--limit <number>', 'Maximum number of comments (default: 25)')
   .option('--all', 'List all comments (overrides --limit)')
+  .option('--resolved', 'Only show resolved comments')
+  .option('--unresolved', 'Only show unresolved comments')
   .addHelpText(
     'after',
     buildHelpText({
       examples: [
         'bb pr comments list 42',
         'bb pr comments list 42 --no-truncate',
+        'bb pr comments list 42 --unresolved',
         'bb pr comments list 42 --all',
         'bb pr comments list 42 --limit 50 --json',
       ],

--- a/src/commands/pr/comments.list.command.ts
+++ b/src/commands/pr/comments.list.command.ts
@@ -17,10 +17,13 @@ import {
   getUserDisplayName,
 } from '../../services/response-parsers.js';
 import type { GlobalOptions } from '../../types/config.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
 
 export interface ListCommentsPROptions extends GlobalOptions {
   limit?: string;
   all?: boolean;
+  resolved?: boolean;
+  unresolved?: boolean;
 }
 
 export class ListCommentsPRCommand extends BaseCommand<
@@ -49,9 +52,28 @@ export class ListCommentsPRCommand extends BaseCommand<
 
     const prId = this.parsePositiveInt(options.id, 'id');
 
+    if (options.resolved && options.unresolved) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: '--resolved and --unresolved cannot be combined',
+      });
+    }
+    const resolutionFilter = options.resolved
+      ? 'resolved'
+      : options.unresolved
+        ? 'unresolved'
+        : null;
+
     await this.runList<PullrequestComment>(
       {
         options,
+        shouldInclude: (comment) => {
+          if (resolutionFilter === null) {
+            return true;
+          }
+          const isResolved = comment.resolution != null;
+          return resolutionFilter === 'resolved' ? isResolved : !isResolved;
+        },
         fetchPage: async (page, pagelen) => {
           const response =
             await this.pullrequestsApi.repositoriesWorkspaceRepoSlugPullrequestsPullRequestIdCommentsGet(
@@ -72,9 +94,15 @@ export class ListCommentsPRCommand extends BaseCommand<
           workspace: repoContext.workspace,
           repoSlug: repoContext.repoSlug,
           pullRequestId: prId,
+          filters: {
+            resolution: resolutionFilter,
+          },
         },
-        emptyMessage: 'No comments found on this pull request',
-        tableHeaders: ['ID', 'Author', 'Content', 'Date'],
+        emptyMessage: () =>
+          resolutionFilter !== null
+            ? 'No comments matched the requested filter'
+            : 'No comments found on this pull request',
+        tableHeaders: ['ID', 'Author', 'Content', 'Status', 'Date'],
         mapRow: (comment) => {
           const content = getRawContent(comment.content) ?? '';
           return [
@@ -83,6 +111,11 @@ export class ListCommentsPRCommand extends BaseCommand<
             comment.deleted
               ? '[deleted]'
               : this.truncateText(content, 60, context.globalOptions),
+            comment.resolution
+              ? 'resolved'
+              : comment.pending
+                ? 'pending'
+                : 'open',
             this.output.formatDate(comment.created_on ?? ''),
           ];
         },

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1771,6 +1771,61 @@ describe('ListCommentsPRCommand', () => {
     ).rejects.toThrow('--resolved and --unresolved cannot be combined');
   });
 
+  it('should show the filtered empty message when a filter matches nothing', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      comments: [
+        {
+          id: 1,
+          type: 'pullrequest_comment',
+          content: { raw: 'Open thread' },
+          user: mockUser,
+          created_on: '2024-01-01T00:00:00.000Z',
+          deleted: false,
+        } as PullrequestComment,
+      ],
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1', resolved: true }, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.includes('No comments matched the requested filter')
+      )
+    ).toBe(true);
+  });
+
+  it('should show the default empty message without a filter', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({ comments: [] });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) =>
+        log.includes('No comments found on this pull request')
+      )
+    ).toBe(true);
+  });
+
   it('should include the resolution filter in json output', async () => {
     const pullrequestsApi = createMockPullrequestsApi({
       comments: mixedResolutionComments(),

--- a/tests/commands/pr.test.ts
+++ b/tests/commands/pr.test.ts
@@ -1655,6 +1655,149 @@ describe('ListCommentsPRCommand', () => {
     expect(parsed.count).toBe(2);
     expect(parsed.comments).toHaveLength(2);
   });
+
+  const mixedResolutionComments = (): PullrequestComment[] => [
+    {
+      id: 1,
+      type: 'pullrequest_comment',
+      content: { raw: 'Resolved thread' },
+      user: mockUser,
+      created_on: '2024-01-01T00:00:00.000Z',
+      deleted: false,
+      resolution: { type: 'comment_resolution' },
+    } as PullrequestComment,
+    {
+      id: 2,
+      type: 'pullrequest_comment',
+      content: { raw: 'Open thread' },
+      user: mockUser,
+      created_on: '2024-01-01T01:00:00.000Z',
+      deleted: false,
+    } as PullrequestComment,
+    {
+      id: 3,
+      type: 'pullrequest_comment',
+      content: { raw: 'Pending comment' },
+      user: mockUser,
+      created_on: '2024-01-01T02:00:00.000Z',
+      deleted: false,
+      pending: true,
+    } as PullrequestComment,
+  ];
+
+  it('should render the resolution status column', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      comments: mixedResolutionComments(),
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1' }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows.map((row) => row[3])).toEqual(['resolved', 'open', 'pending']);
+  });
+
+  it('should only list resolved comments with --resolved', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      comments: mixedResolutionComments(),
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1', resolved: true }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.[0]).toBe('1');
+  });
+
+  it('should only list unresolved comments with --unresolved', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      comments: mixedResolutionComments(),
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute({ id: '1', unresolved: true }, { globalOptions: {} });
+
+    const rows = getTableRows(output.logs);
+    expect(rows.map((row) => row[0])).toEqual(['2', '3']);
+  });
+
+  it('should reject --resolved combined with --unresolved', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({ comments: [] });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+
+    expect(
+      command.execute(
+        { id: '1', resolved: true, unresolved: true },
+        { globalOptions: {} }
+      )
+    ).rejects.toThrow('--resolved and --unresolved cannot be combined');
+  });
+
+  it('should include the resolution filter in json output', async () => {
+    const pullrequestsApi = createMockPullrequestsApi({
+      comments: mixedResolutionComments(),
+    });
+    const contextService = createMockContextService({
+      workspace: 'workspace',
+      repoSlug: 'repo',
+    });
+    const output = createMockOutputService();
+
+    const command = new ListCommentsPRCommand(
+      pullrequestsApi,
+      contextService,
+      output
+    );
+    await command.execute(
+      { id: '1', unresolved: true },
+      { globalOptions: { json: true } }
+    );
+
+    const jsonLog = output.logs.find((log) => log.startsWith('json:'));
+    const parsed = JSON.parse(jsonLog!.substring(5));
+    expect(parsed.filters).toEqual({ resolution: 'unresolved' });
+    expect(parsed.comments.map((c: PullrequestComment) => c.id)).toEqual([
+      2, 3,
+    ]);
+  });
 });
 
 describe('ChecksPRCommand', () => {


### PR DESCRIPTION
Closes #295 (the secondary ask from #292).

- `bb pr comments list` gains a `Status` column: `resolved`, `pending`, or `open`
- new `--resolved` / `--unresolved` flags filter on resolution state (mutually exclusive, validated)
- active filter echoed as `filters.resolution` in `--json` output, docs updated (comments.mdx + json-output.mdx filters row)
- 5 new tests; full suite 1393/1393, lint and format clean

Note: Bitbucket records resolution on the thread root, so replies always show `open` (documented in the Notes section).