### PR TITLE
docs: full content refresh — accuracy pass and prose rewrite

### DIFF
--- a/docs/src/content/docs/commands/api.mdx
+++ b/docs/src/content/docs/commands/api.mdx
@@ -3,29 +3,29 @@ title: API Command — Raw Authenticated Bitbucket API Access
 description: Call any Bitbucket Cloud 2.0 API endpoint through the CLI's authenticated stack — the escape hatch for endpoints not yet wrapped by a typed command. Mirrors gh api.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+`bb api` sends an authenticated request to any Bitbucket Cloud 2.0 endpoint
+through the same stack as every other command: Basic/Bearer auth, automatic
+OAuth token refresh, rate-limit and transient-error retries, and secret
+redaction. Same shape as `gh api`.
 
-`bb api` makes an authenticated request to **any** Bitbucket Cloud 2.0 API
-endpoint, reusing the same stack as every other command: Basic/Bearer auth,
-automatic OAuth token refresh, rate-limit and transient-error retries, and
-secret redaction. It is the escape hatch for endpoints not yet wrapped by a
-typed command family, so you are never blocked. Mirrors `gh api`.
-
-Global options: `--json [fields]`, `--jq <expression>`, `--no-color`,
-`-w, --workspace`, `-r, --repo`.
+Every global flag is inherited — see [Global Flags](/reference/global-flags/).
+The ones that matter here are `--json [fields]`, `--jq <expression>`,
+`-w/--workspace`, `-r/--repo`, and `--no-color`/`--no-unicode`, which style the
+error and `--paginate` warning lines. `--no-truncate` and `--locale` change
+nothing: `bb api` prints no tables and no dates.
 
 ## `bb api`
 
 ```bash
-bb api [method] <endpoint> [options]
+bb api [options] [method] <endpoint>
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `method` | Optional HTTP verb (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`). When omitted, defaults to `GET`, or `POST` when fields/body are present. Both `bb api GET /user` and `bb api /user` work. |
-| `endpoint` | The API path, relative to `https://api.bitbucket.org/2.0` (a leading `/` is optional). `{workspace}` and `{repo}` placeholders are substituted from `--workspace`/`--repo` or the current repository. |
+| `method` | Optional HTTP verb (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`), case-insensitive. When omitted, defaults to `GET`, or `POST` when fields/body are present. Both `bb api GET /user` and `bb api /user` work. |
+| `endpoint` | The API path, relative to `https://api.bitbucket.org/2.0` (a leading `/` is optional). A redundant leading `/2.0` is stripped, so paths copied straight out of the Bitbucket REST docs (`/2.0/user`) work unchanged. `{workspace}` and `{repo}` placeholders are substituted from `--workspace`/`--repo` or the current repository. |
 
 ### Options
 
@@ -39,6 +39,30 @@ bb api [method] <endpoint> [options]
 | `-i, --include` | Print the HTTP status line and response headers before the body (text mode only — suppressed under `--json`). |
 | `--paginate` | Follow the cursor (`next`) across pages and merge every page into a single `{ "values": [...] }` result (`GET`/`HEAD` only). |
 
+### Argument errors
+
+Positionals are strict: at most two, and with two the first must be an HTTP
+verb. Every case below exits `1` without sending a request.
+
+```text
+$ bb api
+✗ An endpoint path is required (e.g. /user). Run `bb api --help` for usage.
+
+$ bb api GET
+✗ An endpoint path is required after the method (e.g. bb api GET /user). Run `bb api --help` for usage.
+
+$ bb api GTE /user
+✗ 'GTE' is not a valid HTTP method. Expected one of: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS. Run `bb api --help` for usage.
+(Did you mean GET?)
+
+$ bb api -X GTE /user
+✗ --method must be one of: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+(Did you mean GET?)
+
+$ bb api GET /user /extra
+error: too many arguments for 'api'. Expected 2 arguments but got 3: GET, /user, /extra.
+```
+
 ### Examples
 
 ```bash
@@ -48,11 +72,14 @@ bb api /user
 # Explicit method (equivalent to the above)
 bb api GET /user
 
-# List every pull request, following pagination, using the current repo
+# List every pull request, following pagination, using the current repository
 bb api /repositories/{workspace}/{repo}/pullrequests --paginate
 
 # Create an issue (method inferred as POST because fields are present)
-bb api POST /repositories/my-ws/my-repo/issues -f title=Bug -F priority=3
+bb api /repositories/my-ws/my-repo/issues -f title=Bug -f priority=major
+
+# -F applies gh-style magic typing: true/false/null and numbers become JSON literals
+bb api PUT /repositories/my-ws/my-repo -F is_private=true
 
 # Send a JSON body from a file
 bb api PUT /repositories/my-ws/my-repo/pullrequests/42 --input body.json
@@ -72,19 +99,15 @@ bb api -i /user
 
 ### How fields are sent
 
-- **`GET` / `HEAD`** — `-f`/`-F` fields are appended as a URL query string
+- **`GET` / `HEAD`** — `-f`/`-F` are appended as a URL query string
   (`?key=value&...`).
-- **Other methods** — `-f`/`-F` fields are assembled into a JSON request body.
-- **`--input`** — sends the file (or stdin) contents as the raw body verbatim,
-  and cannot be combined with `-f`/`-F`.
+- **Every other method** — `-f`/`-F` are assembled into a JSON request body.
 - Repeating the same key turns it into an array, matching `gh`.
 
 ### Placeholders
 
-`{workspace}` and `{repo}` in the endpoint are filled from `--workspace` /
-`--repo` or inferred from the current git checkout. Repository context is only
-resolved when a placeholder is actually present, so `bb api /user` works
-anywhere.
+`{workspace}` and `{repo}` are resolved only when they actually appear in the
+path, so `bb api /user` works outside a checkout.
 
 ```bash
 # Inside a Bitbucket checkout, these resolve automatically:
@@ -97,10 +120,10 @@ bb api -w my-ws -r my-repo /repositories/{workspace}/{repo}/commits
 ### Output
 
 The response body is printed to stdout. JSON responses are pretty-printed and
-respect the global `--json [fields]` projection and `--jq` filtering; non-JSON
+respect the global `--json [fields]` projection and `--jq` filtering. Non-JSON
 responses (e.g. raw diffs) are printed verbatim, and `--json`/`--jq` are inert
 on them. An empty response body (e.g. a `HEAD` or `204`) prints nothing in text
-mode, and `{}` under `--json` so a downstream `jq` never sees zero bytes.
+mode, and `{}` under `--json`, so a downstream `jq` never sees zero bytes.
 
 ```bash
 bb api /user
@@ -115,11 +138,21 @@ bb api /user
 }
 ```
 
-<Aside type="note">
-  Unlike list/table commands, `bb api` output is already JSON, so `--jq` works
-  on its own — you do **not** need to pass `--json` as well:
-  `bb api /repositories/my-ws --jq '.values[].name'`.
-</Aside>
+`bb api` is the only command where `--jq` works without `--json`; everywhere
+else a bare `--jq` fails with `✗ --jq requires --json`.
+
+On a paginated endpoint, `--json <fields>` unwraps the `values` array and drops
+the envelope (`pagelen`, `size`, `next`), returning a bare array of projected
+objects. Projection runs before `--jq`, so once you pass `--json <fields>` the
+expression sees that flat array — use `.[]`, not `.values[]`.
+
+```bash
+# Envelope intact
+bb api /repositories/my-ws --jq '.values[].name'
+
+# Projected and unwrapped
+bb api /repositories/my-ws --json name --jq '.[].name'
+```
 
 ### Notes
 
@@ -130,6 +163,13 @@ bb api /user
   when they point at `api.bitbucket.org`. This prevents the CLI from sending
   your token to a foreign host. Pagination cursors (which are absolute
   `api.bitbucket.org` URLs) are followed safely.
+- **`--paginate` degrades instead of erroring.** On a non-`GET`/`HEAD` request
+  it prints `--paginate only applies to GET/HEAD requests; ignoring it.` on
+  stderr and sends the request unpaginated. If the first response has no
+  `values` array — a single resource rather than a collection — it prints
+  `--paginate: response has no "values" array; returning the first page only.`
+  and returns page 1. Both warnings are suppressed under `--json`. Combined
+  with `-i`, the status line and headers printed are the first page's.
 - **Errors surface the API response.** On a non-2xx status, the API's error
   body is printed and the command exits non-zero. With `--json`, the error
   payload (including `statusCode` and `response`) is emitted as structured JSON.

--- a/docs/src/content/docs/commands/auth.mdx
+++ b/docs/src/content/docs/commands/auth.mdx
@@ -5,7 +5,7 @@ description: Authentication commands reference
 
 Manage authentication with Bitbucket.
 
-Global options available on all auth commands: `--json`, `--no-color`.
+Global options available on all auth commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--locale <locale>`. See [Global flags](/reference/global-flags/) for the full list.
 
 ## `bb auth login`
 
@@ -22,10 +22,9 @@ bb auth login [options]
 | `-u, --username <username>` | Bitbucket username (implies API token auth) |
 | `-p, --password <password>` | Bitbucket API token (implies API token auth) |
 | `--with-token` | Read the API token from stdin so it never appears in shell history or process args (implies API token auth) |
-| `--app-password` | Use API token authentication instead of OAuth (legacy flag name — uses API tokens, not app passwords) |
+| `--app-password` | Use API token authentication instead of OAuth (see the note below) |
 | `--client-id <clientId>` | Custom OAuth consumer client ID |
 | `--client-secret <clientSecret>` | Custom OAuth consumer client secret |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -53,9 +52,16 @@ bb auth login
 read from stdin, so it never lands in your shell history or in process-listing
 tools like `ps`. It pairs well with secret managers, e.g.
 `my-secret-tool get bb-token | bb auth login -u myuser --with-token`.
+
+Two rules: `--with-token` cannot be combined with `-p/--password` (hard error,
+`VALIDATION_INVALID`), and it reads all of stdin and trims it, so an empty
+stdin fails instead of prompting — `bb auth login -u me --with-token < /dev/null`
+errors with `No API token found on stdin.`
 :::
 
-### How It Works
+### How it works
+
+OAuth is used unless any of `--app-password`, `--with-token`, `-u`, `-p`, or the `BB_API_TOKEN` environment variable is present.
 
 **OAuth flow (default):**
 
@@ -73,7 +79,7 @@ headless hosts (SSH sessions, containers, CI) use API token auth — ideally
 `--with-token` — instead.
 :::
 
-**API token flow (with `-u`/`-p`, `--with-token`, or `--app-password`):**
+**API token flow:**
 
 1. You provide your Bitbucket username and API token (token via `-p`, piped to
    stdin with `--with-token`, or the `BB_API_TOKEN` environment variable)
@@ -81,36 +87,21 @@ headless hosts (SSH sessions, containers, CI) use API token auth — ideally
 3. The CLI verifies the credentials by fetching your user information
 4. If verification fails, credentials are not saved
 
-### Auth Method Detection
-
-The CLI determines which flow to use based on flags:
-
-| Condition | Auth Method |
-|-----------|------------|
-| No flags | OAuth |
-| `-u` or `-p` provided | API Token |
-| `--with-token` flag | API Token (read from stdin) |
-| `--app-password` flag | API Token |
-| `BB_API_TOKEN` env var set | API Token |
-
 :::note
-The `--app-password` flag is a legacy name. It triggers API token authentication, not Bitbucket app passwords (which are deprecated). Prefer using `-u`/`-p` flags or environment variables instead.
+The `--app-password` flag is a legacy name. It triggers API token authentication, not Bitbucket app passwords (which are deprecated). Prefer `-u`/`-p`, `--with-token`, or the environment variables.
 :::
 
-### Required Scopes (API Token)
+### Required scopes (API token)
 
-When using API tokens, your token needs these scopes:
+`bb auth login` and `bb auth status` need `read:user:bitbucket` to verify your identity, and so does `bb pr list --mine` (it resolves your account UUID).
 
-- `read:user:bitbucket` — verify your identity
-- `read:repository:bitbucket` — list and view repositories
-- `write:repository:bitbucket` — create repositories
-- `admin:repository:bitbucket` — delete repositories (optional)
-- `read:pullrequest:bitbucket` — list and view pull requests
-- `write:pullrequest:bitbucket` — create, edit, merge, approve, decline pull requests
+Repository and pull request commands need `read:repository:bitbucket` and `read:pullrequest:bitbucket`, plus the matching `write:` scopes to create, edit, merge, approve, or decline. Creating a repository needs the admin scope (legacy `repository:admin`) and deleting one needs the delete scope (legacy `repository:delete`); Atlassian publishes these as `admin:repository:bitbucket` and `delete:repository:bitbucket`.
 
-OAuth scopes are requested automatically during authorization.
+Everything else — pipelines, issues, snippets, projects — needs its own scope. See [Token scopes](/reference/token-scopes/) for the per-command table.
 
-See the [Authentication guide](/getting-started/authentication/) for detailed setup instructions.
+OAuth logins request a fixed scope set: `account repository repository:admin pullrequest pullrequest:write`. Commands outside repositories and pull requests (`bb pipeline`, `bb issue`, `bb snippet`, `bb project`) are not covered, and neither is `bb repo delete`. Use an API token with the matching scopes for those.
+
+See the [Authentication guide](/getting-started/authentication/) for setup instructions.
 
 ---
 
@@ -122,24 +113,23 @@ Log out of Bitbucket and remove stored credentials.
 bb auth logout [options]
 ```
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
 bb auth logout
+
+# Machine-readable result
+bb auth logout --json
 ```
 
-### What Gets Removed
+### What gets removed
 
 - **OAuth**: Revokes the token on Bitbucket's side, then removes `oauthAccessToken`, `oauthRefreshToken`, `oauthExpiresAt`, `authMethod`, and custom OAuth consumer credentials from the config file.
 - **API Token**: Removes `username` and `apiToken` from the config file.
 
 Other settings like `defaultWorkspace`, `skipVersionCheck`, and `versionCheckInterval` are preserved.
+
+If revocation fails, the CLI still clears local credentials and warns you to revoke the token manually (`revokeFailed: true` in `--json`).
 
 ---
 
@@ -150,12 +140,6 @@ Show current authentication status and account information.
 ```bash
 bb auth status [options]
 ```
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -175,8 +159,9 @@ When authenticated with OAuth:
   Authentication: OAuth
   Username: myuser
   Display name: My Name
-  Account ID: 123456789
+  Account ID: 712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f
   Token expires: in 1h 42m
+  Default workspace: myworkspace
 ```
 
 When authenticated with API token:
@@ -185,14 +170,21 @@ When authenticated with API token:
   Authentication: API Token
   Username: myuser
   Display name: My Name
-  Account ID: 123456789
+  Account ID: 712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f
+  Default workspace: myworkspace
 ```
+
+The `Default workspace:` line appears only when `defaultWorkspace` is set. On an OAuth login with a stale token, `Token expires:` reads `expired (will refresh automatically)`.
 
 When not authenticated:
 ```
 ℹ Not logged in
 Run bb auth login to authenticate.
 ```
+
+:::caution
+`bb auth status --json` reports `method: "basic"` for API-token logins, while `bb auth login --json` reports `method: "api_token"` for the same credentials. In scripts, match on `!== "oauth"` rather than on either literal. See [JSON output](/reference/json-output/) for the full payloads.
+:::
 
 ---
 
@@ -204,17 +196,20 @@ Print the current access token.
 bb auth token [options]
 ```
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
 # Print the token
 bb auth token
+
+# Copy it to the clipboard
+bb auth token | pbcopy
+
+# Use it against the raw API (OAuth login — bearer token)
+curl -H "Authorization: Bearer $(bb auth token)" https://api.bitbucket.org/2.0/user
+
+# Use it against the raw API (API token login — base64 basic credentials)
+curl -H "Authorization: Basic $(bb auth token)" https://api.bitbucket.org/2.0/user
 
 # Get token as JSON
 bb auth token --json
@@ -222,16 +217,9 @@ bb auth token --json
 
 ### Output
 
-- **OAuth**: Prints the bearer access token (automatically refreshes if expired).
-- **API Token**: Prints a base64-encoded `username:apiToken` string suitable for HTTP Basic auth headers.
-
-### Use Cases
-
-This is useful for:
-- Debugging authentication issues
-- Using the token with other tools or scripts
-- Verifying token format
+- **OAuth**: Prints the bearer access token (automatically refreshes if expired). `--json` reports `type: "bearer"`.
+- **API Token**: Prints a base64-encoded `username:apiToken` string suitable for HTTP Basic auth headers. `--json` reports `type: "basic"`.
 
 :::caution
-Keep your token secure! Anyone with this token can access your Bitbucket account with the scopes you've granted.
+Anyone holding this token has your Bitbucket access, within the scopes you granted. Don't paste it into logs, CI output, or issue reports.
 :::

--- a/docs/src/content/docs/commands/browse.mdx
+++ b/docs/src/content/docs/commands/browse.mdx
@@ -3,17 +3,15 @@ title: Browse Command — Open Bitbucket Pages from the Terminal
 description: Open Bitbucket Cloud web pages — repo home, files, branches, commits, pull requests, pipelines, settings — directly from the CLI, or print the URL for scripts.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
-`bb browse` opens Bitbucket Cloud web pages — repo home, files, branches,
+`bb browse` opens Bitbucket Cloud web pages — repository home, files, branches,
 commits, pull requests, pipelines, settings, and more — in your default
 browser. Mirrors `gh browse`.
 
 It also doubles as a script-friendly URL builder: pass `--no-browser` to
 print the URL instead, or `--json url` for machine-readable output.
 
-Global options: `--json [fields]`, `--jq <expression>`, `--no-color`,
-`-w, --workspace`, `-r, --repo`.
+It accepts the [global flags](/reference/global-flags/), including
+`--json [fields]`, `--jq <expression>`, `-w, --workspace`, and `-r, --repo`.
 
 ## `bb browse`
 
@@ -113,13 +111,16 @@ bb browse --pr 217 --json url
   Outside a git checkout (when using `--workspace`/`--repo` overrides), it
   falls back to the literal `HEAD` segment, which Bitbucket resolves
   server-side to the repository's default branch.
-- **URL encoding.** Workspace and repo slugs, branch names, and path
+- **URL encoding.** Workspace and repository slugs, branch names, and path
   segments are URL-encoded individually, so branches with slashes
   (`feature/foo`) and paths or names with spaces still produce valid URLs.
   Path separators (`/` between segments) are preserved.
-- **No API call required for most variants.** `bb browse` is primarily a
-  URL-construction command; only `--commit` (no SHA) makes a local
-  `git rev-parse HEAD` call.
+- **No API calls.** `bb browse` never talks to the Bitbucket API — it only
+  builds URLs. It does shell out to git: to resolve workspace and repository
+  from your remote (skipped only when you pass both `-w` and `-r`), and to
+  resolve a ref — `git rev-parse --abbrev-ref HEAD` for a path target without
+  `--branch`, `git rev-parse HEAD` for `--commit` with no SHA. `--branch <name>`,
+  an explicit SHA, and the resource flags need no extra git call.
 - **`--json` does not open the browser.** Either output mode (JSON or
   `--no-browser`) suppresses the open action, so scripts can capture the
   URL deterministically.
@@ -143,7 +144,9 @@ With `--json`:
 }
 ```
 
-Combine with `--jq` to pluck just the URL string:
+`--jq` output is JSON-quoted (the embedded jq has no `-r`), so for a bare,
+pipe-ready URL use `--no-browser` as shown above. Reach for `--jq` when you are
+feeding a JSON consumer:
 
 ```bash
 bb browse --pr 217 --json url --jq '.url'
@@ -154,6 +157,6 @@ bb browse --pr 217 --json url --jq '.url'
 - [`bb pr diff --web`](/commands/pr/diff-and-checkout/) — open the PR
   diff page directly in the browser.
 - [Repository Context](/guides/repository-context/) — how the CLI infers
-  workspace and repo from your current directory.
+  workspace and repository from your current directory.
 - [Scripting & Automation](/guides/scripting/) — capture URLs from
   `bb browse` to feed other tools.

--- a/docs/src/content/docs/commands/commit.mdx
+++ b/docs/src/content/docs/commands/commit.mdx
@@ -10,11 +10,13 @@ Commit commands operate at **repository** scope. Run them inside a cloned
 Bitbucket repository, or pass `-w, --workspace <workspace>` and
 `-r, --repo <repo>` explicitly.
 
-Global options available on all commit commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all commit commands: `--json [fields]`,
+`--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`,
+`--locale <locale>`, `-w, --workspace`, `-r, --repo`.
 
-Commit SHAs are accepted as raw strings: full 40-character hashes and
-abbreviated prefixes (e.g. `abc1234`) both pass through to the API unchanged,
-so humans and scripts can use whichever they have.
+A `<sha>` is a full 40-character hash or any abbreviated prefix (`abc1234`).
+`--json` output is wrapped in an envelope keyed by `workspace` and `repoSlug`;
+the `# →` comments below show each shape.
 
 ---
 
@@ -30,12 +32,9 @@ bb commit list [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--ref <ref>` | Branch, tag, or commit SHA to list history for (default: current git branch) |
 | `--limit <number>` | Maximum number of commits (default: 25) |
 | `--all` | List all commits (overrides `--limit`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -46,7 +45,7 @@ bb commit list
 bb commit list --ref main
 bb commit list --ref v1.0.0 --limit 50
 
-# Stable JSON envelope: { workspace, repoSlug, [ref], count, commits }
+# → { workspace, repoSlug, [ref], count, commits }
 bb commit list --json
 
 # Hashes only, via built-in --jq
@@ -59,36 +58,31 @@ bb commit list --json --jq '.commits[].hash'
   run inside a git repository. When branch detection fails (outside a git
   repository, detached HEAD), it falls back to the repository's default
   commit listing instead of erroring.
-- The table shows the short hash (7 characters), the first line of the commit
-  message (truncated to 60 characters; disable with `--no-truncate`), the
-  author (Bitbucket display name, or the name parsed from the raw git author),
-  and the commit date.
-- `--limit` is enforced across paginated responses; a hint appears when
-  results were capped (suppressed with `--json`).
-- An unknown `--ref` returns an actionable "Ref `<ref>` not found" error.
+- Columns: short hash (7 characters), first line of the commit message
+  (truncated to 60 characters; disable with `--no-truncate`), author (Bitbucket
+  display name, or the name parsed from the raw git author), and commit date.
+- `--limit` is enforced across paginated responses. When results are capped the
+  CLI prints `Showing 25 commits. Use --limit <n> or --all to see more.`
+  (suppressed with `--json`).
+- An unknown `--ref` returns
+  `Ref 'no-such-branch' not found in acme/api. Pass --ref <branch|tag|sha> to choose a different ref.`
 
 ---
 
 ## `bb commit view`
 
-View the full details of a single commit.
+View the full details of a single commit. `<sha>` is a full or abbreviated hash.
 
 ```bash
 bb commit view <sha> [options]
 ```
-
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `sha` | Commit hash (full or abbreviated, e.g. `abc1234`) |
 
 ### Examples
 
 ```bash
 bb commit view abc1234
 
-# Stable JSON envelope: { workspace, repoSlug, commit }
+# → { workspace, repoSlug, commit }
 bb commit view abc1234 --json
 
 # Raw author string of the commit
@@ -102,7 +96,7 @@ bb commit view abc1234 --json --jq '.commit.author.raw'
   message including the body.
 - In `--json` mode, `commit` is the raw commit resource as returned by the
   Bitbucket API (hash, author, parents, message, links, ...).
-- A `404` returns an actionable "Commit `<sha>` not found" error.
+- An unknown sha returns `Commit abc1234 not found in acme/api.`
 
 ---
 

--- a/docs/src/content/docs/commands/completion.mdx
+++ b/docs/src/content/docs/commands/completion.mdx
@@ -1,112 +1,118 @@
 ---
 title: Completion Commands
-description: Shell completion utilities reference
+description: Install or remove bb tab completion for bash, zsh, and fish, and see exactly what the completer suggests.
 ---
 
-Enable tab completion for bash, zsh, or fish shells.
+Tab completion for bash, zsh, and fish.
 
-Global options available on completion commands: `--json`, `--no-color`.
-
-## Supported Shells
-
-| Shell | Config File |
-|-------|-------------|
-| bash | `~/.bashrc` |
-| zsh | `~/.zshrc` |
-| fish | `~/.config/fish/config.fish` |
+Global options: every global flag is accepted here (see
+[Global Flags](/reference/global-flags/)). Only `--json`, `--no-color` and
+`--no-unicode` change anything — `--jq` needs `--json`, and
+`--no-truncate`/`--locale`/`-w`/`-r` have no output to affect.
 
 ## `bb completion install`
-
-Install shell completions for your current shell.
 
 ```bash
 bb completion install [options]
 ```
 
-### Options
+This command is interactive. It asks two questions:
 
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
+1. **"Which Shell do you use ?"** — pick `bash`, `zsh`, or `fish`. The default
+   is `bash`; the prompt does **not** preselect your current shell.
+2. **"We will install completion to `<file>`, is it ok ?"** — confirm, or
+   decline and supply an absolute path of your own.
 
-The installer auto-detects your shell and adds the necessary configuration.
+It then appends a source line to that file and writes the completion script
+under `~/.config/tabtab/`.
 
-### Post-Installation
+| Shell | Config file offered |
+|-------|---------------------|
+| bash | `~/.bashrc` |
+| zsh | `~/.zshrc` |
+| fish | `~/.config/fish/config.fish` |
 
-After installing, restart your shell or source your config:
+Because it prompts, `bb completion install` is not scriptable. It blocks on the
+shell question in CI, `--json` included.
+
+A failure throws error code `9001`
+([`COMPLETION_INSTALL_FAILED`](/reference/error-codes/)) with the message
+`Failed to install completions: <error>`, and the command exits `1`.
+
+### After installing
+
+Restart your shell, or source the file you chose:
 
 ```bash
-# Bash
-source ~/.bashrc
-
-# Zsh
-source ~/.zshrc
-
-# Fish
-source ~/.config/fish/config.fish
+source ~/.bashrc                    # bash
+source ~/.zshrc                     # zsh
+source ~/.config/fish/config.fish   # fish
 ```
 
-### Examples
+Then check it works:
 
 ```bash
-# Install completions
-bb completion install
-
-# Install with JSON output
-bb completion install --json
-
-# Test it works
-bb <Tab>        # Shows: auth, repo, pr, snippet, browse, api, config, completion
-bb repo <Tab>   # Shows: clone, create, list, view, delete, default-reviewers
+bb <Tab>        # every top-level command (the root flags are offered too)
+bb repo <Tab>   # clone, create, list, view, delete, default-reviewers
 ```
 
----
+### JSON output
+
+`--json` replaces both the success line and the "Restart your shell…" follow-up
+with a single object:
+
+```json
+{
+  "success": true,
+  "shellCompletion": {
+    "command": "bb",
+    "installed": true
+  }
+}
+```
 
 ## `bb completion uninstall`
-
-Remove shell completions.
 
 ```bash
 bb completion uninstall [options]
 ```
 
-### Options
+No prompt. It deletes `~/.config/tabtab/bb.<shell>`, removes the `bb` lines from
+`~/.config/tabtab/__tabtab.<shell>`, and drops the source line from your shell
+config once no other package is left in that file. Both `<shell>` and that
+config file come from `$SHELL` — your login shell, not the shell you happen to
+be typing in, and not the shell you picked at the install prompt. If they
+disagree, the source line is left behind and you have to delete it by hand.
+On success it prints `✓ Shell completions uninstalled successfully!`; with
+`--json` you get the same envelope as install, with `"installed": false`.
 
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
+Most uninstall failures are swallowed by tabtab: it prints
+`ERROR while uninstalling <error>` and resolves anyway, so the command still
+reports success and exits `0`. Error code `9002`
+([`COMPLETION_UNINSTALL_FAILED`](/reference/error-codes/)) only fires for
+failures thrown outside that handler.
 
-### Examples
+## What gets completed
 
-```bash
-# Remove completions
-bb completion uninstall
+Completions are generated from the live command tree, so they always match the
+commands and flags the CLI actually ships.
 
-# Remove completions with JSON output
-bb completion uninstall --json
-```
+- **Commands and subcommands** — every command in the tree, at every depth.
+- **Options** — every flag on the command plus the inherited globals (`--json`,
+  `--jq`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale`,
+  `--workspace`, `--repo`, `--help`), plus `--version` on the bare `bb`. Only
+  long forms are suggested; short aliases like `-w` still work but are never
+  offered.
+- **Flag values** for options with a fixed set of choices.
 
----
-
-## What Gets Completed
-
-Completions are derived from the live command tree, so they always reflect the
-commands and flags the CLI actually ships — there is no separate list to fall
-out of date.
-
-Tab completion works for:
-
-- **Commands**: `auth`, `repo`, `pr`, `snippet`, `browse`, `api`, `config`, `completion`
-- **Subcommands**: `login`, `clone`, `create`, `list`, etc.
-- **Options**: `--json`, `--no-color`, `--workspace`, `--repo`, `--help`
-- **Flag values** for enum options (see below)
-
-`-w` is reserved as the global shorthand for `--workspace`.
+Commands and flags carry their help text as a completion description. zsh and
+fish display it alongside the name; bash shows bare names. Enum **values** never
+carry a description, so they are bare in every shell.
 
 ### Flag-value completion
 
-When a flag accepts a fixed set of values, completing right after it suggests
-the valid values:
+Completing right after a flag that takes a fixed set of values suggests those
+values, and nothing else:
 
 ```bash
 $ bb pr merge 42 --strategy <Tab>
@@ -127,10 +133,7 @@ GET   POST     PUT  PATCH
 HEAD  OPTIONS  DELETE
 ```
 
-In zsh and fish, each completion is shown with its description; bash shows the
-bare names.
-
-### Example Session
+### Example session
 
 ```bash
 $ bb pr<Tab>
@@ -142,8 +145,17 @@ diff      edit      list      merge     ready     reviewers view
 
 $ bb pr create --<Tab>
 # the command's own flags, plus inherited global flags:
---title       --body                  --source       --destination
---draft       --close-source-branch   --reviewer     --default-reviewers
---json        --jq                    --workspace    --repo
---no-color    --no-unicode            --no-truncate  --locale  --help
+--title                 --body          --source       --destination
+--close-source-branch   --draft         --reviewer     --default-reviewers
+--no-default-reviewers
+--json                  --jq            --no-color     --no-unicode
+--no-truncate           --locale        --workspace    --repo         --help
 ```
+
+### Related
+
+- [Global Flags](/reference/global-flags/) — the flags the completer offers on
+  every command.
+- [Error Codes](/reference/error-codes/) — `9001` and `9002` in context.
+- [Scripting & Automation](/guides/scripting/) — `--json` envelopes and exit
+  codes for the non-interactive commands.

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -5,37 +5,38 @@ description: Configuration commands reference
 
 Manage CLI configuration settings.
 
-Global options available on all config commands: `--json`, `--no-color`.
+Global options available on all config commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--locale <locale>`. See [Global flags](/reference/global-flags/) for the full list.
 
-## Configuration File
+## Configuration file
 
 Configuration is stored in a JSON file at:
 
-- **Linux/macOS**: `~/.config/bb/config.json`
-- **Windows**: `%APPDATA%\bb\config.json`
+- **Linux/macOS**: `~/.config/bb/config.json` (fixed path — `XDG_CONFIG_HOME` is not read)
+- **Windows**: `%APPDATA%\bb\config.json`, falling back to `%USERPROFILE%\AppData\Roaming\bb\config.json`
 
-## Available Settings
+On Linux and macOS the CLI creates the directory `0700` and the file `0600`, and refuses to run if either grants group or other access. See [Configuration file](/reference/configuration/) for the permission rules and how to fix them.
 
-The configuration file stores your CLI settings and authentication credentials.
+## Available settings
 
-| Key | Description |
-|-----|-------------|
-| `username` | Bitbucket username (set during `auth login`) |
-| `apiToken` | Bitbucket API token (set during `auth login`, masked in output) |
-| `defaultWorkspace` | Default workspace for commands |
-| `skipVersionCheck` | Disable update notifications (default: false) |
-| `versionCheckInterval` | Days between update checks (default: 1) |
-| `prCreateIncludeDefaultReviewers` | Auto-add the repo's default reviewers on `bb pr create` (default: false) |
-| `lastVersionCheck` | Timestamp of the last update check. Auto-managed by the CLI; read-only from a user's perspective (do not set manually) |
+| Key | `bb config get` | `bb config set` | Description |
+|-----|-----------------|-----------------|-------------|
+| `defaultWorkspace` | yes | yes | Default workspace for commands |
+| `skipVersionCheck` | yes | yes | Disable update notifications (default: false) |
+| `versionCheckInterval` | yes | yes | Days between update checks (default: 1) |
+| `prCreateIncludeDefaultReviewers` | yes | yes | Auto-add the repository's default reviewers on `bb pr create` (default: false) |
+| `username` | yes | no — use `bb auth login` | Bitbucket username |
+| `apiToken` | no — use `bb auth token` | no — use `bb auth login` | Bitbucket API token (masked in `bb config list`) |
+| `lastVersionCheck` | no | no | Timestamp of the last update check. Auto-managed; `bb config get lastVersionCheck` fails with `Unknown config key` |
 
-### Configuration File Format
+`bb auth login` also writes `authMethod` — `basic` for API tokens, `oauth` for OAuth — and, after an OAuth login, the `oauth*` keys (`oauthAccessToken`, `oauthRefreshToken`, `oauthExpiresAt`, and custom consumer credentials). Only `bb auth login` and `bb auth logout` touch those keys; see [Configuration file](/reference/configuration/) for the full schema.
 
-The config file is stored as JSON:
+### Configuration file format
 
 ```json
 {
+  "authMethod": "basic",
   "username": "myuser",
-  "apiToken": "***",
+  "apiToken": "ATBB_xxxxxxxxxxxxxxxxxxxx",
   "defaultWorkspace": "myworkspace",
   "skipVersionCheck": false,
   "versionCheckInterval": 1,
@@ -43,23 +44,17 @@ The config file is stored as JSON:
 }
 ```
 
-:::tip
-You typically won't edit this file manually. Use `bb config set` to change settings and `bb auth login` to set credentials.
-:::
+Don't edit this file by hand. Use `bb config set` for settings and `bb auth login` for credentials.
 
 ## `bb config get`
 
-Get a configuration value.
+Print a configuration value.
 
 ```bash
 bb config get <key>
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `key` | Configuration key to retrieve |
+Readable keys: `username`, `defaultWorkspace`, `skipVersionCheck`, `versionCheckInterval`, `prCreateIncludeDefaultReviewers`. Any other key exits `1` with `Unknown config key '<key>'`, except `apiToken`, which points you at `bb auth token`.
 
 ### Examples
 
@@ -74,12 +69,6 @@ bb config get username
 bb config get defaultWorkspace --json
 ```
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
-
 ---
 
 ## `bb config set`
@@ -90,22 +79,13 @@ Set a configuration value.
 bb config set <key> <value>
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `key` | Configuration key to set |
-| `value` | Value to set (parsed by key type) |
-
-### Typed Value Parsing
-
-`bb config set` validates and stores typed values for known typed keys:
+Settable keys, and the values each accepts:
 
 | Key | Accepted values | Stored type |
 |-----|-----------------|-------------|
 | `defaultWorkspace` | Any string | string |
 | `skipVersionCheck` | `true` or `false` | boolean |
-| `versionCheckInterval` | Positive integer (`>= 1`) | number |
+| `versionCheckInterval` | Positive integer (`>= 1`), in days | number |
 | `prCreateIncludeDefaultReviewers` | `true` or `false` | boolean |
 
 ### Examples
@@ -120,27 +100,34 @@ bb config set skipVersionCheck true
 # Check for updates weekly instead of daily
 bb config set versionCheckInterval 7
 
-# Invalid values are rejected
-bb config set skipVersionCheck maybe
-
 # Get output as JSON
 bb config set defaultWorkspace myworkspace --json
 ```
 
-Example JSON output for typed keys:
+Values that don't match the key's type are rejected and exit `1`:
+
+```bash
+bb config set skipVersionCheck maybe
+```
+
+```
+✗ Invalid value for 'skipVersionCheck'. Expected 'true' or 'false'.
+```
+
+JSON output for typed keys:
 
 ```json
 { "success": true, "key": "skipVersionCheck", "value": true }
 ```
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
-
 :::caution
-Use `bb auth login` to set credentials instead of manually setting `username` and `apiToken`.
+`bb config set username …` and `bb config set apiToken …` are rejected outright:
+
+```
+✗ Cannot set 'username' directly. Use 'bb auth login' to configure authentication.
+```
+
+Use `bb auth login` for credentials.
 :::
 
 ---
@@ -153,12 +140,6 @@ List all configuration values.
 bb config list [options]
 ```
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
@@ -167,6 +148,9 @@ bb config list
 
 # List as JSON for scripting
 bb config list --json
+
+# Read one value out of the JSON
+bb config list --json --jq '.config.defaultWorkspace'
 ```
 
 ### Output
@@ -175,13 +159,15 @@ bb config list --json
 Config file: /Users/you/.config/bb/config.json
 
 KEY               VALUE
-----------------  ------------------------
+----------------  -----------
 username          myuser
-apiToken          ********
 defaultWorkspace  myworkspace
+apiToken          ********
 skipVersionCheck  false
+
+Settable keys: defaultWorkspace, skipVersionCheck, versionCheckInterval, prCreateIncludeDefaultReviewers. Run 'bb config set --help' for details.
 ```
 
-:::note
-The `apiToken` value is always masked for security.
-:::
+With an empty config file the table is replaced by `ℹ No configuration set`; the `Config file:` line and the `Settable keys:` footer still print.
+
+`apiToken` is always masked. OAuth credentials are omitted from `bb config list` entirely — after an OAuth login the listing shows no auth rows at all.

--- a/docs/src/content/docs/commands/issue.mdx
+++ b/docs/src/content/docs/commands/issue.mdx
@@ -12,21 +12,16 @@ Issue commands operate at **repository** scope. Run them inside a cloned
 Bitbucket repository, or pass `-w, --workspace <workspace>` and
 `-r, --repo <repo>` explicitly.
 
-Global options available on all issue commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all issue commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo`. See [Global flags](/reference/global-flags/) for the full list. The per-command tables below list only command-specific options.
 
 <Aside type="caution">
   Bitbucket's issue tracker is **opt-in per repository** and disabled by
-  default — many teams use Jira instead. When the tracker is disabled, the
-  Bitbucket API answers `404` on every issues endpoint, so `bb issue list` and
-  `bb issue create` fail with: *"This repository's issue tracker is disabled
-  (or the repo was not found). Enable it under Repository settings → Issue
-  tracker on Bitbucket, or check `--workspace`/`--repo`. Many teams use Jira
-  instead — see the docs."* Enable the tracker under **Repository settings →
-  Issue tracker** before using these commands.
+  default. When it is off, every issues endpoint answers `404` and
+  `bb issue list` / `bb issue create` report: *"This repository's issue tracker
+  is disabled (or the repo was not found). Enable it under Repository settings →
+  Issue tracker on Bitbucket, or check `--workspace`/`--repo`. Many teams use
+  Jira instead — see the docs."*
 </Aside>
-
-Issue IDs are accepted as raw numeric strings (e.g. `42`), so humans and
-scripts can pass them straight through.
 
 ---
 
@@ -43,8 +38,6 @@ bb issue list [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--state <state>` | Filter by exact state: `submitted`, `new`, `open`, `resolved`, `on-hold`, `invalid`, `duplicate`, `wontfix`, or `closed` |
 | `--kind <kind>` | Filter by kind: `bug`, `enhancement`, `proposal`, or `task` |
 | `--assignee <username>` | Filter by assignee username |
@@ -52,7 +45,6 @@ bb issue list [options]
 | `--query <q>` | Raw Bitbucket `q` filter expression (escape hatch) |
 | `--limit <number>` | Maximum number of issues (default: 25) |
 | `--all` | List all issues (overrides `--limit`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -75,14 +67,20 @@ bb issue list --json --jq '.issues[] | select(.priority == "critical") | .id'
 ### Notes
 
 - **Filter composition:** without `--state` or `--query` the command filters on
-  `(state="new" OR state="open")`, mirroring `gh issue list` defaulting to open
-  issues. An explicit `--state` matches exactly (the CLI's `on-hold` maps to
-  the API's `"on hold"`). `--kind`, `--assignee`, and `--reporter` clauses are
-  AND-ed on. `--query` is used verbatim and replaces the default state filter,
-  but is still AND-ed with the other flags.
-- **JSON envelope:** `{ workspace, repoSlug, filters, count, issues }`. The
-  `filters` object echoes the active flags plus the effective `q` expression
-  that was sent to the API.
+  `(state="new" OR state="open")`. An explicit `--state` matches exactly (the
+  CLI's `on-hold` maps to the API's `"on hold"`). `--kind`, `--assignee`, and
+  `--reporter` clauses are AND-ed on.
+- **`--query` grouping:** the expression replaces the default state filter. It
+  is wrapped in parentheses and placed first in the AND-ed clause list, so a
+  top-level `OR` inside it stays correctly grouped against
+  `--kind`/`--assignee`/`--reporter`. The composed expression comes back as
+  `filters.q` in `--json` output.
+- **JSON envelope:** `{ workspace, repoSlug, filters, count, issues }`, where
+  `filters` echoes the active flags plus the effective `q` expression.
+- TITLE is truncated to 50 characters in the table; pass the global
+  `--no-truncate` for full titles (`--json` always carries the full value).
+  UPDATED is formatted with `--locale`/`BB_LOCALE`, falling back to the system
+  locale and then `en-US`.
 - `--limit` is enforced across paginated responses; a hint shows when results
   were capped (suppressed with `--json`).
 
@@ -102,20 +100,12 @@ bb issue view <id> [options]
 |----------|-------------|
 | `id` | Issue ID (e.g. `42`) |
 
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
 bb issue view 42
 
-# Machine-readable
+# Print just the state, for a CI guard
 bb issue view 42 --json --jq '.issue.state'
 ```
 
@@ -124,7 +114,8 @@ bb issue view 42 --json --jq '.issue.state'
 - Human output shows the id, title, state, kind, priority, reporter, assignee,
   created/updated dates, votes, the issue body, and the web URL.
 - **JSON envelope:** `{ workspace, repoSlug, issue }`.
-- A `404` is reported as `Issue #<id> not found`, with a reminder that a
+- A `404` is reported as
+  `Issue #<id> not found in <workspace>/<repo>.`, with a reminder that a
   disabled issue tracker 404s identically.
 
 ---
@@ -141,15 +132,12 @@ bb issue create --title <title> [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-t, --title <title>` | Issue title (**required**) |
 | `-b, --body <text>` | Issue description (Markdown) |
 | `-F, --body-file <file>` | Read the description from a file (mutually exclusive with `--body`) |
 | `--kind <kind>` | `bug`, `enhancement`, `proposal`, or `task` |
 | `--priority <priority>` | `trivial`, `minor`, `major`, `critical`, or `blocker` |
 | `--assignee <username>` | Assign the issue to a user |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -183,21 +171,18 @@ bb issue edit <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `id` | Issue ID |
+| `id` | Issue ID (e.g. `42`) |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-t, --title <title>` | New title |
 | `-b, --body <text>` | New description (replaces the existing body) |
 | `--kind <kind>` | New kind |
 | `--priority <priority>` | New priority |
 | `--assignee <username>` | Reassign to a user |
 | `--state <state>` | New state (`on-hold` for the API's `"on hold"`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -205,7 +190,7 @@ bb issue edit <id> [options]
 bb issue edit 42 --title "Crash on login (Safari only)"
 bb issue edit 42 --state on-hold --priority critical
 
-# Machine-readable
+# Confirm the reassignment landed
 bb issue edit 42 --assignee some.user --json --jq '.issue.assignee.display_name'
 ```
 
@@ -229,16 +214,13 @@ bb issue close <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `id` | Issue ID |
+| `id` | Issue ID (e.g. `42`) |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-c, --comment <text>` | Post this comment before closing |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -246,14 +228,14 @@ bb issue close <id> [options]
 bb issue close 42
 bb issue close 42 --comment "Fixed in 1.4.2"
 
-# Machine-readable
+# Verify the new state
 bb issue close 42 --json --jq '.issue.state'
 ```
 
 ### Notes
 
 - With `--comment`, the comment is posted **before** the state change so it
-  lands while the issue is still open (matching `gh issue close --comment`).
+  lands while the issue is still open.
 - **JSON envelope:** `{ workspace, repoSlug, issue }` with the closed issue.
 
 ---
@@ -270,23 +252,20 @@ bb issue comment <id> --body <text>
 
 | Argument | Description |
 |----------|-------------|
-| `id` | Issue ID |
+| `id` | Issue ID (e.g. `42`) |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-b, --body <text>` | Comment text in Markdown (**required**) |
-| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
 bb issue comment 42 --body "Reproduced on main"
 
-# Machine-readable
+# Capture the new comment id
 bb issue comment 42 --body "Reproduced on main" --json --jq '.comment.id'
 ```
 

--- a/docs/src/content/docs/commands/pipeline.mdx
+++ b/docs/src/content/docs/commands/pipeline.mdx
@@ -3,25 +3,26 @@ title: Pipeline Commands - Run and Inspect Bitbucket Pipelines
 description: Reference for Bitbucket CLI pipeline commands. List, view, trigger, stop, and read logs of Bitbucket Pipelines builds from the command line.
 ---
 
-Manage Bitbucket Pipelines (CI/CD) — list runs, inspect builds and steps,
-trigger pipelines, stop them, and stream step logs.
+Manage Bitbucket Pipelines (CI/CD) — list runs, inspect a run and its steps,
+trigger and stop runs, and read step logs.
 
 Pipeline commands operate at **repository** scope. Run them inside a cloned
 Bitbucket repository, or pass `-w, --workspace <workspace>` and
 `-r, --repo <repo>` explicitly.
 
-Global options available on all pipeline commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all pipeline commands: `--json [fields]`,
+`--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`,
+`--locale <locale>`, `-w, --workspace`, `-r, --repo`.
 
-Pipeline IDs are accepted in two forms everywhere an `<id>` is expected: the
-**build number** you see in the UI (e.g. `42`) or the **pipeline UUID**
-including curly braces (e.g. `{a1b2c3d4-...}`). Both pass through to the API
-unchanged, so humans and scripts can use whichever they have.
+An `<id>` is either the build number from the UI (`42`) or the pipeline UUID
+with braces (`{a1b2c3d4-...}`). `--json` output is wrapped in an envelope keyed
+by `workspace` and `repoSlug`; the `# →` comments below show each shape.
 
 ---
 
 ## `bb pipeline list`
 
-List pipelines for a repository, newest first.
+List pipeline runs, newest first.
 
 ```bash
 bb pipeline list [options]
@@ -31,14 +32,11 @@ bb pipeline list [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--status <status>` | Filter by status: `PARSING`, `PENDING`, `PAUSED`, `HALTED`, `BUILDING`, `ERROR`, `PASSED`, `FAILED`, `STOPPED`, `UNKNOWN` (case-insensitive) |
 | `--branch <branch>` | Filter by target branch |
 | `--sort <attribute>` | Sort attribute: `created_on`, `run_creation_date`, `creator.uuid`; prefix with `-` for descending (default: `-created_on`) |
-| `--limit <number>` | Maximum number of pipelines (default: 25) |
-| `--all` | List all pipelines (overrides `--limit`) |
-| `--json` | Output as JSON |
+| `--limit <number>` | Maximum number of runs (default: 25) |
+| `--all` | List all runs (overrides `--limit`) |
 
 ### Examples
 
@@ -47,7 +45,7 @@ bb pipeline list
 bb pipeline list --status FAILED
 bb pipeline list --branch main --limit 50
 
-# Stable JSON envelope: { workspace, repoSlug, [status], [branch], sort, count, pipelines }
+# → { workspace, repoSlug, [status], [branch], sort, count, pipelines }
 bb pipeline list --json
 
 # Build numbers of recent failures, via built-in --jq
@@ -56,24 +54,34 @@ bb pipeline list --status FAILED --json --jq '.pipelines[].build_number'
 
 ### Notes
 
-- The table shows build number, status (colored), ref, trigger, created date, and duration for completed runs.
-- `--limit` is enforced across paginated responses; a hint appears when results were capped (suppressed with `--json`).
+- Columns: build number, status (colored), ref (truncated to 40 characters;
+  disable with `--no-truncate`), trigger, created date, and duration for
+  completed runs.
+- `--limit` is enforced across paginated responses. When results are capped the
+  CLI prints `Showing 25 pipelines. Use --limit <n> or --all to see more.`
+  (suppressed with `--json`).
+- `--status` is upper-cased before validation, so `failed` and `FAILED` both
+  work. `--sort` is matched case-sensitively.
+- An invalid value lists the allowed ones and, when the input is close to a
+  valid one, suggests it:
+
+  ```text
+  --status must be one of: PARSING, PENDING, PAUSED, HALTED, BUILDING, ERROR, PASSED, FAILED, STOPPED, UNKNOWN
+  (Did you mean FAILED?)
+  ```
+
+  A `--sort` value that differs only in case gets
+  `(Values are case-sensitive — use created_on.)` instead of a suggestion.
 
 ---
 
 ## `bb pipeline view`
 
-View pipeline details and a per-step summary.
+View run details and a per-step summary. `<id>` is a build number or UUID.
 
 ```bash
 bb pipeline view <id> [options]
 ```
-
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pipeline build number (e.g. `42`) or UUID (e.g. `{a1b2c3d4-...}`) |
 
 ### Examples
 
@@ -81,7 +89,7 @@ bb pipeline view <id> [options]
 bb pipeline view 42
 bb pipeline view {a1b2c3d4-0000-0000-0000-000000000000}
 
-# Stable JSON envelope: { workspace, repoSlug, pipeline, steps }
+# → { workspace, repoSlug, pipeline, steps }
 bb pipeline view 42 --json
 
 # Status name of the run
@@ -90,9 +98,13 @@ bb pipeline view 42 --json --jq '.pipeline.state.result.name // .pipeline.state.
 
 ### Notes
 
-- The human view shows number, UUID, status, ref, trigger, creator, created/completed timestamps, duration, and a step table (name, status, duration).
-- The step table and the JSON `steps` array are complete even on large pipelines — the CLI follows the steps endpoint's pagination.
-- A `404` returns an actionable "Pipeline `<id>` not found" error.
+- The human view shows number, UUID, status, ref, the custom pipeline selector
+  when the run used one (`Pipeline:`), trigger, creator, created/completed
+  timestamps, duration, and a step table (index, name, status, duration).
+- The step index is the value you pass to `bb pipeline logs --step`.
+- The step table and the JSON `steps` array are complete even on large runs —
+  the CLI follows the steps endpoint's pagination.
+- An unknown id returns `Pipeline 42 not found in acme/api.`
 
 ---
 
@@ -108,13 +120,10 @@ bb pipeline run [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-b, --branch <branch>` | Branch to run on (default: current git branch) |
 | `--commit <hash>` | Run against a specific commit on the branch |
 | `-p, --pipeline <name>` | Custom pipeline definition from `bitbucket-pipelines.yml` |
 | `--var <key=value...>` | Pipeline variable; repeatable, value may contain `=` |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -126,90 +135,96 @@ bb pipeline run --branch main
 bb pipeline run --pipeline deploy-prod --var ENV=prod --var DRY_RUN=false
 bb pipeline run --branch main --commit abc123def456
 
-# Stable JSON envelope: { workspace, repoSlug, pipeline }; grab the build number
+# → { workspace, repoSlug, pipeline }; grab the build number
 bb pipeline run --branch main --json --jq '.pipeline.build_number'
 ```
 
 ### Notes
 
 - Outside a git repository, `--branch` is required (the error tells you so).
-- `--pipeline <name>` selects a `custom:` pipeline defined in `bitbucket-pipelines.yml`.
-- Variables are sent unsecured; secured variables must be configured in repository settings.
-- On success the CLI prints the build number plus ready-to-paste `bb pipeline view` / `bb pipeline logs` commands.
+- `--pipeline <name>` selects a `custom:` pipeline defined in
+  `bitbucket-pipelines.yml`.
+- Variables are sent unsecured; secured variables must be configured in
+  repository settings.
+- On success the CLI prints the build number plus ready-to-paste
+  `bb pipeline view` / `bb pipeline logs` commands.
 
 ---
 
 ## `bb pipeline stop`
 
-Stop a running pipeline.
+Stop a running pipeline. `<id>` is a build number or UUID.
 
 ```bash
 bb pipeline stop <id> [options]
 ```
-
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pipeline build number or UUID |
 
 ### Examples
 
 ```bash
 bb pipeline stop 42
 
-# Stable JSON envelope: { workspace, repoSlug, pipelineId, stopped }
+# → { workspace, repoSlug, pipelineId, stopped }
 bb pipeline stop 42 --json --jq '.stopped'
 ```
 
 ### Notes
 
-- No `--yes` confirmation is required: stopping CI is reversible — rerun with `bb pipeline run`.
+- No `--yes` confirmation is required: stopping CI is reversible — rerun with
+  `bb pipeline run`.
 
 ---
 
 ## `bb pipeline logs`
 
-Print the raw log of a pipeline step.
+Print the raw log of a pipeline step. `<id>` is a build number or UUID.
 
 ```bash
 bb pipeline logs <id> [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pipeline build number or UUID |
-
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-s, --step <uuid-or-index>` | Step to fetch: a step UUID (braces optional) or a 1-based index |
-| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
-# Single-step pipelines need no --step
+# Single-step runs need no --step
 bb pipeline logs 42
 
 bb pipeline logs 42 --step 2
-bb pipeline logs 42 --step {step-uuid}
+bb pipeline logs 42 --step {a1b2c3d4-0000-0000-0000-000000000000}
+bb pipeline logs 42 --step a1b2c3d4-0000-0000-0000-000000000000
 
-# Stable JSON envelope: { workspace, repoSlug, pipelineId, stepUuid, log }
+# → { workspace, repoSlug, pipelineId, stepUuid, log }
 bb pipeline logs 42 --json --jq '.log'
 ```
 
 ### Notes
 
 - With exactly one step, it is selected automatically.
-- With several steps and no `--step`, the CLI lists the steps (with indexes and UUIDs) instead of guessing; in `--json` mode it returns `{ workspace, repoSlug, pipelineId, count, steps }` so scripts and agents can pick a step UUID and call again.
-- Every step is selectable even on large pipelines — the CLI follows the steps endpoint's pagination, so indexes and UUIDs beyond the API's default page size of 10 work.
-- The log is printed verbatim to stdout, so it pipes cleanly into `grep`, `less`, or a file.
+- With several steps and no `--step`, the CLI lists the steps (index, name,
+  status, UUID) instead of guessing. With `--json` it returns
+  `{ workspace, repoSlug, pipelineId, count, steps }` so scripts and agents can
+  pick a step UUID and call again.
+- Every step is selectable even on large runs — the CLI follows the steps
+  endpoint's pagination, so indexes and UUIDs beyond the API's default page
+  size of 10 work.
+- The log is printed verbatim to stdout, so it pipes cleanly into `grep`,
+  `less`, or a file.
+- Four failure modes — a queued run with no steps yet, an out-of-range `--step`
+  index, a `--step` UUID that matches nothing, and a step that has produced no
+  log yet — each get their own message, in that order:
+
+  ```text
+  Pipeline 42 has no steps yet. It may still be queued — check with `bb pipeline view 42`.
+  --step index 9 is out of range; the pipeline has 3 steps.
+  No step matching 'abc' found. Available steps: 1 ({uuid-1}), 2 ({uuid-2}).
+  No log found for step {uuid-2} of pipeline 42. The step may not have started yet.
+  ```
 
 ---
 

--- a/docs/src/content/docs/commands/pr/activity-and-checks.mdx
+++ b/docs/src/content/docs/commands/pr/activity-and-checks.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 Inspect pull request activity and build checks.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
 
 ## `bb pr activity`
 
@@ -25,14 +25,15 @@ bb pr activity <id> [options]
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `--limit <number>` | Maximum number of activity entries (default: 25) |
-| `--all` | Show all activity entries (overrides `--limit`) |
-| `--type <types>` | Filter by activity type (comma-separated): `comment`, `approval`, `changes_requested`, `merge`, `decline`, `commit`, `update` |
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <number>` | Maximum number of activity entries | `25` |
+| `--all` | Show all activity entries (overrides `--limit`) | |
+| `--type <types>` | Filter by activity type (comma-separated): `comment`, `approval`, `changes_requested`, `merge`, `decline`, `commit`, `update` | |
+| `--no-truncate` | Global flag. Show full details without truncation | |
+| `-w, --workspace <workspace>` | Workspace | |
+| `-r, --repo <repo>` | Repository | |
+| `--json` | Output as JSON | |
 
 ### Examples
 
@@ -53,12 +54,23 @@ bb pr activity 42 --all
 bb pr activity 42 --json
 ```
 
+Output:
+
+```text
+TYPE      ACTOR     DATE                      DETAILS
+--------  --------  ------------------------  --------------------------------
+UPDATE    Sam Ali   Jul 29, 2026 at 01:20 PM  state: OPEN
+COMMENT   Jane Doe  Jul 29, 2026 at 10:41 AM  #486513002 Why was this removed?
+APPROVAL  Lee Park  Jul 28, 2026 at 06:05 PM  approved
+COMMIT    Sam Ali   Jul 28, 2026 at 05:58 PM  commit a1b2c3d
+```
+
 ### Notes
 
+- Comment snippets and change-request reasons are truncated to 80 characters, and `title:` change details to 60. Use `--no-truncate` for the full text
+- An unrecognized `--type` token fails with `--type must be one of: comment, approval, changes_requested, merge, decline, commit, update`. Each bad token that is close to a valid one adds a `(Did you mean ...?)` line; tokens with no close match add nothing
 - `--limit` is enforced across paginated activity responses
 - When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
-- Valid `--type` values: `comment`, `approval`, `changes_requested`, `merge`, `decline`, `commit`, `update`
-- Multiple types can be combined: `--type comment,approval`
 
 ---
 
@@ -80,6 +92,7 @@ bb pr checks <id> [options]
 
 | Option | Description |
 |--------|-------------|
+| `--no-truncate` | Global flag. Show full check descriptions without truncation |
 | `-w, --workspace <workspace>` | Workspace |
 | `-r, --repo <repo>` | Repository |
 | `--json` | Output as JSON |
@@ -96,3 +109,26 @@ bb pr checks 42 -w myworkspace -r myrepo
 # Get checks as JSON
 bb pr checks 42 --json
 ```
+
+Output:
+
+```text
+Pull Request #42 - 3 checks
+────────────────────────────────────────────────────────────
+STATUS       NAME            DESCRIPTION                    UPDATED
+-----------  --------------  -----------------------------  ------------------------
+OK passed    build           Build succeeded in 2m 11s      Jul 29, 2026 at 01:31 PM
+FAIL failed  unit-tests      3 of 412 tests failed          Jul 29, 2026 at 01:34 PM
+RUN running  deploy-preview  Deploying preview environment  Jul 29, 2026 at 01:36 PM
+
+OK 1 successful, FAIL 1 failed, RUN 1 pending
+```
+
+### Notes
+
+- The `STATUS` cell is an icon plus a label: `OK passed`, `FAIL failed`, `RUN running`, `STOP stopped`, or `?` plus the raw state for anything else
+- The summary line counts only successful, failed, and running checks, so it can total fewer than the header count
+- Check descriptions are truncated to 40 characters in the table view. Use `--no-truncate` for the full text
+- `bb pr checks` is not paginated — it makes a single request and has no `--limit` or `--all`
+- `--json` returns `{ pullRequestId, workspace, repoSlug, summary, statuses }`. Unlike list commands, there is no `count` key — use the length of `statuses`
+- With no checks, the command prints `No CI/CD checks found for this pull request`; with `--json` it returns an empty `statuses` array

--- a/docs/src/content/docs/commands/pr/comments.mdx
+++ b/docs/src/content/docs/commands/pr/comments.mdx
@@ -10,7 +10,19 @@ sidebar:
 
 Manage pull request comments.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+
+Every `bb pr comments` subcommand accepts those globals. They work the same everywhere, so the per-command examples below leave them out:
+
+```bash
+# Target a repository other than the one you are standing in
+bb pr comments list 42 -w myworkspace -r myrepo
+
+# Machine-readable output
+bb pr comments list 42 --json
+```
+
+`view`, `edit`, `reply`, `resolve`, and `unresolve` have no options of their own — only the globals.
 
 ## `bb pr comments`
 
@@ -34,7 +46,7 @@ Global options available on all PR commands: `--json`, `--no-color`, `-w, --work
 List comments on a pull request.
 
 ```bash
-bb pr comments list <id>
+bb pr comments list <id> [options]
 ```
 
 ### Arguments
@@ -45,16 +57,13 @@ bb pr comments list <id>
 
 ### Options
 
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--limit <number>` | Maximum number of comments (default: 25) |
-| `--all` | List all comments (overrides `--limit`) |
-| `--resolved` | Only show resolved comments |
-| `--unresolved` | Only show unresolved comments |
-| `--no-truncate` | Show full comment content without truncation |
-| `--json` | Output as JSON |
+| Option | Description | Default |
+|---------|-------------|---------|
+| `--limit <number>` | Maximum number of comments | `25` |
+| `--all` | List all comments (overrides `--limit`) | |
+| `--resolved` | Only show resolved comments | |
+| `--unresolved` | Only show unresolved comments | |
+| `--no-truncate` | Global flag. Show full comment content without truncation | |
 
 ### Examples
 
@@ -73,28 +82,31 @@ bb pr comments list 42 --all
 
 # Show full comment content (not truncated)
 bb pr comments list 42 --no-truncate
+```
 
-# List comments in specific repository
-bb pr comments list 42 -w myworkspace -r myrepo
+Output:
 
-# Get comments as JSON
-bb pr comments list 42 --json
+```text
+ID         Author    Content                          Status    Date
+---------  --------  -------------------------------  --------  ------------------------
+486512301  Jane Doe  Consider renaming this variable  resolved  Jul 28, 2026 at 11:14 AM
+486512477  Sam Ali   Good catch, fixed.               open      Jul 28, 2026 at 12:02 PM
+486513002  Jane Doe  Why was this removed?            open      Jul 29, 2026 at 10:41 AM
 ```
 
 ### Notes
 
-- By default, comment content is truncated to 60 characters in the table view
-- Use `--no-truncate` to display the full comment text
-- The `Status` column shows `resolved`, `pending`, or `open`; Bitbucket records resolution on the thread root, so replies always show `open`
+- Comment content is truncated to 60 characters in the table view. Use `--no-truncate` for the full text
+- The `Status` column shows `resolved`, `pending`, or `open`. Bitbucket records resolution on the comment that was resolved, so a reply inside a resolved thread shows `open` (or `pending` if it is an unpublished draft)
 - `--resolved` and `--unresolved` filter on the same resolution state and cannot be combined
-- `--limit` is enforced across paginated comment responses
+- With `--resolved`/`--unresolved` the filter is applied client-side after each page is fetched, so `--limit` counts comments that survive the filter — `--unresolved --limit 25` keeps fetching pages until 25 unresolved comments are found or the list is exhausted
 - When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
 
 ---
 
 ## `bb pr comments add`
 
-Add a comment to a pull request. Supports both general comments and inline comments on specific file lines.
+Add a general comment, or an inline comment anchored to a file line.
 
 ```bash
 bb pr comments add <id> <message> [options]
@@ -114,9 +126,6 @@ bb pr comments add <id> <message> [options]
 | `--file <path>` | File path for an inline comment (requires `--line-to` and/or `--line-from`) |
 | `--line-to <number>` | Line number in the new version of the file (requires `--file`) |
 | `--line-from <number>` | Line number in the old version of the file (requires `--file`) |
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -124,20 +133,14 @@ bb pr comments add <id> <message> [options]
 # Add a general comment to PR #42
 bb pr comments add 42 "LGTM! This looks great."
 
-# Add an inline comment on a specific line in the new file
+# Inline comment on a line in the new file
 bb pr comments add 42 "Consider renaming this variable" --file src/index.ts --line-to 15
 
-# Add an inline comment on a line in the old (removed) version of the file
+# Inline comment on a line in the old (removed) version of the file
 bb pr comments add 42 "Why was this removed?" --file src/utils.ts --line-from 10
 
-# Add an inline comment spanning old and new lines
+# Inline comment spanning old and new lines
 bb pr comments add 42 "This logic changed" --file src/app.ts --line-from 5 --line-to 8
-
-# Add a comment to PR in specific repository
-bb pr comments add 42 "Please review this." -w myworkspace -r myrepo
-
-# Get comment as JSON
-bb pr comments add 42 "Good job!" --json
 ```
 
 ### Notes
@@ -150,7 +153,7 @@ bb pr comments add 42 "Good job!" --json
 
 ## `bb pr comments view`
 
-View a single comment on a pull request, including whether its thread is resolved.
+View a single comment, including whether it is resolved.
 
 ```bash
 bb pr comments view <pr-id> <comment-id>
@@ -163,25 +166,11 @@ bb pr comments view <pr-id> <comment-id>
 | `pr-id` | Pull request ID |
 | `comment-id` | Comment ID |
 
-### Options
-
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
-# View comment #123 on PR #42
-bb pr comments view 42 123
-
-# View a comment in a specific repository
-bb pr comments view 42 123 -w myworkspace -r myrepo
-
-# Get the raw comment object as JSON
-bb pr comments view 42 123 --json
+# View comment #486512301 on PR #42
+bb pr comments view 42 486512301
 ```
 
 ### Notes
@@ -209,32 +198,18 @@ bb pr comments edit <pr-id> <comment-id> <message>
 | `comment-id` | Comment ID |
 | `message` | New comment message |
 
-### Options
-
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
-# Edit comment #123 on PR #42
-bb pr comments edit 42 123 "Updated: I noticed something else..."
-
-# Edit comment in specific repository
-bb pr comments edit 42 123 "Revised feedback" -w myworkspace -r myrepo
-
-# Get updated comment as JSON
-bb pr comments edit 42 123 "Final comment" --json
+# Replace the body of comment #486512301 on PR #42
+bb pr comments edit 42 486512301 "Updated: I noticed something else..."
 ```
 
 ---
 
 ## `bb pr comments reply`
 
-Reply to an existing comment. The new comment is attached to the parent comment, so it shows up in the same thread.
+Reply to an existing comment. The reply is attached to the parent comment, so it lands in the same thread.
 
 ```bash
 bb pr comments reply <pr-id> <comment-id> <message>
@@ -248,31 +223,17 @@ bb pr comments reply <pr-id> <comment-id> <message>
 | `comment-id` | ID of the comment to reply to |
 | `message` | Reply message |
 
-### Options
-
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
-# Reply to comment #123 on PR #42
-bb pr comments reply 42 123 "Good catch, fixed."
-
-# Reply in a specific repository
-bb pr comments reply 42 123 "Fixed in the latest push" -w myworkspace -r myrepo
-
-# Get the created reply as JSON
-bb pr comments reply 42 123 "Done" --json
+# Reply to comment #486512301 on PR #42
+bb pr comments reply 42 486512301 "Good catch, fixed."
 ```
 
 ### Notes
 
 - Use `bb pr comments list <id>` to find the comment ID to reply to
-- The reply is attached to the parent comment; how Bitbucket anchors a reply to an inline comment is decided server-side
+- How Bitbucket anchors a reply to an inline comment is decided server-side
 
 ---
 
@@ -291,25 +252,11 @@ bb pr comments resolve <pr-id> <comment-id>
 | `pr-id` | Pull request ID |
 | `comment-id` | Comment ID |
 
-### Options
-
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
-# Resolve comment thread #123 on PR #42
-bb pr comments resolve 42 123
-
-# Resolve in a specific repository
-bb pr comments resolve 42 123 -w myworkspace -r myrepo
-
-# Get the resolution as JSON
-bb pr comments resolve 42 123 --json
+# Resolve comment thread #486512301 on PR #42
+bb pr comments resolve 42 486512301
 ```
 
 ### Notes
@@ -334,25 +281,11 @@ bb pr comments unresolve <pr-id> <comment-id>
 | `pr-id` | Pull request ID |
 | `comment-id` | Comment ID |
 
-### Options
-
-| Option | Description |
-|---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
 ### Examples
 
 ```bash
-# Reopen comment thread #123 on PR #42
-bb pr comments unresolve 42 123
-
-# Reopen in a specific repository
-bb pr comments unresolve 42 123 -w myworkspace -r myrepo
-
-# Get the result as JSON
-bb pr comments unresolve 42 123 --json
+# Reopen comment thread #486512301 on PR #42
+bb pr comments unresolve 42 486512301
 ```
 
 ### Notes
@@ -363,10 +296,10 @@ bb pr comments unresolve 42 123 --json
 
 ## `bb pr comments delete`
 
-Delete a comment from a pull request.
+Delete a comment from a pull request. `--yes` is required.
 
 ```bash
-bb pr comments delete <pr-id> <comment-id>
+bb pr comments delete <pr-id> <comment-id> [options]
 ```
 
 ### Arguments
@@ -380,23 +313,16 @@ bb pr comments delete <pr-id> <comment-id>
 
 | Option | Description |
 |---------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
+| `-y, --yes` | Confirm deletion (required) |
 
 ### Examples
 
 ```bash
-# Delete comment #123 from PR #42
-bb pr comments delete 42 123
-
-# Delete comment in specific repository
-bb pr comments delete 42 456 -w myworkspace -r myrepo
-
-# Delete comment with JSON output
-bb pr comments delete 42 456 --json
+# Delete comment #486512301 from PR #42
+bb pr comments delete 42 486512301 --yes
 ```
 
 ### Notes
 
+- `bb pr comments delete` never prompts. Without `--yes` it exits with a validation error ending in `Use --yes to confirm.`
 - Deleting a comment is permanent and cannot be undone

--- a/docs/src/content/docs/commands/pr/create-and-edit.mdx
+++ b/docs/src/content/docs/commands/pr/create-and-edit.mdx
@@ -5,13 +5,15 @@ sidebar:
   order: 2
 ---
 
-Create and inspect pull requests.
+Create and inspect pull requests (PRs).
 
-Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options work on every PR command: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo` — see [Global Flags](/reference/global-flags/).
+
+Field projection (`--json id,title`) works on list commands such as `bb pr list`. It does not work on `bb pr create`, `bb pr edit` or `bb pr view`. The payload there is a single PR carrying a `reviewers` array, and the projector unwraps that array instead — you get the reviewers back, or `[]` when there are none. Use `--json --jq '{...}'` on those three.
 
 ## `bb pr create`
 
-Create a new pull request.
+Create a pull request.
 
 ```bash
 bb pr create [options]
@@ -21,18 +23,15 @@ bb pr create [options]
 
 | Option | Description |
 |--------|-------------|
-| `-t, --title <title>` | Pull request title (required) |
-| `-b, --body <body>` | Pull request description |
+| `-t, --title <title>` | PR title (required) |
+| `-b, --body <body>` | PR description |
 | `-s, --source <branch>` | Source branch (default: current branch) |
 | `-d, --destination <branch>` | Destination branch (default: main) |
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--close-source-branch` | Close source branch after merge |
-| `--draft` | Create the pull request as draft |
+| `--draft` | Create the PR as draft |
 | `--reviewer <user>` | Add a reviewer by account ID or `{uuid}` (repeatable) |
 | `--default-reviewers` | Include the repository's default reviewers (opt-in) |
 | `--no-default-reviewers` | Skip default reviewers even when the config key enables them |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -49,7 +48,7 @@ bb pr create -t "Hotfix: Critical bug" --close-source-branch
 # Create a draft PR
 bb pr create -t "WIP: Add feature" --draft
 
-# Auto-add the repo's default reviewers (matches the Bitbucket web UI)
+# Auto-add the repository's default reviewers (matches the Bitbucket web UI)
 bb pr create -t "Add new feature" --default-reviewers
 
 # Add specific reviewers (repeatable; accepts account ID or {uuid})
@@ -63,9 +62,6 @@ bb pr create -t "Add new feature" --default-reviewers \
 
 # Capture the new PR's URL from JSON output for scripting
 bb pr create -t "Add new feature" --json --jq '.links.html.href'
-
-# Project the response to just the fields you need
-bb pr create -t "Add new feature" --json id,title,links.html.href
 ```
 
 ### Reviewers
@@ -80,7 +76,7 @@ By default `bb pr create` does **not** attach reviewers to the PR — this diffe
   bb config set prCreateIncludeDefaultReviewers true
   ```
   Pass `--no-default-reviewers` to skip defaults for a single invocation when this is enabled.
-- If the default-reviewer fetch fails (network error, permission issue, etc.), the PR is still created without reviewers and a warning is printed — the failure does not block the creation.
+- If the default-reviewer fetch fails (network error, permission issue, etc.) the CLI prints `Could not fetch default reviewers: … Continuing without them.` and creates the PR anyway. Only the *defaults* are dropped — reviewers you passed with `--reviewer` are still attached. A failed `--reviewer` lookup, by contrast, aborts the create.
 
 See [`bb repo default-reviewers`](/commands/repo/#bb-repo-default-reviewers) to inspect or manage the underlying default reviewer list.
 
@@ -94,42 +90,35 @@ Edit an existing pull request's title or description.
 bb pr edit [id] [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID (optional - auto-detects from current branch) |
+`[id]` is the PR number. Omit it to auto-detect the open PR whose source branch matches your current git branch.
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-t, --title <title>` | New pull request title |
-| `-b, --body <body>` | New pull request description |
+| `-t, --title <title>` | New PR title |
+| `-b, --body <body>` | New PR description |
 | `-F, --body-file <file>` | Read description from file |
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
-# Edit PR title by ID
+# Edit the title by ID
 bb pr edit 42 -t "Updated: Add new feature"
 
-# Edit PR description
+# Edit the description
 bb pr edit 42 -b "This PR implements the new login flow"
 
 # Edit both title and description
 bb pr edit 42 -t "New title" -b "New description"
 
-# Auto-detect PR from current branch and update title
+# Auto-detect the PR from the current branch and update the title
 bb pr edit -t "Updated title"
 
-# Read description from a file
+# Read the description from a file
 bb pr edit 42 -F description.md
 
-# Get updated PR as JSON
+# Get the updated PR as JSON
 bb pr edit 42 -t "New title" --json
 ```
 
@@ -137,7 +126,8 @@ bb pr edit 42 -t "New title" --json
 
 - When no ID is provided, the command searches for an open PR where the source branch matches your current git branch
 - At least one of `--title`, `--body`, or `--body-file` must be provided
-- The `--body-file` option reads the entire file contents as the new description
+- If both `-b/--body` and `-F/--body-file` are given, the file wins and no error is raised. This differs from `bb issue create`, which rejects the combination
+- An unreadable path fails with `Failed to read file '<path>': <reason>`
 
 ---
 
@@ -153,12 +143,10 @@ bb pr list [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-s, --state <state>` | Filter by state: OPEN, MERGED, DECLINED, SUPERSEDED (default: OPEN) |
 | `--limit <number>` | Maximum number of PRs (default: 25) |
-| `--mine` | Show only pull requests where you are a reviewer |
-| `--json` | Output as JSON |
+| `--all` | List all PRs (overrides `--limit`) |
+| `--mine` | Show only PRs where you are a reviewer |
 
 ### Examples
 
@@ -187,7 +175,10 @@ bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
 # List more results
 bb pr list --limit 50
 
-# Show only pull requests assigned to you for review
+# Fetch every open PR, ignoring the default limit of 25
+bb pr list --all
+
+# Show only PRs assigned to you for review
 bb pr list --mine
 ```
 
@@ -195,11 +186,12 @@ bb pr list --mine
 
 - Draft PRs are shown with a `[DRAFT]` prefix in the title
 - `--limit` is enforced across paginated API responses
+- The TITLE column is truncated to 50 characters, and the `[DRAFT] ` prefix counts against that budget. Pass `--no-truncate` for full titles; `--json` output is never truncated
 
 :::caution[`--mine` does not mean "my PRs"]
-`--mine` filters PRs where you are assigned as a **reviewer**, not PRs you authored. It uses the Bitbucket API's `reviewers.uuid` filter. To find PRs you created, use `--json` with `jq`:
+`--mine` filters PRs where you are assigned as a **reviewer**, not PRs you authored. It uses the Bitbucket API's `reviewers.uuid` filter. To find PRs you created, filter the JSON yourself:
 ```bash
-bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "your-username")'
+bb pr list --json --jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "your-username")'
 ```
 :::
 
@@ -213,19 +205,7 @@ View pull request details.
 bb pr view <id> [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
+`<id>` is the PR number.
 
 ### Examples
 
@@ -239,9 +219,9 @@ bb pr view 42 -w myworkspace -r myrepo
 # Get PR details as JSON
 bb pr view 42 --json
 
-# Project to specific fields
-bb pr view 42 --json id,title,state,author.display_name
+# Pick out fields with built-in --jq
+bb pr view 42 --json --jq '{id, title, state, author: .author.display_name}'
 
-# Extract just the web URL with built-in --jq
+# Extract just the web URL
 bb pr view 42 --json --jq '.links.html.href'
 ```

--- a/docs/src/content/docs/commands/pr/diff-and-checkout.mdx
+++ b/docs/src/content/docs/commands/pr/diff-and-checkout.mdx
@@ -7,11 +7,11 @@ sidebar:
 
 Review pull request changes with local checkout and diff tooling.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
 
 ## `bb pr checkout`
 
-Checkout a pull request locally. This command fetches the PR's source branch and checks it out, creating a local tracking branch if needed.
+Check out a pull request's source branch locally.
 
 ```bash
 bb pr checkout <id> [options]
@@ -43,17 +43,19 @@ bb pr checkout 42 -w myworkspace -r myrepo
 
 ### Notes
 
-The command will:
+The command, in order:
 
-1. Fetch the latest changes from the remote
-2. Try to checkout the PR's source branch
-3. If the branch doesn't exist locally, create a new branch named `pr-<id>` tracking `origin/<source-branch>`
+1. Fetches the latest changes from the remote
+2. Checks out the pull request's source branch
+3. If that checkout fails, creates a local branch `pr-<id>` tracking `origin/<source-branch>`
+
+`--json` returns `{ success, pullRequestId, branch, pullRequest }`, where `branch` is whichever of the two names was checked out.
 
 ---
 
 ## `bb pr diff`
 
-View the diff of a pull request. Shows the changes introduced by the PR in unified diff format with syntax highlighting.
+View the diff of a pull request in unified diff format.
 
 ```bash
 bb pr diff [id] [options]
@@ -105,12 +107,22 @@ bb pr diff 42 --color never > pr-42.patch
 bb pr diff 42 --stat --json
 ```
 
+`--stat` output:
+
+```text
+src/index.ts | +12 -3
+src/utils.ts | +4
+docs/README.md | -8
+
+3 files changed, 16 insertions(+), 11 deletions(-)
+```
+
 ### Notes
 
-- When no ID is provided, the command searches for an open PR where the source branch matches your current git branch
-- The `--stat` output shows files changed with insertions (+) and deletions (-)
-- `-w` remains the global short alias for `--workspace`; use `--web` (long form) to open the diff in a browser
-- Use `--color never` when piping output to files or other commands
-- Use the global `--no-color` flag to disable color output for all command formatting
-- The diff is colorized by default when output is a terminal (green for additions, red for deletions, cyan for hunk headers)
+- When no ID is provided, the command searches for an open pull request whose source branch matches your current git branch
+- `--color auto` colors the diff only when stdout is a terminal: green for additions, red for deletions, cyan for hunk headers. Whole lines are colored by their leading marker — there is no language-aware highlighting
+- `--color never` forces plain text, which is what you want when redirecting to a file or piping into another command. The global `--no-color` flag does the same for every command
+- The value is validated before the request. A typo fails with `--color must be one of: auto, always, never` plus a `(Did you mean never?)` suggestion, rather than silently falling back
+- Passing `--color <when>` at all turns the *global* color setting on, because the CLI resolves color by scanning raw argv for a `--color` token. `bb pr diff 42 --color never` still leaves the diff body uncolored, but it overrides `--no-color` and `NO_COLOR` for everything else that invocation prints. See [Global Flags → Precedence summary](/reference/global-flags/#precedence-summary)
+- `-w` is the global short alias for `--workspace`. To open the diff in a browser you must spell out `--web`
 - For opening other Bitbucket pages (PR detail, files, commits, pipelines, settings) in the browser, see [`bb browse`](/commands/browse/)

--- a/docs/src/content/docs/commands/pr/index.mdx
+++ b/docs/src/content/docs/commands/pr/index.mdx
@@ -5,41 +5,34 @@ sidebar:
   order: 1
 ---
 
-import {
-  Badge,
-  CardGrid,
-  LinkButton,
-  LinkCard,
-} from '@astrojs/starlight/components';
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Manage pull requests in Bitbucket repositories.
+Manage pull requests (PRs) in Bitbucket repositories. New here? Start with [Create, edit, and view](/commands/pr/create-and-edit/).
 
-Global options available on all PR commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options work on every PR command: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo` — see [Global Flags](/reference/global-flags/).
 
-`--json` accepts an optional comma-separated field list to project the output, and `--jq` filters the JSON in-process — see [JSON Output](/reference/json-output/) for the full reference.
-
-## Choose a Workflow <Badge text="Task-based" variant="note" />
+## Command groups
 
 <CardGrid>
   <LinkCard
     title="Create, edit, and view"
     href="/commands/pr/create-and-edit/"
-    description="Open pull requests, update metadata, and inspect details with JSON output support."
+    description="Open a PR, change its title or description, list PRs, inspect one."
   />
   <LinkCard
     title="Activity and checks"
     href="/commands/pr/activity-and-checks/"
-    description="Inspect activity history and CI/build status before approving or merging."
+    description="Read the activity timeline and CI build statuses before approving or merging."
   />
   <LinkCard
     title="Diff and checkout"
     href="/commands/pr/diff-and-checkout/"
-    description="Review patch output, fetch PR branches locally, and open browser diffs."
+    description="Print the patch or diffstat, fetch the PR branch locally, open the diff in a browser."
   />
   <LinkCard
     title="Review and merge"
     href="/commands/pr/review-and-merge/"
-    description="Approve, decline, mark drafts ready, and merge with explicit strategy control."
+    description="Approve, decline, mark a draft ready, and merge with an explicit strategy."
   />
   <LinkCard
     title="Comments"
@@ -49,18 +42,16 @@ Global options available on all PR commands: `--json [fields]`, `--jq <expressio
   <LinkCard
     title="Reviewers"
     href="/commands/pr/reviewers/"
-    description="Assign and remove reviewers with clear behavior in idempotent cases."
+    description="Add and remove reviewers. Adding someone already assigned is a no-op, as is removing someone who is not."
   />
 </CardGrid>
 
-<LinkButton href="/commands/pr/create-and-edit/" icon="right-arrow" variant="primary">Start with PR creation</LinkButton>
-
-## Most-Used Commands
+## Most-used commands
 
 | Task | Command |
 |------|---------|
 | Create a PR | `bb pr create -t "Add feature"` |
-| Create a PR with the repo's default reviewers | `bb pr create -t "Add feature" --default-reviewers` |
+| Create a PR with the repository's default reviewers | `bb pr create -t "Add feature" --default-reviewers` |
 | List open PRs | `bb pr list` |
 | List all PRs (ignore the default limit) | `bb pr list --all` |
 | List PRs where you are a reviewer | `bb pr list --mine` |
@@ -71,9 +62,9 @@ Global options available on all PR commands: `--json [fields]`, `--jq <expressio
 | Approve PR | `bb pr approve 42` |
 | Merge PR | `bb pr merge 42 --strategy squash` |
 
-## JSON for Automation
+## JSON for automation
 
-Use `--json` when scripting. The optional field list (`--json id,title,state`) projects to just those fields, and `--jq` filters in-process — no external `jq` binary required:
+List commands wrap their results in an envelope. Bare `bb pr list --json` returns `{workspace, repoSlug, state, filters, count, pullRequests}`, so a `--jq` filter starts at `.pullRequests[]`. Adding a field list (`--json id,title`) drops the envelope and returns a flat array, so the filter starts at `.[]` instead. Single-PR commands like `bb pr view` return the PR object itself, with no envelope.
 
 ```bash
 # Project to specific fields (returns a flat array)
@@ -91,3 +82,5 @@ bb pr view 42 --json --jq '.links.html.href'
 # Capture diffstat totals
 bb pr diff 42 --stat --json --jq '{filesChanged, totalAdditions, totalDeletions}'
 ```
+
+`--json <fields>` misfires on `bb pr create`, `bb pr edit` and `bb pr view` — see [Create, Edit, and View PRs](/commands/pr/create-and-edit/) for why, and [JSON Output](/reference/json-output/) for the full reference.

--- a/docs/src/content/docs/commands/pr/review-and-merge.mdx
+++ b/docs/src/content/docs/commands/pr/review-and-merge.mdx
@@ -5,160 +5,102 @@ sidebar:
   order: 5
 ---
 
-Complete review and merge pull request workflows.
+The four commands that change a pull request's state: `bb pr approve`, `bb pr decline`, `bb pr ready`, `bb pr merge`.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options work on every PR command: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo` — see [Global Flags](/reference/global-flags/).
+
+`--json` accepts an optional comma-separated field list and `--jq` filters the JSON in-process — see [JSON Output](/reference/json-output/) for the full reference. On these four commands the field list is matched against the result envelope shown under [JSON output](#json-output), not against the PR, so `--json title` returns `{"title": null}`. Use a dotted path (`--json pullRequest.state`) or `--jq` instead.
 
 ## `bb pr merge`
-
-Merge a pull request.
 
 ```bash
 bb pr merge <id> [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
+`<id>` is the pull request ID.
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `-m, --message <message>` | Merge commit message |
-| `--close-source-branch` | Delete source branch after merge |
-| `--strategy <strategy>` | Merge strategy (see table below) |
-| `--json` | Output as JSON |
+| `--close-source-branch` | Delete the source branch after merging |
+| `--strategy <strategy>` | Merge strategy (see below) |
 
-### Merge Strategies
+### Merge strategies
 
 | Strategy | Description |
 |----------|-------------|
-| `merge_commit` | Create a merge commit (default) |
+| `merge_commit` | Create a merge commit |
 | `squash` | Squash all commits into a single commit |
 | `fast_forward` | Fast-forward if possible, fail otherwise |
 | `squash_fast_forward` | Squash commits and fast-forward |
 | `rebase_fast_forward` | Rebase source commits onto destination and fast-forward |
 | `rebase_merge` | Rebase source commits onto destination and create a merge commit |
 
+Omitting `--strategy` uses the repository's configured merge strategy (typically `merge_commit`), not a CLI default. The CLI sends no strategy at all unless you pass one.
+
+Strategy names are checked when the command runs, not by the argument parser. An unknown value fails with [`5002` VALIDATION_INVALID](/reference/error-codes/#5002---validation_invalid) and the message `--strategy must be one of: merge_commit, squash, …`. A wrong-case value such as `SQUASH` gets a case-sensitivity note; a typo such as `sqush` gets a "did you mean" suggestion. Under `--json` that failure comes back as a JSON error envelope.
+
 ### Examples
 
 ```bash
-# Merge PR #42
+# Merge PR #42 using the repository's configured strategy
 bb pr merge 42
 
-# Merge with squash strategy and delete source branch
+# Squash and delete the source branch
 bb pr merge 42 --strategy squash --close-source-branch
 
-# Merge with custom commit message
+# Merge with a custom commit message
 bb pr merge 42 -m "Merge feature: Add user authentication"
 
 # Rebase and fast-forward
 bb pr merge 42 --strategy rebase_fast_forward
+
+# Capture the merge commit hash (--jq prints JSON-quoted strings, so strip them)
+bb pr merge 42 --json --jq '.pullRequest.merge_commit.hash' | tr -d '"'
 ```
 
 ---
 
-## `bb pr approve`
+## `bb pr approve`, `bb pr decline`, `bb pr ready`
 
-Approve a pull request.
-
-```bash
-bb pr approve <id> [options]
-```
-
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
+Each takes a pull request ID and nothing else — no command-specific options, only the global ones.
 
 ```bash
-# Approve PR in current repository
-bb pr approve 42
+bb pr approve 42   # Approve
+bb pr decline 42   # Decline
+bb pr ready 42     # Clear the draft flag, marking the PR ready for review
 
-# Approve PR in specific repository
+# Any of them against an explicit repository
 bb pr approve 42 -w myworkspace -r myrepo
 ```
 
----
+`bb pr ready` is a pull request update that sets `draft: false`. It sends no other fields.
 
-## `bb pr decline`
+## JSON output
 
-Decline a pull request.
+The four commands on this page do not return the same shape. `bb pr approve` returns only the identifiers:
 
-```bash
-bb pr decline <id> [options]
+```json
+{
+  "success": true,
+  "pullRequestId": 42
+}
 ```
 
-### Arguments
+`bb pr decline`, `bb pr ready`, and `bb pr merge` add the pull request exactly as the API returned it, so `state` reflects the command you ran — `DECLINED`, `OPEN`, and `MERGED` respectively. Abridged, for `bb pr merge`:
 
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
-
-```bash
-# Decline PR in current repository
-bb pr decline 42
-
-# Decline PR in specific repository
-bb pr decline 42 -w myworkspace -r myrepo
+```json
+{
+  "success": true,
+  "pullRequestId": 42,
+  "pullRequest": {
+    "id": 42,
+    "title": "Add user authentication",
+    "state": "MERGED"
+  }
+}
 ```
 
----
-
-## `bb pr ready`
-
-Mark a draft pull request as ready for review.
-
-```bash
-bb pr ready <id> [options]
-```
-
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
-
-```bash
-# Mark draft PR as ready
-bb pr ready 42
-
-# Mark draft PR in specific repository
-bb pr ready 42 -w myworkspace -r myrepo
-```
+A script that reads `.pullRequest` after `bb pr approve --json` gets `null`. Fetch the PR separately with `bb pr view 42 --json` if you need its fields after approving.

--- a/docs/src/content/docs/commands/pr/reviewers.mdx
+++ b/docs/src/content/docs/commands/pr/reviewers.mdx
@@ -5,9 +5,9 @@ sidebar:
   order: 7
 ---
 
-Manage pull request reviewers.
+Manage pull request (PR) reviewers.
 
-Global options available on all PR commands: `--json`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options work on every PR command: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo` — see [Global Flags](/reference/global-flags/).
 
 :::tip[Looking for repo-level defaults?]
 This page covers reviewers on **existing** pull requests. To manage the repository's **default reviewers** — the list Bitbucket auto-suggests when someone opens a PR — see [`bb repo default-reviewers`](/commands/repo/#bb-repo-default-reviewers). `bb pr create` can also auto-apply them via `--default-reviewers` or the `prCreateIncludeDefaultReviewers` config key.
@@ -20,11 +20,23 @@ Bitbucket Cloud no longer accepts the legacy `username` (login name) when modify
 - An **account ID**, e.g. `712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f`
 - A **UUID** wrapped in braces, e.g. `{c1cb1bb5-2e32-456e-a373-43978dc12aa1}`
 
-Both forms are returned by `bb pr reviewers list --json` (the `account_id` and `uuid` fields), so you can pipe the output of one command into another to script reviewer changes. See [`bb pr create`](/commands/pr/create-and-edit/#bb-pr-create) for matching `--reviewer` examples.
+Both forms come back from `bb pr reviewers list --json`, as the `account_id` and `uuid` fields:
+
+```bash
+# One object per reviewer: [{"account_id": "712020:3cfed..."}, …]
+bb pr reviewers list 42 --json account_id
+
+# Copy every reviewer from PR #42 onto PR #43
+for u in $(bb pr reviewers list 42 --json --jq '.reviewers[].account_id' | tr -d '"'); do
+  bb pr reviewers add 43 "$u"
+done
+```
+
+Two things to watch in scripts. `--json <fields>` projects across the `reviewers` array and drops the surrounding `{workspace, repoSlug, pullRequestId, count}` envelope, so you get a bare array of objects — not bare IDs. And the built-in jq runs without `-r`, so strings arrive JSON-quoted; strip the quotes with `tr -d '"'` or interpolate inside jq.
+
+See [`bb pr create`](/commands/pr/create-and-edit/#bb-pr-create) for matching `--reviewer` examples.
 
 ## `bb pr reviewers`
-
-### Subcommands
 
 | Subcommand | Description |
 |------------|-------------|
@@ -32,139 +44,100 @@ Both forms are returned by `bb pr reviewers list --json` (the `account_id` and `
 | `add <id> <user>` | Add a reviewer to a pull request |
 | `remove <id> <user>` | Remove a reviewer from a pull request |
 
+None of the three take command-specific options — only the global ones. `<id>` is the pull request ID; `<user>` is an account ID or a braced UUID.
+
 ---
 
 ## `bb pr reviewers list`
-
-List reviewers assigned to a pull request.
 
 ```bash
 bb pr reviewers list <id>
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
-
 ```bash
 # List reviewers on PR #42
 bb pr reviewers list 42
 
-# List reviewers in specific repository
+# List reviewers in a specific repository
 bb pr reviewers list 42 -w myworkspace -r myrepo
-
-# Get reviewers as JSON for scripting
-bb pr reviewers list 42 --json
 ```
 
-### Notes
+Human output is a two-column table of display name and account ID. If the pull request has no reviewers, the command prints `No reviewers assigned to this pull request`. The deprecated `username` field is never shown — Bitbucket Cloud stopped returning it for GDPR reasons.
 
-- Displays reviewers in a table with display name and account ID
-- Shows a message if no reviewers are assigned
-- Due to Bitbucket Cloud GDPR changes, the deprecated `username` field is not displayed
+`--json` returns the full envelope:
+
+```json
+{
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "pullRequestId": 42,
+  "count": 1,
+  "reviewers": [
+    {
+      "display_name": "Jane Doe",
+      "account_id": "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f",
+      "uuid": "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
+    }
+  ]
+}
+```
 
 ---
 
 ## `bb pr reviewers add`
 
-Add a reviewer to a pull request by account ID or UUID. The legacy `username` (login name) is not accepted by Bitbucket Cloud — see [Identifying users](#identifying-users).
+Add a reviewer by account ID or UUID. The legacy `username` (login name) is not accepted by Bitbucket Cloud — see [Identifying users](#identifying-users).
 
 ```bash
 bb pr reviewers add <id> <user>
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-| `user` | Account ID (e.g. `712020:3cfed7e0-…`) or UUID (`{c1cb1bb5-…}`) of the user to add |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
-
 ```bash
-# Add reviewer by account ID
+# By account ID
 bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
 
-# Add reviewer by UUID (note the braces)
+# By UUID (keep the braces, and quote the argument so the shell leaves them alone)
 bb pr reviewers add 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
-
-# Add reviewer in specific repository
-bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" -w myworkspace -r myrepo
-
-# Add reviewer and get result as JSON
-bb pr reviewers add 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --json
 ```
 
-### Notes
-
-- The user must exist in Bitbucket; you'll get a clear error message if the user is not found
-- If the user is already a reviewer, the command succeeds without making changes
-- Uses UUID for identification (GDPR-compliant)
+Adding someone who is already a reviewer succeeds and changes nothing.
 
 ---
 
 ## `bb pr reviewers remove`
 
-Remove a reviewer from a pull request by account ID or UUID. The legacy `username` (login name) is not accepted by Bitbucket Cloud — see [Identifying users](#identifying-users).
+Remove a reviewer by account ID or UUID. Same `<user>` rules as `add`.
 
 ```bash
 bb pr reviewers remove <id> <user>
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `id` | Pull request ID |
-| `user` | Account ID (e.g. `712020:3cfed7e0-…`) or UUID (`{c1cb1bb5-…}`) of the reviewer to remove |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
-| `--json` | Output as JSON |
-
-### Examples
-
 ```bash
-# Remove reviewer by account ID
+# By account ID
 bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
 
-# Remove reviewer by UUID (note the braces)
+# By UUID
 bb pr reviewers remove 42 "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
-
-# Remove reviewer in specific repository
-bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" -w myworkspace -r myrepo
-
-# Remove reviewer and get result as JSON
-bb pr reviewers remove 42 "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f" --json
 ```
 
-### Notes
+Removing someone who is not a reviewer succeeds and changes nothing.
 
-- The user must exist in Bitbucket; you'll get a clear error message if the user is not found
-- If the user is not a reviewer on the PR, the command succeeds without making changes
-- Uses UUID for identification (GDPR-compliant)
+## JSON output for `add` and `remove`
+
+Both commands emit the same envelope. `reviewer.username` echoes the `<user>` value you passed, whatever form it was in; `reviewer.uuid` is the resolved UUID.
+
+```json
+{
+  "success": true,
+  "pullRequestId": 42,
+  "reviewer": {
+    "username": "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f",
+    "uuid": "{c1cb1bb5-2e32-456e-a373-43978dc12aa1}"
+  },
+  "pullRequest": { "id": 42, "title": "Add user authentication" }
+}
+```
+
+## When the user lookup fails
+
+Both commands resolve `<user>` through Bitbucket's user endpoint before touching the pull request. A bad account ID or UUID fails there with a 404, carrying whatever message Bitbucket returns. The CLI appends its generic 404 hint, which mentions `--workspace` and `--repo` — but for these two commands the wrong value is almost always the `<user>` argument, not the repository.

--- a/docs/src/content/docs/commands/project.mdx
+++ b/docs/src/content/docs/commands/project.mdx
@@ -3,16 +3,19 @@ title: Project Commands - Manage Bitbucket Projects
 description: Reference for Bitbucket CLI project commands. List, view, and create Bitbucket Cloud projects to organize repositories from the command line.
 ---
 
-Manage Bitbucket Cloud projects — the grouping layer for repositories inside a
-workspace. Use these commands to discover the project keys you pass to
-`bb repo create -p <KEY>`.
+Projects are the grouping layer for repositories inside a workspace. Use these
+commands to discover the project keys you pass to `bb repo create -p <KEY>`.
 
-Project commands operate at **workspace** scope (no repo context required).
-Use `-w, --workspace <workspace>` or set a default with
-`bb config set defaultWorkspace <workspace>` — see
-[`bb workspace list`](/commands/workspace/) to discover your slugs.
+Project commands run at **workspace** scope; no repository context is required.
+Unlike `bb workspace view` and the repo-scoped commands, they never infer the
+workspace from your git remote. Resolution is `-w/--workspace` → `BB_WORKSPACE`
+→ `defaultWorkspace`. With none of those set, `bb project list` fails with
+`No workspace specified.` even inside a Bitbucket checkout — see
+[Repository Context](/guides/repository-context/).
 
-Global options available on all project commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
+All three subcommands are non-interactive and accept the
+[global flags](/reference/global-flags/), including `--json [fields]` and
+`--jq <expression>`.
 
 ---
 
@@ -40,23 +43,39 @@ bb project list
 bb project list -w my-workspace
 bb project list --all
 
-# Project to specific fields (returns a flat array)
+# Just key and name — a flat array, not the envelope
 bb project list --json key,name
 
-# Grab keys for scripting with built-in --jq
+# Keys, one per line (JSON-quoted — the embedded jq has no -r)
 bb project list --json --jq '.projects[].key'
+
+# Unquoted keys for a shell loop — needs the jq binary
+bb project list --json | jq -r '.projects[].key'
 ```
+
+### Output
+
+```text
+KEY       NAME               PRIVACY  DESCRIPTION                        UPDATED
+--------  -----------------  -------  ---------------------------------  ------------------------
+PLATFORM  Platform Services  private  Shared infrastructure and tooling  Jul 30, 2026 at 09:12 AM
+WEB       Web Apps           private  Customer-facing web frontends      Jul 24, 2026 at 04:38 PM
+```
+
+An empty workspace prints `No projects found in workspace <workspace>`.
 
 ### JSON output
 
-The `--json` envelope is `{ workspace, count, projects }`, where `projects` is
-the array of project objects.
+The envelope is `{ workspace, count, projects }`, where `projects` is the array
+of project objects.
 
 ### Notes
 
-- Long descriptions are truncated to 50 characters in the table (disable with
-  the global `--no-truncate`); `--json` always carries the full values.
-- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
+- The `DESCRIPTION` column is truncated to 50 characters. Pass the global
+  `--no-truncate` for the full text; `--json` always carries the full values.
+- When more results exist than `--limit` returned, the table is followed by
+  `Showing 25 projects. Use --limit <n> or --all to see more.` This footer is
+  never printed under `--json`.
 
 ---
 
@@ -72,7 +91,7 @@ bb project view <key> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `key` | Project key (e.g. `PROJ`; lowercase input is uppercased automatically) |
+| `key` | Project key (e.g. `PROJ`; lowercase input is uppercased automatically, so `proj` and `PROJ` resolve the same project) |
 
 ### Options
 
@@ -87,16 +106,14 @@ bb project view <key> [options]
 bb project view PROJ
 bb project view PROJ -w my-workspace
 
-# Stable JSON envelope: { workspace, project }
+# JSON is wrapped: { workspace, project }
 bb project view PROJ --json --jq '.project.name'
 ```
 
 ### Notes
 
-- Bitbucket stores project keys uppercased, so `bb project view proj` resolves
-  the same project as `bb project view PROJ`.
-- An unknown key returns `Project <KEY> not found in workspace <workspace>.`
-  (exit code 1, `--json` gives a structured error envelope).
+- An unknown key fails with `Project <KEY> not found in workspace <workspace>.`
+  — exit code 1, and `--json` writes a structured error envelope to stderr.
 
 ---
 
@@ -129,16 +146,22 @@ bb project create -k PROJ -n "My Project" -d "Team things" --public
 # Then create repositories inside it
 bb repo create my-repo -p PROJ
 
-# Stable JSON envelope: { workspace, project }
+# The response is wrapped: { workspace, project }
 bb project create -k PROJ -n "My Project" --json --jq '.project.key'
 ```
 
 ### Notes
 
-- Projects are private by default; `--private` and `--public` cannot both be
-  set. Note that private projects cannot contain public repositories.
+- Projects are private by default. `--private` and `--public` cannot both be
+  set. A private project cannot contain public repositories.
 - Keys must start with a letter and contain only letters, digits, and
   underscores. Bitbucket requires uppercase keys, so lowercase input is
-  uppercased automatically (the CLI prints a note when it does).
-- The command is fully non-interactive: all inputs are flags, so it is safe
-  for scripts and automation.
+  uppercased automatically; the CLI prints a note when it does, except under
+  `--json`.
+
+### Related
+
+- [Workspace Commands](/commands/workspace/) — find the workspace slug these
+  commands need.
+- [Repository Context](/guides/repository-context/) — how the CLI resolves
+  workspace and repository.

--- a/docs/src/content/docs/commands/repo.mdx
+++ b/docs/src/content/docs/commands/repo.mdx
@@ -5,7 +5,7 @@ description: Complete reference for Bitbucket CLI repository commands. Learn to 
 
 Manage Bitbucket repositories.
 
-Global options available on all repo commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all repo commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`, `-r, --repo`. See [Global flags](/reference/global-flags/) for the full list. The per-command tables below list only command-specific options. One exception: `bb repo clone` ignores `-w, --workspace`.
 
 ## `bb repo clone`
 
@@ -19,14 +19,15 @@ bb repo clone <repository> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `repository` | Repository to clone (`workspace/repo` or full URL) |
+| `repository` | `workspace/repo`, a bare repository name, or a full clone URL |
+
+For a bare name, the workspace comes from `BB_WORKSPACE`, then the `defaultWorkspace` config key. The global `-w` is **not** honoured by this command.
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
 | `-d, --directory <dir>` | Directory to clone into |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -37,9 +38,18 @@ bb repo clone myworkspace/myrepo
 # Clone into a specific directory
 bb repo clone myworkspace/myrepo -d my-local-dir
 
+# Bare name — workspace comes from the environment
+BB_WORKSPACE=myworkspace bb repo clone myrepo
+
 # Clone using full URL
 bb repo clone git@bitbucket.org:myworkspace/myrepo.git
 ```
+
+### Notes
+
+- For the `workspace/repo` and bare-name forms the CLI clones over SSH (`git@bitbucket.org:<workspace>/<repo>.git`). Pass a full HTTPS URL if you do not have SSH keys set up.
+- A path with more than one `/` fails with `Invalid repository format. Use workspace/repo or a full URL.`
+- `--json` emits `{ success, repository, path, cloneUrl }`.
 
 ---
 
@@ -59,14 +69,12 @@ bb repo create <name> [options]
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace to create repository in |
-| `-d, --description <description>` | Repository description |
-| `--private` | Create a private repository (default) |
-| `--public` | Create a public repository |
-| `-p, --project <project>` | Project key |
-| `--json` | Output as JSON |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-d, --description <description>` | Repository description | |
+| `--private` | Create a private repository | true |
+| `--public` | Create a public repository | |
+| `-p, --project <project>` | Project key | |
 
 ### Examples
 
@@ -81,6 +89,11 @@ bb repo create my-new-repo -w myworkspace --public -d "My awesome project"
 bb repo create my-new-repo -w myworkspace -p PROJ
 ```
 
+### Notes
+
+- Visibility is private unless `--public` is passed. If both `--private` and `--public` are given, `--public` currently wins and no error is raised — unlike `bb snippet create` and `bb project create`, which reject the combination.
+- `--json` emits the raw Bitbucket repository object, with no envelope.
+
 ---
 
 ## `bb repo list`
@@ -93,12 +106,10 @@ bb repo list [options]
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace to list repositories from |
-| `--limit <number>` | Maximum number of repositories (default: 25) |
-| `--all` | List all repositories (overrides `--limit`) |
-| `--json` | Output as JSON |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <number>` | Maximum number of repositories | 25 |
+| `--all` | List all repositories (overrides `--limit`) | |
 
 ### Examples
 
@@ -122,10 +133,15 @@ bb repo list -w myworkspace --json full_name,is_private,language
 bb repo list -w myworkspace --json --jq '.repositories[] | select(.is_private == false) | .full_name'
 ```
 
+### JSON output
+
+The `--json` envelope is `{ workspace, count, repositories }`, where `repositories` is the array of repository objects. `--json <fields>` drops the envelope and returns a flat array.
+
 ### Notes
 
-- `--limit` is enforced across paginated repository responses
-- When the result is capped by `--limit`, a hint is printed showing how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`)
+- `--limit` caps how many repositories come back, not the page size. The CLI walks pages (at most 50 per request) until the cap is reached. A value below 1 fails with `--limit must be a positive integer`.
+- Long descriptions are truncated to 50 characters in the table (disable with the global `--no-truncate`); `--json` always carries the full values.
+- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
 
 ---
 
@@ -141,14 +157,7 @@ bb repo view [repository] [options]
 
 | Argument | Description |
 |----------|-------------|
-| `repository` | Repository to view in `workspace/repo` format (optional if in a repo directory) |
-
-### Options
-
-| Option | Description |
-|--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `--json` | Output as JSON |
+| `repository` | `workspace/repo`, or a bare repository name paired with `-w`. Optional inside a repository directory. |
 
 ### Examples
 
@@ -168,14 +177,14 @@ bb repo view --json
 
 ### Notes
 
-- The positional `[repository]` argument is the primary way to specify the repo (e.g., `bb repo view myworkspace/myrepo`). The global `-w` and `-r` flags also work as an alternative.
-- The command will automatically detect the repository from your current directory's git remote if you don't specify one.
+- Resolution order: the positional argument wins, then the global `-w`/`-r` flags, then the git remote of the current directory.
+- `--json` emits the raw Bitbucket repository object, with no envelope.
 
 ---
 
 ## `bb repo delete`
 
-Delete a repository. This action is permanent and cannot be undone.
+Delete a repository.
 
 ```bash
 bb repo delete <repository> [options]
@@ -185,15 +194,13 @@ bb repo delete <repository> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `repository` | Repository to delete in `workspace/repo` format |
+| `repository` | `workspace/repo`, or a bare repository name when the workspace comes from `-w`, `BB_WORKSPACE` or the `defaultWorkspace` config key |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-y, --yes` | Confirm deletion (required) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -205,8 +212,10 @@ bb repo delete myworkspace/myrepo --yes
 bb repo delete myrepo -w myworkspace --yes
 ```
 
+`--json` emits `{ success, workspace, repoSlug }`.
+
 :::danger
-This action is permanent and cannot be undone! All repository data, including code, issues, and pull requests will be deleted.
+Deletion is permanent. All repository data, including code, issues and pull requests, is destroyed. There is no interactive prompt — without `--yes` the command exits with `This will permanently delete <workspace>/<repo>.` followed by `Use --yes to confirm.`
 :::
 
 ---
@@ -215,15 +224,7 @@ This action is permanent and cannot be undone! All repository data, including co
 
 ## `bb repo default-reviewers`
 
-Inspect and manage the default reviewers configured on a repository. Default reviewers in Bitbucket Cloud are automatically suggested when someone opens a pull request through the web UI; this command group lets you see and edit that list from the CLI.
-
-### Subcommands
-
-| Subcommand | Description |
-|------------|-------------|
-| `list` | List the default reviewers for a repository |
-| `add <user>` | Add a default reviewer (accepts account ID or `{uuid}`) |
-| `remove <user>` | Remove a default reviewer (accepts account ID or `{uuid}`, requires `--yes`) |
+Default reviewers are auto-suggested when someone opens a pull request in Bitbucket's web UI. This group reads and edits that list.
 
 ### `bb repo default-reviewers list`
 
@@ -231,12 +232,11 @@ Inspect and manage the default reviewers configured on a repository. Default rev
 bb repo default-reviewers list [options]
 ```
 
-By default the **effective** reviewer list is shown — this includes reviewers configured directly on the repository *and* reviewers inherited from the parent project, matching what Bitbucket's web UI would auto-populate.
+By default the **effective** reviewer list is shown: reviewers configured directly on the repository *and* reviewers inherited from the parent project, matching what Bitbucket's web UI would auto-populate.
 
 | Option | Description |
 |--------|-------------|
 | `--repo-only` | Only show reviewers configured on the repository (exclude project-inherited) |
-| `--json` | Output as JSON |
 
 ```bash
 # Effective list (repo + project-inherited)
@@ -249,6 +249,8 @@ bb repo default-reviewers list --repo-only
 bb repo default-reviewers list --json
 ```
 
+`--json` emits `{ workspace, repoSlug, mode, count, reviewers }`, where `mode` is `effective` or `direct`.
+
 ### `bb repo default-reviewers add`
 
 ```bash
@@ -259,7 +261,7 @@ Adds a user as a default reviewer on the repository. Requires repository admin p
 
 The `<user>` argument accepts either an **account ID** (e.g. `712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f`) or a **UUID** in curly braces (e.g. `{c1cb1bb5-2e32-456e-a373-43978dc12aa1}`). Bitbucket Cloud's GDPR changes retired username lookups, so nicknames like `jdoe` are no longer accepted.
 
-You can find a user's account ID from the Bitbucket web UI under their profile, or by running `bb pr reviewers list <pr-id> --json` on a PR they've reviewed.
+You can find a user's account ID from the Bitbucket web UI under their profile, or by running `bb pr reviewers list <pr-id> --json` on a pull request they have reviewed.
 
 ```bash
 bb repo default-reviewers add "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"

--- a/docs/src/content/docs/commands/snippet.mdx
+++ b/docs/src/content/docs/commands/snippet.mdx
@@ -5,11 +5,11 @@ description: Reference for Bitbucket CLI snippet commands. Create, view, edit, d
 
 Manage Bitbucket Cloud snippets — workspace-scoped code/text pastes.
 
-Snippet commands operate at **workspace** scope (no repo context required). Use
-`-w, --workspace <workspace>` or set a default with
+Snippet commands operate at **workspace** scope (no repository context
+required). Use `-w, --workspace <workspace>` or set a default with
 `bb config set defaultWorkspace <workspace>`.
 
-Global options available on all snippet commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
+Global options available on all snippet commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`, `--locale <locale>`, `-w, --workspace`. See [Global flags](/reference/global-flags/) for the full list. The per-command tables below list only command-specific options.
 
 ---
 
@@ -25,11 +25,9 @@ bb snippet list [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `--role <role>` | Filter by authenticated user's role: `owner`, `contributor`, or `member` |
 | `--limit <number>` | Maximum number of snippets (default: 25) |
 | `--all` | List all snippets (overrides `--limit`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -48,6 +46,8 @@ bb snippet list --json --jq '.snippets[] | select(.is_private == false) | .title
 
 ### Notes
 
+- Table columns: ID, TITLE, VISIBILITY, CREATOR, UPDATED.
+- **JSON envelope:** `{ workspace, count, snippets }`.
 - `--limit` is enforced across paginated responses.
 - When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
 
@@ -71,10 +71,8 @@ bb snippet view <id> [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-f, --file <name>` | Print contents of a specific file in the snippet |
 | `--files` | Print contents of all files in the snippet |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -84,6 +82,21 @@ bb snippet view kypj --json
 bb snippet view kypj --file config.yml
 bb snippet view kypj --files
 ```
+
+### Notes
+
+- `--file` takes precedence over `--files`. Pass both and only the single file
+  is printed.
+- An unknown file name fails with `File not found in snippet: <name>`
+  (`5003 FILE_NOT_FOUND`, see [Error codes](/reference/error-codes/)). The error
+  context carries `available` with the snippet's actual file names.
+- `--files` prints the snippet header first, then each file under a bold
+  `── <name> ──` heading. With the global `--no-unicode` the separator renders
+  as `--`.
+- **JSON shapes** differ per flag:
+  - no flag → the bare Bitbucket snippet object, no envelope
+  - `--file <name>` → `{ file, content }`
+  - `--files` → `{ snippet, files: { "<name>": "<content>" } }`
 
 ---
 
@@ -100,18 +113,19 @@ bb snippet create [options]
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-t, --title <title>` | Snippet title (required) |
-| `-f, --file <path...>` | One or more file paths to include (required) |
+| `-f, --file <path...>` | File path(s) to include (required; variadic — pass several paths or repeat the flag) |
 | `--private` | Create a private snippet (default) |
 | `--public` | Create a public snippet |
-| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
 bb snippet create -t "My snippet" -f file.txt
 bb snippet create -t "Config files" -f config.yml -f setup.sh --public
+
+# Capture the new snippet id
+bb snippet create -t "My snippet" -f file.txt --json --jq '.id'
 ```
 
 ### Notes
@@ -119,6 +133,7 @@ bb snippet create -t "Config files" -f config.yml -f setup.sh --public
 - Snippets are private by default.
 - `--private` and `--public` cannot both be set.
 - Each `--file` must exist on disk; missing files fail the command before any upload.
+- `--json` emits the bare Bitbucket snippet object, with no envelope.
 
 ---
 
@@ -134,18 +149,16 @@ bb snippet edit <id> [options]
 
 | Argument | Description |
 |----------|-------------|
-| `id` | Snippet encoded ID |
+| `id` | Snippet encoded ID (e.g. `kypj`) |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-t, --title <title>` | New title |
 | `--private` | Make snippet private |
 | `--public` | Make snippet public |
-| `-f, --file <path...>` | Replace or add file(s); sends a multipart update |
-| `--json` | Output as JSON |
+| `-f, --file <path...>` | Replace or add file(s); sends a multipart update (variadic) |
 
 ### Examples
 
@@ -160,24 +173,29 @@ bb snippet edit kypj -f updated.txt
 - Metadata-only edits (title, visibility) send a JSON PUT.
 - Passing `--file` switches to a multipart PUT and uploads the given files.
 - At least one of `--title`, `--private`, `--public`, or `--file` is required.
+- `--json` emits the bare Bitbucket snippet object, with no envelope.
 
 ---
 
 ## `bb snippet delete`
 
-Delete a snippet. Permanent.
+Delete a snippet.
 
 ```bash
 bb snippet delete <id> [options]
 ```
 
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID (e.g. `kypj`) |
+
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-y, --yes` | Confirm deletion (required) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -185,8 +203,12 @@ bb snippet delete <id> [options]
 bb snippet delete kypj --yes
 ```
 
+### Notes
+
+- **JSON envelope:** `{ success, snippetId, workspace }`.
+
 :::danger
-This action is permanent and cannot be undone.
+Deletion is permanent and cannot be undone. There is no interactive prompt — without `--yes` the command exits with `This will permanently delete snippet <id>.` followed by `Use --yes to confirm.`
 :::
 
 ---
@@ -200,12 +222,23 @@ bb snippet watch <id> [options]
 bb snippet unwatch <id> [options]
 ```
 
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID (e.g. `kypj`) |
+
 ### Examples
 
 ```bash
 bb snippet watch kypj
 bb snippet unwatch kypj
 ```
+
+### Notes
+
+- **JSON envelope:** `{ success, snippetId, watching }` — `watching` is `true`
+  for `watch` and `false` for `unwatch`.
 
 ---
 
@@ -217,14 +250,18 @@ List comments on a snippet.
 bb snippet comments list <id> [options]
 ```
 
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID (e.g. `kypj`) |
+
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `--limit <number>` | Maximum number of comments (default: 25) |
 | `--all` | List all comments (overrides `--limit`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -234,6 +271,15 @@ bb snippet comments list kypj --all
 bb snippet comments list kypj --limit 50 --json
 ```
 
+### Notes
+
+- Table columns: ID, AUTHOR, DATE, CONTENT.
+- CONTENT is truncated to 60 characters; pass the global `--no-truncate` for
+  full comment bodies (`--json` always carries the full value). DATE is
+  formatted with `--locale`/`BB_LOCALE`, falling back to the system locale and
+  then `en-US`.
+- **JSON envelope:** `{ workspace, snippetId, count, comments }`.
+
 ---
 
 ## `bb snippet comments add`
@@ -241,22 +287,35 @@ bb snippet comments list kypj --limit 50 --json
 Add a comment to a snippet.
 
 ```bash
-bb snippet comments add <id> [options]
+bb snippet comments add <id> [message] [options]
 ```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `id` | Snippet encoded ID (e.g. `kypj`) |
+| `message` | Comment body. Alternative to `-m, --message`; one of the two is required. The positional wins if both are passed. |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-m, --message <message>` | Comment body (required) |
-| `--json` | Output as JSON |
+| `-m, --message <text>` | Comment body (alternative to the positional `message`) |
 
 ### Examples
 
 ```bash
+bb snippet comments add kypj "Great snippet!"
 bb snippet comments add kypj -m "Great snippet!"
+bb snippet comments add kypj "Great snippet!" --json
 ```
+
+### Notes
+
+- Omitting both forms fails with
+  `Comment message is required. Use --message option.`
+- **JSON envelope:** `{ success, snippetId, comment }` with the created comment.
 
 ---
 
@@ -268,11 +327,25 @@ Edit a comment on a snippet.
 bb snippet comments edit <snippet-id> <comment-id> <message> [options]
 ```
 
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `snippet-id` | Snippet encoded ID (e.g. `kypj`) |
+| `comment-id` | Numeric comment ID (e.g. `123`) |
+| `message` | Replacement comment body (Markdown) |
+
 ### Examples
 
 ```bash
 bb snippet comments edit kypj 123 "Updated comment"
+bb snippet comments edit kypj 123 "Updated comment" --json
 ```
+
+### Notes
+
+- The message replaces the existing body outright.
+- **JSON envelope:** `{ success, snippetId, comment }` with the updated comment.
 
 ---
 
@@ -284,16 +357,27 @@ Delete a comment on a snippet.
 bb snippet comments delete <snippet-id> <comment-id> [options]
 ```
 
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `snippet-id` | Snippet encoded ID (e.g. `kypj`) |
+| `comment-id` | Numeric comment ID (e.g. `123`) |
+
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
 | `-y, --yes` | Confirm deletion (required) |
-| `--json` | Output as JSON |
 
 ### Examples
 
 ```bash
 bb snippet comments delete kypj 123 --yes
 ```
+
+### Notes
+
+- There is no interactive prompt. Without `--yes` the command fails with
+  `This will permanently delete comment #<comment-id> on snippet <snippet-id>.`
+- **JSON envelope:** `{ success, snippetId, commentId }`.

--- a/docs/src/content/docs/commands/status.mdx
+++ b/docs/src/content/docs/commands/status.mdx
@@ -11,7 +11,13 @@ Status commands operate at **repository** scope. Run them inside a cloned
 Bitbucket repository, or pass `-w, --workspace <workspace>` and
 `-r, --repo <repo>` explicitly.
 
-Global options available on all status commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`, `-r, --repo`.
+Global options available on all status commands: `--json [fields]`,
+`--jq <expression>`, `--no-color`, `--no-unicode`, `--no-truncate`,
+`--locale <locale>`, `-w, --workspace`, `-r, --repo`.
+
+A `<sha>` is a full 40-character hash or any abbreviated prefix (`abc1234`).
+`--json` output is wrapped in an envelope keyed by `workspace` and `repoSlug`;
+the `# →` comments below show each shape.
 
 ---
 
@@ -23,21 +29,12 @@ List the build statuses reported on a commit.
 bb status list <sha> [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `sha` | Commit hash (full or abbreviated, e.g. `abc1234`) |
-
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--limit <number>` | Maximum number of statuses (default: 25) |
 | `--all` | List all statuses (overrides `--limit`) |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -45,7 +42,7 @@ bb status list <sha> [options]
 bb status list abc1234
 bb status list abc1234 --all
 
-# Stable JSON envelope: { workspace, repoSlug, commit, count, statuses }
+# → { workspace, repoSlug, commit, count, statuses }
 bb status list abc1234 --json
 
 # States only, via built-in --jq
@@ -54,41 +51,36 @@ bb status list abc1234 --json --jq '.statuses[].state'
 
 ### Notes
 
-- The table shows the status key, state (colored: green `SUCCESSFUL`, red
-  `FAILED`, yellow `INPROGRESS`, gray `STOPPED`), name, description
-  (truncated to 40 characters; disable with `--no-truncate`), and URL —
-  the same rendering as `bb pr checks`.
-- A `404` returns an actionable "Commit `<sha>` not found" error.
+- Columns: status key, state (colored: green `SUCCESSFUL`, red `FAILED`,
+  yellow `INPROGRESS`, gray `STOPPED`), name, description (truncated to 40
+  characters; disable with `--no-truncate`), and URL.
+- `bb pr checks` colors states the same way but renders a different table:
+  `STATUS / NAME / DESCRIPTION / UPDATED`, with the state shown as
+  `OK passed` / `FAIL failed` / `RUN running` / `STOP stopped` rather than the
+  raw state string.
+- An unknown sha returns `Commit abc1234 not found in acme/api.`
 
 ---
 
 ## `bb status set`
 
-Create or update a build status on a commit.
+Create or update a build status on a commit. `<sha>` is a full or abbreviated
+hash.
 
 ```bash
 bb status set <sha> --key <key> --state <state> [options]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `sha` | Commit hash (full or abbreviated) |
-
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-w, --workspace <workspace>` | Workspace |
-| `-r, --repo <repo>` | Repository |
 | `--key <key>` | **Required.** Unique status key, e.g. `BB-DEPLOY`. Re-running with the same key updates the existing status. |
-| `--state <state>` | **Required.** One of `SUCCESSFUL`, `FAILED`, `INPROGRESS`, `STOPPED` (case-insensitive) |
+| `--state <state>` | **Required.** One of `FAILED`, `INPROGRESS`, `STOPPED`, `SUCCESSFUL` (case-insensitive) |
 | `--url <url>` | Link back to the build system |
 | `--name <name>` | Build identifier, e.g. `BB-DEPLOY-1` |
 | `--description <description>` | Short build description |
 | `--refname <refname>` | Ref the build ran on, e.g. a branch name |
-| `--json` | Output as JSON |
 
 ### Examples
 
@@ -97,7 +89,7 @@ bb status set abc1234 --key CI --state INPROGRESS
 bb status set abc1234 --key CI --state SUCCESSFUL --url https://ci.example.com/builds/42
 bb status set abc1234 --key LINT --state FAILED --description "ESLint found 3 errors" --refname main
 
-# Stable JSON envelope: { workspace, repoSlug, commit, status }
+# → { workspace, repoSlug, commit, status }
 bb status set abc1234 --key CI --state SUCCESSFUL --json --jq '.status.state'
 ```
 
@@ -127,13 +119,21 @@ fi
 
 ### Notes
 
-- **Idempotent per key:** the CLI first POSTs a new status; if Bitbucket
-  rejects it because a status with that key already exists on the commit
-  (typical on CI re-runs), it automatically falls back to updating the
-  existing status via PUT. Repeated `bb status set` calls with the same
-  `--key` are therefore always safe.
-- `--state` is validated client-side against the API enum; an invalid value
-  lists the allowed states.
+- **Idempotent per status key:** the CLI first POSTs a new status. If the POST
+  is rejected for anything other than an auth or not-found failure — most
+  commonly because a status with that key already exists on the commit, the
+  normal case on CI re-runs — it retries as a PUT against the existing key.
+  Repeated `bb status set` calls with the same `--key` are therefore always
+  safe.
+- `--state` is upper-cased before validation, so `successful` and `SUCCESSFUL`
+  both work. An invalid value lists the allowed states and, when the input is
+  close to a valid one, suggests it:
+
+  ```text
+  --state must be one of: FAILED, INPROGRESS, STOPPED, SUCCESSFUL
+  (Did you mean SUCCESSFUL?)
+  ```
+
 - On success the CLI prints `✓ Status <key> set to <state> on <short-sha>`;
   with `--json` it returns the resulting status resource wrapped in
   `{ workspace, repoSlug, commit, status }`.

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -3,17 +3,16 @@ title: Workspace Commands - Discover Bitbucket Workspaces
 description: Reference for Bitbucket CLI workspace commands. List the workspaces you have access to and view workspace details from the command line.
 ---
 
-Discover and inspect Bitbucket Cloud workspaces. Use these commands to find
-the workspace slugs you need for `-w, --workspace`, for
-[`bb config set defaultWorkspace`](/reference/configuration/), and for
+Find the workspace slugs you pass to `-w, --workspace`, to
+[`bb config set defaultWorkspace`](/reference/configuration/), and to
 `bb repo create`.
 
-Workspace commands operate at **account** scope: `bb workspace list` needs no
-workspace context at all (it lists your own workspaces), while
-`bb workspace view` falls back to the resolved workspace context when no slug
-is passed.
+Workspace commands run at **account** scope. `bb workspace list` needs no
+context at all — it lists your own workspaces. `bb workspace view` falls back
+to the resolved workspace context when you pass no slug.
 
-Global options available on all workspace commands: `--json [fields]`, `--jq <expression>`, `--no-color`, `-w, --workspace`.
+Both accept the [global flags](/reference/global-flags/), including
+`--json [fields]`, `--jq <expression>`, and `-w, --workspace`.
 
 ---
 
@@ -41,28 +40,41 @@ bb workspace list
 bb workspace list --role owner
 bb workspace list --all
 
-# Project to specific fields (returns a flat array)
+# Only the columns you need — a flat array, not the envelope
 bb workspace list --json slug,name
 
-# Grab slugs for scripting with built-in --jq
+# Slugs, one per line (JSON-quoted — the embedded jq has no -r)
 bb workspace list --json --jq '.workspaces[].slug'
+
+# Bare slugs for a shell loop, via the jq binary
+bb workspace list --json | jq -r '.workspaces[].slug'
 ```
+
+### Output
+
+```text
+SLUG           NAME           PRIVACY  UUID
+-------------  -------------  -------  --------------------------------------
+acme-corp      Acme Corp      private  {6f1e8a2c-9d34-4b7e-8f21-0c5a7d3e1b90}
+side-projects  Side Projects  public   {b2c9e740-15af-4d63-9a08-3e6f2c81d475}
+Use a slug with -w <slug> or set a default: bb config set defaultWorkspace <slug>
+```
+
+That last line prints after every non-JSON `bb workspace list`.
 
 ### JSON output
 
-The `--json` envelope is `{ filters, count, workspaces }`, where `workspaces`
-is the array of workspace objects and `filters` echoes the active `--role`
-filter (empty object when unfiltered).
+The envelope is `{ filters, count, workspaces }`. `workspaces` holds the
+workspace objects; `filters` echoes the active `--role` filter, and is an empty
+object when unfiltered.
 
 ### Notes
 
-- Requires no workspace context — this is the discovery entry point when you
-  do not know your slugs yet.
-- After listing, use a slug with `-w <slug>` on any command, or set a default
-  once: `bb config set defaultWorkspace <slug>`.
 - Role semantics: `owner` = admin access, `collaborator` = write access to at
   least one repository, `member` = member of at least one group or repository.
-- When the result is capped by `--limit`, a hint shows how many were listed; use a higher `--limit` or `--all` to see the rest (suppressed with `--json`).
+- When more results exist than `--limit` returned, the table is followed by
+  `Showing 25 workspaces. Use --limit <n> or --all to see more.` This footer is
+  never printed under `--json`.
 
 ---
 
@@ -90,21 +102,30 @@ bb workspace view [slug] [options]
 ### Examples
 
 ```bash
-# View the current workspace (from -w, the current repo's remote,
-# BB_WORKSPACE, or defaultWorkspace)
+# Resolved workspace: -w, the current repository's remote,
+# BB_WORKSPACE, then defaultWorkspace
 bb workspace view
 
 bb workspace view my-workspace
 
-# Stable JSON envelope: { workspace: { ... } }
+# JSON is wrapped: { workspace: { ... } }
 bb workspace view my-workspace --json --jq '.workspace.uuid'
 ```
 
 ### Notes
 
-- Without a `slug`, the workspace is resolved like any other command: `-w`
-  flag, then the current repository's Bitbucket remote, then the
-  `BB_WORKSPACE` environment variable, then the configured
-  `defaultWorkspace`.
-- A missing or inaccessible workspace returns a clear not-found error
-  (exit code 1, `--json` gives a structured error envelope).
+- Without a `slug`, the workspace resolves in this order: the `-w` flag, the
+  current repository's Bitbucket remote, the `BB_WORKSPACE` environment
+  variable, then the configured `defaultWorkspace`.
+- An unknown or inaccessible slug fails with
+  `Workspace <slug> not found (or you do not have access to it).` — exit code 1,
+  and `--json` writes a structured error envelope to stderr. Because that
+  message already names the missing workspace, the generic 404 "check the
+  slug" hint is suppressed.
+
+### Related
+
+- [Project Commands](/commands/project/) — list the projects inside a workspace.
+- [Repository Context](/guides/repository-context/) — how the CLI resolves
+  workspace and repository.
+- [Configuration](/reference/configuration/) — set `defaultWorkspace` once.

--- a/docs/src/content/docs/getting-started/authentication.mdx
+++ b/docs/src/content/docs/getting-started/authentication.mdx
@@ -3,29 +3,25 @@ title: Authentication
 description: How to authenticate with Bitbucket
 ---
 
-import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-The Bitbucket CLI supports two authentication methods: **OAuth** (recommended) and **API Tokens**.
+The Bitbucket CLI supports two authentication methods: **OAuth** (recommended) and **API tokens**.
 
-## OAuth (Recommended)
-
-The simplest way to authenticate. Just run:
+## OAuth (recommended)
 
 ```bash
 bb auth login
 ```
 
-This opens your browser where you authorize the CLI with your Bitbucket account. No tokens to copy, no scopes to select manually.
+This opens your browser where you authorize the CLI with your Bitbucket account. No tokens to copy, no scopes to select manually. Tokens expire after 2 hours and are refreshed automatically.
 
-<Aside type="tip">
-OAuth tokens expire after 2 hours but are refreshed automatically — you won't be interrupted.
-</Aside>
+If `BB_API_TOKEN` is exported in your shell, `bb auth login` uses API-token auth instead of opening a browser. It is the variable being *set* that switches the flow, not its value — even `export BB_API_TOKEN=` does it. Run `unset BB_API_TOKEN` first if you want OAuth.
 
 <Aside type="caution">
 OAuth needs a browser that can reach a loopback callback server on `http://localhost:19872/callback`. There is **no device-code flow**, so if you're on a headless host (SSH session, container, CI runner) where no browser is available, use an [API token](#api-token-for-cicd-and-headless-environments) instead.
 </Aside>
 
-### Using a Custom OAuth Consumer
+### Using a custom OAuth consumer
 
 Organizations can use their own OAuth consumer instead of the built-in default:
 
@@ -42,15 +38,19 @@ To set up a custom OAuth consumer:
 
 Custom credentials are stored in your config file for subsequent logins.
 
+<Aside type="caution" title="OAuth cannot reach every command">
+The CLI requests a hardcoded OAuth scope set: `account repository repository:admin pullrequest pullrequest:write`. A custom consumer cannot widen it. `bb pipeline`, `bb issue`, `bb snippet`, `bb project` and `bb repo delete` are not covered — use an API token for those. See [Token Scopes](/reference/token-scopes/).
+</Aside>
+
 ---
 
-## API Token (for CI/CD and headless environments)
+## API token (for CI/CD and headless environments)
 
 Use API tokens when a browser is not available (SSH sessions, Docker containers, CI/CD pipelines).
 
 <Steps>
 
-1. **Create an API Token**
+1. **Create an API token**
 
    1. Log in to [Bitbucket](https://bitbucket.org)
    2. Go to **Personal settings** (click your avatar in the bottom left)
@@ -59,16 +59,17 @@ Use API tokens when a browser is not available (SSH sessions, Docker containers,
    5. Give it a descriptive name (e.g., "Bitbucket CLI")
    6. Select the required scopes:
       - `read:user:bitbucket` — verify your identity
-      - `read:repository:bitbucket` — list and view repositories
-      - `write:repository:bitbucket` — create repositories
-      - `admin:repository:bitbucket` — delete repositories (optional)
+      - `read:repository:bitbucket` — list and view repositories, commits, build statuses
+      - `write:repository:bitbucket` — set commit build statuses
+      - `admin:repository:bitbucket` — create repositories, manage default reviewers
+      - `delete:repository:bitbucket` — delete repositories (optional)
       - `read:pullrequest:bitbucket` — list and view pull requests
       - `write:pullrequest:bitbucket` — create, edit, merge, approve, decline pull requests
 
       See [Token Scopes](/reference/token-scopes/) for a per-command breakdown
       if you want to mint a token with the minimum scope set for your workflow.
    7. Click **Create**
-   8. **Copy the generated token** - you won't be able to see it again!
+   8. **Copy the generated token** — Bitbucket will not show it again.
 
 2. **Authenticate**
 
@@ -77,11 +78,16 @@ Use API tokens when a browser is not available (SSH sessions, Docker containers,
    ```
 
    Or pipe the token via stdin so it never lands in your shell history or
-   `ps` output (recommended, and great with secret managers):
+   `ps` output (recommended):
 
    ```bash
    echo "$BB_API_TOKEN" | bb auth login -u your-username --with-token
    ```
+
+   `--with-token` reads all of stdin and trims it, so a trailing newline is
+   fine. It cannot be combined with `-p` — that fails with error `5002`
+   ("Cannot combine --password with --with-token"). If nothing is piped in,
+   the login fails with `5001` ("No API token found on stdin").
 
    Or using environment variables:
 
@@ -101,13 +107,23 @@ See [Environment Variables Reference](/reference/environment-variables/) for mor
 
 ---
 
-## Check Auth Status
+## Check auth status
 
 ```bash
 bb auth status
 ```
 
-This shows your current authentication method, account information, and token expiry (for OAuth).
+```text
+✓ Logged in to Bitbucket
+  Authentication: OAuth
+  Username: jdoe
+  Display name: Jane Doe
+  Account ID: 5f1a2b3c4d5e6f7a8b9c0d1e
+  Token expires: in 1h 42m
+  Default workspace: acme
+```
+
+`Token expires` only appears for OAuth logins. `Default workspace` only appears once one is configured. Add `--json` for a machine-readable version.
 
 ## Logout
 
@@ -117,7 +133,7 @@ bb auth logout
 
 This removes stored credentials and revokes your OAuth token (if using OAuth). Non-auth settings are preserved.
 
-## Configuration Storage
+## Configuration storage
 
 Credentials are stored in:
 
@@ -127,10 +143,10 @@ Credentials are stored in:
 See [Configuration File Reference](/reference/configuration/) for details on the config file format.
 
 <Aside type="caution">
-Never share your credentials or config file. Keep them secure!
+Tokens are stored in plaintext JSON. On Linux and macOS the CLI writes the file with mode `600` and the directory with mode `700`, and refuses to read either if any group or other permission bit is set — you get error `4001` with the exact `chmod` to run. Windows skips the check.
 </Aside>
 
-## Next Steps
+## Next steps
 
 - [Quick Start Guide](/getting-started/quickstart/) - Get up and running in 60 seconds
 - [Repository Context](/guides/repository-context/) - How the CLI detects your workspace/repo

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -1,36 +1,46 @@
 ---
-title: Install Bitbucket CLI - npm, pnpm, Bun Setup Guide
-description: Step-by-step installation guide for Bitbucket CLI using npm, pnpm, or Bun. Learn prerequisites, global installation, and build from source. Get started in minutes.
+title: Installation
+description: Install the Bitbucket CLI with npm, pnpm, or Bun, or build it from source. Requires the Bun runtime.
 ---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Prerequisites
 
-- [Bun](https://bun.sh) runtime 1.0 or higher (required to run the CLI)
+- [Bun](https://bun.sh) runtime 1.0 or higher — the CLI runs on Bun, not Node.js
 - Git
+
+Install Bun if `bun --version` fails:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+For other platforms and install methods, see [bun.sh](https://bun.sh).
 
 ## Install
 
-You can install the CLI using any package manager, but **Bun runtime is required** to execute it.
+Any package manager works. Bun is still required to run `bb`.
 
-### Using npm
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npm install -g @pilatos/bitbucket-cli
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add -g @pilatos/bitbucket-cli
+    ```
+  </TabItem>
+  <TabItem label="Bun">
+    ```bash
+    bun install -g @pilatos/bitbucket-cli
+    ```
+  </TabItem>
+</Tabs>
 
-```bash
-npm install -g @pilatos/bitbucket-cli
-```
-
-### Using pnpm
-
-```bash
-pnpm add -g @pilatos/bitbucket-cli
-```
-
-### Using Bun
-
-```bash
-bun install -g @pilatos/bitbucket-cli
-```
-
-## Build from Source
+## Build from source
 
 ```bash
 # Clone the repository
@@ -47,12 +57,15 @@ bun run build
 bun link
 ```
 
-## Verify Installation
+## Verify installation
 
 ```bash
 bb --version
 ```
 
-## Next Steps
+## Next steps
 
-After installation, you'll need to [authenticate](/getting-started/authentication/) with your Bitbucket account.
+[Authenticate](/getting-started/authentication/) with your Bitbucket account.
+
+Then install [shell completion](/commands/completion/) so your shell can
+complete `bb` subcommands and flags.

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -3,9 +3,7 @@ title: Quick Start
 description: Get up and running with Bitbucket CLI in 60 seconds
 ---
 
-import { Steps, Aside, Code } from '@astrojs/starlight/components';
-
-Get productive with the Bitbucket CLI in under a minute.
+import { Steps, Aside } from '@astrojs/starlight/components';
 
 ## TL;DR
 
@@ -16,22 +14,12 @@ bb repo clone myworkspace/myrepo
 bb pr create -t "My feature"
 ```
 
----
-
 ## Prerequisites
 
-Before you begin, you'll need:
+- **[Bun](https://bun.sh) runtime 1.0+**. Installing via npm or pnpm does not install Bun. Without it, `bb` exits with `Error: This CLI requires the Bun runtime.` See [Installation](/getting-started/installation/).
+- A **Bitbucket Cloud** account.
 
-- **[Bun](https://bun.sh) runtime 1.0+** installed (required to run the CLI)
-- A **Bitbucket Cloud** account
-
-<Aside type="caution">
-The CLI requires Bun runtime to execute. You can install the package via npm/pnpm/bun, but Bun must be available on your system to run `bb` commands.
-</Aside>
-
----
-
-## Step-by-Step Setup
+## Step-by-step setup
 
 <Steps>
 
@@ -54,10 +42,12 @@ The CLI requires Bun runtime to execute. You can install the package via npm/pnp
 
    This opens your browser to authorize the CLI with your Bitbucket account. No token setup needed.
 
-   For CI/CD or headless environments, use an API token instead:
+   For CI/CD or headless environments, pipe an API token in on stdin:
    ```bash
-   bb auth login -u your-username -p your-api-token
+   echo "$BB_API_TOKEN" | bb auth login -u your-username --with-token
    ```
+
+   If `BB_API_TOKEN` is set in your environment, a bare `bb auth login` uses API token auth instead of OAuth.
 
    Verify it worked:
    ```bash
@@ -66,14 +56,14 @@ The CLI requires Bun runtime to execute. You can install the package via npm/pnp
 
    See the [Authentication guide](/getting-started/authentication/) for full details.
 
-3. **Clone a Repository**
+3. **Clone a repository**
 
    ```bash
    bb repo clone myworkspace/myrepo
    cd myrepo
    ```
 
-4. **Create Your First PR**
+4. **Create your first pull request**
 
    ```bash
    git checkout -b feature/my-feature
@@ -87,11 +77,7 @@ The CLI requires Bun runtime to execute. You can install the package via npm/pnp
 
 </Steps>
 
----
-
-## Common Commands
-
-Here are the commands you'll use most often:
+## Common commands
 
 | Command | Description |
 |---------|-------------|
@@ -107,9 +93,7 @@ Here are the commands you'll use most often:
 | `bb browse src/cli.ts:20` | Open a file at a specific line in your browser |
 | `bb api /user` | Call any Bitbucket API endpoint (escape hatch) |
 
----
-
-## Set a Default Workspace
+## Set a default workspace
 
 Not sure what your workspace slug is? List the workspaces you have access to:
 
@@ -126,15 +110,11 @@ bb config set defaultWorkspace myworkspace
 Now commands will use this workspace automatically:
 
 ```bash
-bb repo list          # Lists repos in "myworkspace"
+bb repo list          # Lists repositories in "myworkspace"
 bb pr list -r myrepo  # Lists PRs in "myworkspace/myrepo"
 ```
 
----
-
-## Enable Tab Completion
-
-Get intelligent tab completion for commands and options:
+## Enable tab completion
 
 ```bash
 bb completion install
@@ -143,13 +123,11 @@ bb completion install
 Restart your shell, then try:
 
 ```bash
-bb <Tab>                         # Shows: auth, repo, pr, snippet, browse, api, config, completion
+bb <Tab>                         # Shows every top-level command
 bb pr <Tab>                      # Shows: activity, approve, checkout, checks, comments, create, decline, diff, edit, list, merge, ready, reviewers, view
 bb pr create -<Tab>              # Shows available flags
 bb pr merge 42 --strategy <Tab>  # Shows: merge_commit, squash, fast_forward, ...
 ```
-
----
 
 ## Scripting with JSON
 
@@ -167,21 +145,21 @@ bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
 See [JSON Output](/reference/json-output/) for the full shape reference and the [Scripting guide](/guides/scripting/) for end-to-end automation patterns.
 </Aside>
 
----
-
 ## Update notifications
 
-When a newer version is available on npm, `bb` prints a one-time nudge after
-the next command finishes:
+When a newer version is available on npm, `bb` writes a one-time notice to stderr after the next command finishes:
 
 ```text
-⚠ A new version is available: 1.14.0 (you have 1.13.0)
-  Run 'npm install -g @pilatos/bitbucket-cli' to update
+──────────────────────────────────────────────────
+A new version is available: 1.23.0 (you have 1.22.0)
+  Run 'bun install -g @pilatos/bitbucket-cli' to update
   Or disable with 'bb config set skipVersionCheck true'
+──────────────────────────────────────────────────
 ```
 
-The check runs at most once per `versionCheckInterval` (default: 24 hours) and
-is skipped automatically in CI environments. Disable it permanently with:
+Under `--no-unicode` or `BB_NO_UNICODE`, the horizontal rules are drawn with `-` instead of `─`.
+
+The notice never appears with `--json`, when stderr is not a TTY, or in CI environments. The check itself runs at most once every `versionCheckInterval` days (default: 1). Disable it permanently with:
 
 ```bash
 bb config set skipVersionCheck true
@@ -190,14 +168,10 @@ bb config set skipVersionCheck true
 See the [Configuration File reference](/reference/configuration/) for related
 settings.
 
----
-
-## Next Steps
-
-You're all set! Here's where to go next:
+## Next steps
 
 - **[Command Reference](/commands/auth/)** - Full documentation for all commands
-- **[Repository Context](/guides/repository-context/)** - How the CLI detects your workspace/repo
+- **[Repository Context](/guides/repository-context/)** - How the CLI detects your workspace/repository
 - **[Scripting & Automation](/guides/scripting/)** - Use bb in scripts and CI/CD
 - **[JSON Output Reference](/reference/json-output/)** - Field projection, `--jq` filtering, output shapes
 - **[AI Agent Integration](/guides/ai-agents/)** - Wire the CLI into Claude Code, Cursor, or Windsurf

--- a/docs/src/content/docs/guides/ai-agents.mdx
+++ b/docs/src/content/docs/guides/ai-agents.mdx
@@ -5,9 +5,9 @@ description: Set up the Bitbucket CLI with Claude Code, opencode, Cursor, Windsu
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Manage pull requests, repositories, and code reviews through natural conversation. Tell your AI assistant "Create a PR for this branch" and it handles the commands, flags, and context automatically.
+Drop a skill or rules file into your project and your coding assistant drives Bitbucket through `bb`. The templates below cover Claude Code, opencode, Cursor, and Windsurf.
 
-## Quick Start
+## Quick start
 
 Pick your editor and paste the command:
 
@@ -42,12 +42,15 @@ Pick your editor and paste the command:
     **Review:** `bb pr checkout <id>` → `bb pr diff <id>` → `bb pr approve <id>`
     **Merge:** `bb pr merge <id> --strategy squash --close-source-branch`
     **Draft:** `bb pr create -t "WIP" --draft` → later `bb pr ready <id>`
-    **Comments:** `bb pr comments list <id>` / `bb pr comments add <id> "text"`
+    **Comments:** `bb pr comments list <id>` (add `--unresolved` to see open threads), `bb pr comments add <id> "text"`, `bb pr comments view <pr-id> <comment-id>`
+    **Review threads:** `bb pr comments reply <pr-id> <comment-id> "text"` → `bb pr comments resolve <pr-id> <comment-id>` (`unresolve` reopens); `bb pr comments edit <pr-id> <comment-id> "text"`, `bb pr comments delete <pr-id> <comment-id>`
     **Repos:** `bb repo list`, `bb repo clone workspace/repo`, `bb repo view`
     **CI/CD:** `bb pipeline list`, `bb pipeline run --branch main`, `bb pipeline view/logs/stop <id>`
     **Commits:** `bb commit list`, `bb commit view <sha>`; build statuses: `bb status list <sha>`, `bb status set <sha> --key CI --state SUCCESSFUL`
     **Issues:** `bb issue list`, `bb issue view <id>`, `bb issue create -t "title"`, `bb issue edit/comment/close <id>`
+    **Snippets:** `bb snippet list/view/create/edit/delete/watch/unwatch`, plus `bb snippet comments`
     **Workspaces & projects:** `bb workspace list/view`, `bb project list/view/create`
+    **Browser URLs:** `bb browse --pr <id> -n` prints the URL instead of opening it (`--json` does the same and returns `{"url": …}`)
     **Raw API:** `bb api <endpoint>` — any Bitbucket 2.0 endpoint not covered above (e.g. `bb api /repositories/{workspace}/{repo}/branch-restrictions`; supports `--paginate` and `--jq`)
 
     ## Tips
@@ -60,7 +63,7 @@ Pick your editor and paste the command:
     echo "✓ Skill installed. Restart Claude Code to activate."
     ```
 
-    Restart Claude Code and try: **"List my open PRs"**
+    Restart Claude Code and try: **"List my open pull requests"**
 
     <Aside type="tip">
       This also registers `/bb-cli` as a slash command. For personal use across all projects, install to `~/.claude/skills/bb-cli/SKILL.md` instead. Commit the project-level file to git so your team gets it automatically.
@@ -88,8 +91,15 @@ Pick your editor and paste the command:
     - `bb pr approve <id>` / `bb pr decline <id>` - Review
     - `bb pr merge <id> --strategy squash --close-source-branch` - Merge
     - `bb pr ready <id>` - Mark draft as ready
-    - `bb pr comments add <id> "text"` - Add comment
     - `bb pr reviewers add <id> <uuid>` - Add reviewer to an existing PR
+
+    **PR comments and review threads:**
+    - `bb pr comments list <id>` - List comments (`--resolved` / `--unresolved` to filter)
+    - `bb pr comments add <id> "text"` - Add a top-level comment
+    - `bb pr comments view <pr-id> <comment-id>` - Read one comment
+    - `bb pr comments reply <pr-id> <comment-id> "text"` - Reply in a thread
+    - `bb pr comments resolve <pr-id> <comment-id>` / `unresolve <pr-id> <comment-id>` - Close or reopen a thread
+    - `bb pr comments edit <pr-id> <comment-id> "text"` / `delete <pr-id> <comment-id>` - Edit or remove
 
     **Repositories:**
     - `bb repo list` / `bb repo view` / `bb repo clone workspace/repo`
@@ -110,6 +120,13 @@ Pick your editor and paste the command:
     **Workspaces & projects:**
     - `bb workspace list` / `bb workspace view [slug]`
     - `bb project list` / `bb project view <key>` / `bb project create`
+
+    **Snippets:**
+    - `bb snippet list` / `view` / `create` / `edit` / `delete` / `watch` / `unwatch`
+    - `bb snippet comments list <id>` / `add <id> "text"`
+
+    **Browser URLs:**
+    - `bb browse --pr <id> -n` - Print the PR URL instead of opening a browser (`--json` returns `{"url": …}`)
 
     **Raw API access:**
     - `bb api <endpoint>` - Authenticated call to any Bitbucket 2.0 endpoint (escape hatch for anything without a typed command; e.g. `bb api /repositories/{workspace}/{repo}/branch-restrictions`; supports `--paginate` and `--jq`)
@@ -155,12 +172,17 @@ Pick your editor and paste the command:
     - `bb pr approve/decline/merge <id>` - Review and merge
     - `bb pr merge <id> --strategy squash --close-source-branch`
     - `bb pr ready <id>` - Mark draft as ready
+    - `bb pr comments list <id>` - List comments (`--resolved`/`--unresolved` to filter)
     - `bb pr comments add <id> "text"` - Comment on PR
+    - `bb pr comments reply/resolve/unresolve <pr-id> <comment-id>` - Work a review thread
+    - `bb pr comments view/edit/delete <pr-id> <comment-id>` - Read, edit, remove a comment
     - `bb repo list/view/clone` - Repository operations
     - `bb pipeline list/view/run/stop/logs` - CI/CD pipelines
     - `bb commit list/view` + `bb status list/set <sha>` - Commits and build statuses
     - `bb issue list/view/create/edit/comment/close` - Issue tracker
+    - `bb snippet list/view/create/edit/delete/watch/unwatch` + `bb snippet comments` - Snippets
     - `bb workspace list/view` + `bb project list/view/create` - Workspaces and projects
+    - `bb browse --pr <id> -n` - Print a Bitbucket URL instead of opening a browser
     - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
@@ -189,12 +211,17 @@ Pick your editor and paste the command:
     - `bb pr approve/decline/merge <id>` - Review and merge
     - `bb pr merge <id> --strategy squash --close-source-branch`
     - `bb pr ready <id>` - Mark draft as ready
+    - `bb pr comments list <id>` - List comments (`--resolved`/`--unresolved` to filter)
     - `bb pr comments add <id> "text"` - Comment on PR
+    - `bb pr comments reply/resolve/unresolve <pr-id> <comment-id>` - Work a review thread
+    - `bb pr comments view/edit/delete <pr-id> <comment-id>` - Read, edit, remove a comment
     - `bb repo list/view/clone` - Repository operations
     - `bb pipeline list/view/run/stop/logs` - CI/CD pipelines
     - `bb commit list/view` + `bb status list/set <sha>` - Commits and build statuses
     - `bb issue list/view/create/edit/comment/close` - Issue tracker
+    - `bb snippet list/view/create/edit/delete/watch/unwatch` + `bb snippet comments` - Snippets
     - `bb workspace list/view` + `bb project list/view/create` - Workspaces and projects
+    - `bb browse --pr <id> -n` - Print a Bitbucket URL instead of opening a browser
     - `bb api <endpoint>` - Raw call to any Bitbucket 2.0 endpoint (escape hatch; `--paginate`, `--jq`)
     - `bb config set defaultWorkspace <ws>` - Set defaults
 
@@ -206,20 +233,18 @@ Pick your editor and paste the command:
 </Tabs>
 
 <Aside type="tip">
-  **No setup at all?** Just tell your AI assistant:
-  *"Run `bb --help` to learn the bb CLI, then use it to list my open PRs."*
+  **No setup at all?** Tell your AI assistant:
+  *"Run `bb --help` to learn the Bitbucket CLI, then use it to list my open PRs."*
   Most AI coding assistants can learn any CLI from its `--help` output on the fly.
 </Aside>
 
 ---
 
-## Example Workflows
-
-These show what's possible once your AI assistant knows about `bb`. Natural language works — exact phrasing doesn't matter.
+## Example workflows
 
 ### Create and submit a PR
 
-```
+```text
 You: Push my changes and create a PR titled "Add input validation"
       with a description of what changed
 
@@ -234,7 +259,7 @@ AI:   [Runs: git push -u origin feat/input-validation]
 
 ### Review multiple PRs at once
 
-```
+```text
 You: Show me all open PRs and summarize which ones are ready to merge
 
 AI:   [Runs: bb pr list --json]
@@ -251,7 +276,7 @@ AI:   [Runs: bb pr list --json]
 
 ### Full review-and-merge cycle
 
-```
+```text
 You: Check out PR 42, review the diff, and if it looks good,
      approve and squash-merge it
 
@@ -269,9 +294,30 @@ AI:   [Runs: bb pr checkout 42]
       ✅ Merged PR #42 with squash strategy. Source branch deleted.
 ```
 
+### Work an open review thread
+
+```text
+You: What review comments are still open on PR 45?
+
+AI:   [Runs: bb pr comments list 45 --unresolved]
+
+      2 unresolved:
+      • #109820 bob — "This retry loop has no upper bound."
+      • #109834 bob — "Missing test for the 429 path."
+
+You: Fix both, then reply and resolve them
+
+AI:   [Edits src/client.ts, adds tests]
+      [Runs: bb pr comments reply 45 109820 "Capped at 3 attempts in a1b2c3d."]
+      [Runs: bb pr comments resolve 45 109820]
+      [Runs: bb pr comments reply 45 109834 "Added a 429 retry test in a1b2c3d."]
+      [Runs: bb pr comments resolve 45 109834]
+      ✅ Both threads replied to and resolved.
+```
+
 ### Draft PR workflow
 
-```
+```text
 You: Create a draft PR for my work-in-progress
 
 AI:   [Runs: bb pr create -t "WIP: New dashboard" --draft]
@@ -304,24 +350,43 @@ bb auth login   # Reads from env vars automatically
 
 ### Required API token scopes
 
+These cover the command families the templates above teach. For the full
+command-to-scope map, see [Token Scopes](/reference/token-scopes/).
+
 | Scope | Required for |
 |-------|-------------|
-| `read:user:bitbucket` | `bb auth status` — verify identity |
-| `read:repository:bitbucket` | `bb repo list`, `bb repo view` — browse repos |
-| `write:repository:bitbucket` | `bb repo create` — create repos |
-| `admin:repository:bitbucket` | `bb repo delete` — delete repos (optional) |
-| `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view`, `bb pr diff` — browse PRs |
-| `write:pullrequest:bitbucket` | `bb pr create`, `bb pr merge`, `bb pr approve` — manage PRs |
+| `read:user:bitbucket` | Identity checks — `bb auth status`, plus resolving your own UUID for `bb pr create` and `bb pr list --mine` |
+| `read:repository:bitbucket` | `bb repo list`, `bb repo view`, `bb commit list/view`, `bb status list` — browse repos and commits |
+| `write:repository:bitbucket` | `bb status set` — set commit build statuses |
+| `admin:repository:bitbucket` | `bb repo create`, `bb repo default-reviewers add/remove` |
+| `delete:repository:bitbucket` | `bb repo delete` — delete repos (optional) |
+| `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view`, `bb pr diff`, `bb pr comments list` — browse PRs |
+| `write:pullrequest:bitbucket` | `bb pr create`, `bb pr merge`, `bb pr approve`, `bb pr comments add/reply/resolve` — manage PRs |
 | `read:pipeline:bitbucket` | `bb pipeline list`, `bb pipeline view`, `bb pipeline logs` — inspect CI/CD |
 | `write:pipeline:bitbucket` | `bb pipeline run`, `bb pipeline stop` — control CI/CD |
 | `read:issue:bitbucket` | `bb issue list`, `bb issue view` — browse issues |
 | `write:issue:bitbucket` | `bb issue create`, `bb issue edit`, `bb issue close` — manage issues |
 | `read:workspace:bitbucket` | `bb workspace list`, `bb workspace view` — discover workspaces |
 | `read:project:bitbucket` | `bb project list`, `bb project view` — browse projects |
+| `admin:project:bitbucket` | `bb project create` — create projects |
+| `read:snippet:bitbucket` | `bb snippet list`, `bb snippet view` — browse snippets |
+| `write:snippet:bitbucket` | `bb snippet create/edit/delete/watch/unwatch` — manage snippets |
 
-<Aside type="tip">
-  For read-only workflows (listing and viewing PRs), you only need the `read` scopes. OAuth users don't need to select scopes manually — they are requested automatically.
-</Aside>
+For read-only agents (listing and viewing), the `read` scopes are enough.
+
+### OAuth agents
+
+`bb auth login` defaults to OAuth, which requests a fixed scope set and never
+prompts you to choose:
+
+```text
+account repository repository:admin pullrequest pullrequest:write
+```
+
+That covers repository and pull request work, including `bb repo create` and
+`bb repo default-reviewers`. It does **not** cover `bb pipeline`, `bb issue`,
+`bb project`, `bb snippet`, or `bb repo delete` — those return 403 under OAuth.
+Use an API token with the scopes above if your agent needs them.
 
 ---
 
@@ -355,17 +420,16 @@ of scraping HTML:
 | [`/llms-small.txt`](https://bitbucket-cli.paulvanderlei.com/llms-small.txt) | Abridged subset (excludes Help / FAQ / Changelog) for tight context windows |
 
 All three are generated at build time, so they always match the live docs.
-You don't need to do anything to consume them — tools that support
-`llms.txt` will discover them automatically. If your tool doesn't, paste
-the URL into the chat (`@https://bitbucket-cli.paulvanderlei.com/llms-full.txt`
-in Cursor, for example).
+Tools that support `llms.txt` find them on their own. For everything else,
+paste the URL into the chat — in Cursor,
+`@https://bitbucket-cli.paulvanderlei.com/llms-full.txt`.
 
 ---
 
-## Related Guides
+## Related guides
 
 - [Scripting & Automation](/guides/scripting/) — JSON output, exit codes, and shell scripting patterns
 - [CI/CD Integration](/guides/cicd/) — Use `bb` in GitHub Actions, GitLab CI, Jenkins, and more
 - [JSON Output Reference](/reference/json-output/) — Detailed JSON schemas for all commands
-- [Error Codes](/reference/error-codes/) — Full list of exit codes and their meanings
+- [Error Codes](/reference/error-codes/) — the numeric `code` values in `--json` error output (the process exit code is always 0 or 1)
 - [Command Reference](/commands/pr/) — Complete PR command documentation

--- a/docs/src/content/docs/guides/cicd.mdx
+++ b/docs/src/content/docs/guides/cicd.mdx
@@ -5,42 +5,69 @@ description: Integrate Bitbucket CLI into your CI/CD pipelines. Step-by-step exa
 
 import { Aside, Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-The Bitbucket CLI can automate pull request workflows, add comments, and manage repositories in your CI/CD pipelines.
+The Bitbucket CLI automates pull request (PR) workflows, reports build statuses back to commits, and triggers Bitbucket Pipelines from any CI system.
 
-## Quick Setup
+## Quick setup
 
 <Steps>
 
-1. **Store credentials as secrets** in your CI/CD platform
-   - `BB_USERNAME` - Your Bitbucket username
-   - `BB_API_TOKEN` - Your Bitbucket API token
+1. **Store credentials as secrets** in your CI/CD platform.
+   - `BB_USERNAME` — your Bitbucket username
+   - `BB_API_TOKEN` — your Bitbucket API token
 
-2. **Install Bun and the CLI** in your pipeline
+2. **Install Bun and the CLI.** The CLI is Bun-only; it exits immediately under Node.js.
+
    ```bash
-   # Install Bun (required runtime)
    curl -fsSL https://bun.sh/install | bash
-   # Install the CLI (can use npm/pnpm/bun)
-   npm install -g @pilatos/bitbucket-cli
+   export PATH="$HOME/.bun/bin:$PATH"
+   bun install -g @pilatos/bitbucket-cli
    ```
 
-3. **Authenticate** using environment variables
+   On an image that already ships Bun (`oven/bun:latest`) skip the `curl` line and keep the other two — those images contain no Node.js and no npm.
+
+3. **Authenticate.** With `BB_API_TOKEN` set in the environment, `bb auth login` takes the API-token path and stores the credentials. With no token set it opens a browser for OAuth and waits five minutes for a callback that never arrives in a headless runner.
+
    ```bash
    bb auth login
    ```
 
-4. **Run commands** with explicit workspace/repo flags
+4. **Run commands** with explicit workspace and repository flags.
+
    ```bash
    bb pr list -w myworkspace -r myrepo --json
    ```
 
-   If your pipeline needs more than the default page size, include
-   `--limit <number>` on list commands.
-
 </Steps>
+
+### Paging
+
+List commands return 25 items by default. Pass `--limit <n>` to raise or lower that cap, or `--all` to fetch every page — `--all` overrides `--limit`.
+
+```bash
+bb pr list -w myworkspace -r myrepo --all --json
+```
+
+See [Global Flags](/reference/global-flags/#list-command-flags).
+
+### Reading JSON without an external jq
+
+`--json [fields]` and `--jq <expression>` are global flags. `--jq` runs an embedded jq, so it works on minimal CI images and on Windows agents that have no `jq` binary. `--jq` requires `--json`.
+
+```bash
+# Project to a comma-separated field list
+bb pr list -w myworkspace -r myrepo --json id,title
+
+# Filter with the embedded jq
+bb pr list -w myworkspace -r myrepo --all --json --jq '.pullRequests[].id'
+```
+
+Projection runs before jq, and `--json <fields>` drops the envelope on list commands — `count` disappears once you project. See [Scripting & Automation](/guides/scripting/#field-selection-and---jq).
 
 ---
 
-## Platform Examples
+## Platform examples
+
+Each snippet shows the platform-specific part: how secrets reach the job, and how `~/.bun/bin` gets on `PATH`. The install and `bb auth login` steps are the same everywhere.
 
 ### GitHub Actions
 
@@ -65,71 +92,18 @@ jobs:
           bun-version: latest
 
       - name: Install Bitbucket CLI
-        run: npm install -g @pilatos/bitbucket-cli
+        run: bun install -g @pilatos/bitbucket-cli
 
-      - name: Authenticate
-        env:
-          BB_USERNAME: ${{ secrets.BB_USERNAME }}
-          BB_API_TOKEN: ${{ secrets.BB_API_TOKEN }}
-        run: bb auth login
-
-      - name: List Open PRs
-        run: |
-          bb pr list -w myworkspace -r myrepo --json > prs.json
-          echo "Open PRs: $(jq '.count' prs.json)"
-```
-
-#### Auto-Create PR on Push
-
-```yaml
-name: Auto-Create PR
-
-on:
-  push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
-
-jobs:
-  create-pr:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Setup
-        run: npm install -g @pilatos/bitbucket-cli
-
-      - name: Create PR
+      - name: List open PRs
         env:
           BB_USERNAME: ${{ secrets.BB_USERNAME }}
           BB_API_TOKEN: ${{ secrets.BB_API_TOKEN }}
         run: |
           bb auth login
-
-          BRANCH=${GITHUB_REF#refs/heads/}
-          TITLE="$(echo $BRANCH | sed 's/[-_]/ /g' | sed 's/feature\///; s/fix\//Fix: /')"
-
-          # Check if PR already exists
-          EXISTING=$(bb pr list -w workspace -r repo --json | \
-            jq --arg branch "$BRANCH" '[.pullRequests[] | select(.source.branch.name == $branch)] | length')
-
-          if [ "$EXISTING" -eq 0 ]; then
-            bb pr create -w workspace -r repo \
-              -t "$TITLE" \
-              -s "$BRANCH" \
-              -d main
-          fi
+          bb pr list -w myworkspace -r myrepo --json --jq '.count'
 ```
 
----
+`oven-sh/setup-bun` puts `bun` on `PATH` for you, including globally installed binaries.
 
 ### GitLab CI
 
@@ -146,23 +120,18 @@ check-prs:
   image: oven/bun:latest
 
   before_script:
-    - npm install -g @pilatos/bitbucket-cli
+    - bun install -g @pilatos/bitbucket-cli
+    - export PATH="$HOME/.bun/bin:$PATH"
     - bb auth login
 
   script:
     - bb pr list -w $BB_WORKSPACE -r $BB_REPO --json
     - bb repo view -w $BB_WORKSPACE -r $BB_REPO
-
-  variables:
-    BB_USERNAME: $BB_USERNAME  # From CI/CD variables
-    BB_API_TOKEN: $BB_API_TOKEN
 ```
 
----
+Define `BB_USERNAME` and `BB_API_TOKEN` under **Settings > CI/CD > Variables** (masked, protected). GitLab exports project variables into the job environment, so no `variables:` entry is needed for them.
 
 ### Bitbucket Pipelines
-
-Using the CLI within Bitbucket Pipelines itself:
 
 ```yaml
 image: oven/bun:latest
@@ -172,9 +141,9 @@ pipelines:
     - step:
         name: Check PRs
         script:
-          - npm install -g @pilatos/bitbucket-cli
+          - bun install -g @pilatos/bitbucket-cli
+          - export PATH="$HOME/.bun/bin:$PATH"
           - bb auth login
-          # Use built-in variables
           - bb pr list -w $BITBUCKET_WORKSPACE -r $BITBUCKET_REPO_SLUG --json
 
   pull-requests:
@@ -182,7 +151,8 @@ pipelines:
       - step:
           name: PR Info
           script:
-            - npm install -g @pilatos/bitbucket-cli
+            - bun install -g @pilatos/bitbucket-cli
+            - export PATH="$HOME/.bun/bin:$PATH"
             - bb auth login
             - bb pr view $BITBUCKET_PR_ID -w $BITBUCKET_WORKSPACE -r $BITBUCKET_REPO_SLUG
 
@@ -191,15 +161,13 @@ definitions:
     bun: ~/.bun
 ```
 
-<Aside type="tip">
-Bitbucket Pipelines provides `BITBUCKET_WORKSPACE`, `BITBUCKET_REPO_SLUG`, and `BITBUCKET_PR_ID` automatically.
+Pipelines injects `BITBUCKET_WORKSPACE`, `BITBUCKET_REPO_SLUG`, and `BITBUCKET_PR_ID`, which the snippet above passes to `-w`, `-r`, and `bb pr view`.
+
+<Aside type="caution">
+Pipelines does **not** inject Bitbucket credentials, and the CLI never reads the `BITBUCKET_*` variables for auth. Add both `BB_USERNAME` and `BB_API_TOKEN` as secured repository or workspace variables. Without `BB_API_TOKEN`, `bb auth login` falls back to the OAuth browser flow and the step hangs until it times out.
 </Aside>
 
----
-
 ### Jenkins
-
-**Jenkinsfile:**
 
 ```groovy
 pipeline {
@@ -213,9 +181,8 @@ pipeline {
     stages {
         stage('Setup') {
             steps {
-                // Install Bun first (required runtime)
                 sh 'curl -fsSL https://bun.sh/install | bash'
-                sh 'export PATH="$HOME/.bun/bin:$PATH" && npm install -g @pilatos/bitbucket-cli'
+                sh 'export PATH="$HOME/.bun/bin:$PATH" && bun install -g @pilatos/bitbucket-cli'
                 sh 'export PATH="$HOME/.bun/bin:$PATH" && bb auth login'
             }
         }
@@ -224,33 +191,7 @@ pipeline {
             steps {
                 sh '''
                     export PATH="$HOME/.bun/bin:$PATH"
-                    bb pr list -w myworkspace -r myrepo --json > prs.json
-                    PR_COUNT=$(jq '.count' prs.json)
-                    echo "Found $PR_COUNT open PRs"
-                '''
-            }
-        }
-
-        stage('Merge Ready PRs') {
-            when {
-                branch 'main'
-            }
-            steps {
-                sh '''
-                    export PATH="$HOME/.bun/bin:$PATH"
-                    # Get all open PR IDs, then check each for approval
-                    PR_IDS=$(bb pr list -w myworkspace -r myrepo --json | \
-                        jq -r '.pullRequests[].id')
-
-                    for PR_ID in $PR_IDS; do
-                        IS_APPROVED=$(bb pr view $PR_ID -w myworkspace -r myrepo --json | \
-                            jq '[.participants[] | select(.approved == true)] | length > 0')
-                        if [ "$IS_APPROVED" = "true" ]; then
-                            echo "Merging approved PR #$PR_ID"
-                            bb pr merge $PR_ID -w myworkspace -r myrepo --strategy squash
-                        fi
-                        sleep 1
-                    done
+                    bb pr list -w myworkspace -r myrepo --json --jq '.count'
                 '''
             }
         }
@@ -258,7 +199,9 @@ pipeline {
 }
 ```
 
----
+Each `sh` step is a fresh shell, so `PATH` has to be exported in every one.
+
+To merge approved PRs from Jenkins, run the script in [Merge approved PRs automatically](#merge-approved-prs-automatically) as a build step.
 
 ### Azure DevOps
 
@@ -278,74 +221,75 @@ steps:
       echo "##vso[task.prependpath]$HOME/.bun/bin"
     displayName: 'Install Bun'
 
-  - script: npm install -g @pilatos/bitbucket-cli
+  - script: bun install -g @pilatos/bitbucket-cli
     displayName: 'Install Bitbucket CLI'
 
-  - script: bb auth login
-    displayName: 'Authenticate'
+  - script: |
+      bb auth login
+      bb pr list -w myworkspace -r myrepo --json
+    displayName: 'List PRs'
     env:
       BB_USERNAME: $(BB_USERNAME)
       BB_API_TOKEN: $(BB_API_TOKEN)
-
-  - script: |
-      bb pr list -w myworkspace -r myrepo --json
-    displayName: 'List PRs'
 ```
+
+`##vso[task.prependpath]` puts `~/.bun/bin` on `PATH` for every later step.
 
 ---
 
-## Common Use Cases
+## Common use cases
 
-### Auto-Create PR for Dependency Updates
+### Report build status back to Bitbucket
 
-```yaml
-# GitHub Actions example
-name: Dependency Update PR
+`bb status set <sha>` creates or updates a build status on a commit. It is idempotent per `--key`, so calling it again with the same key replaces the previous status instead of adding a second one.
 
-on:
-  schedule:
-    - cron: '0 9 * * 1'  # Weekly on Monday
+```bash
+bb status set "$GITHUB_SHA" -w myworkspace -r myrepo \
+  --key CI --state INPROGRESS --url "$RUN_URL"
 
-jobs:
-  update-deps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+# ... run the build ...
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Update dependencies
-        run: |
-          bun update
-          git config user.name "Bot"
-          git config user.email "bot@example.com"
-          git checkout -b deps/weekly-update
-          git add package*.json
-          git commit -m "chore: weekly dependency update" || exit 0
-          git push -u origin deps/weekly-update
-
-      - name: Create Bitbucket PR
-        env:
-          BB_USERNAME: ${{ secrets.BB_USERNAME }}
-          BB_API_TOKEN: ${{ secrets.BB_API_TOKEN }}
-        run: |
-          npm install -g @pilatos/bitbucket-cli
-          bb auth login
-          bb pr create -w workspace -r repo \
-            -t "chore: Weekly dependency update" \
-            -b "Automated dependency updates" \
-            -s deps/weekly-update \
-            -d main
+bb status set "$GITHUB_SHA" -w myworkspace -r myrepo \
+  --key CI --state SUCCESSFUL --url "$RUN_URL" --description "All tests passed"
 ```
 
-### Merge Approved PRs Automatically
+`--state` accepts `INPROGRESS`, `SUCCESSFUL`, `FAILED`, or `STOPPED`. `--name`, `--description`, and `--refname` are optional. Read statuses back with `bb status list <sha>`.
 
-:::tip[Need CI-status gating too?]
-The script below merges as soon as any reviewer has approved. To also wait for **all CI checks to pass** before merging — the more common production pattern — see the [Auto-merge on green CI recipe](/recipes/auto-merge-on-ci-green/).
-:::
+### Trigger a Bitbucket pipeline from another CI system
+
+```bash
+# Latest commit on a branch
+bb pipeline run -w myworkspace -r myrepo --branch main
+
+# A custom pipeline from bitbucket-pipelines.yml, with variables
+bb pipeline run -w myworkspace -r myrepo \
+  --pipeline deploy-prod --var ENV=prod --var DRY_RUN=false
+```
+
+`bb pipeline list --status FAILED`, `bb pipeline view <id>`, `bb pipeline logs <id> --step <n>`, and `bb pipeline stop <id>` cover the rest. See [bb pipeline](/commands/pipeline/).
+
+### Create a PR from a branch
+
+Create the PR only if one does not already exist for the source branch. This works the same whether the branch came from a feature push or a scheduled dependency bump.
+
+```bash
+BRANCH=${GITHUB_REF#refs/heads/}
+
+EXISTING=$(bb pr list -w myworkspace -r myrepo --all --json \
+  --jq "[.pullRequests[] | select(.source.branch.name == \"$BRANCH\")] | length")
+
+if [ "$EXISTING" -eq 0 ]; then
+  bb pr create -w myworkspace -r myrepo \
+    -t "chore: $BRANCH" \
+    -b "Opened automatically by CI" \
+    -s "$BRANCH" \
+    -d main
+fi
+```
+
+### Merge approved PRs automatically
+
+This script merges as soon as any reviewer has approved. To wait for **all CI checks to pass** first — the more common production pattern — see [Auto-merge on green CI](/recipes/auto-merge-on-ci-green/).
 
 ```bash
 #!/bin/bash
@@ -356,33 +300,29 @@ set -e
 WORKSPACE="myworkspace"
 REPO="myrepo"
 
-# Get all open PR IDs, then check each for approval via pr view
-open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[].id')
+# --all is required: without it only the first 25 open PRs are considered
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --all --json --jq '.pullRequests[].id')
 
-approved_prs=""
 for pr_id in $open_prs; do
-  is_approved=$(bb pr view "$pr_id" -w "$WORKSPACE" -r "$REPO" --json | \
-    jq '[.participants[] | select(.approved == true)] | length > 0')
-  if [ "$is_approved" = "true" ]; then
-    approved_prs="$approved_prs $pr_id"
-  fi
-  sleep 1
-done
+  is_approved=$(bb pr view "$pr_id" -w "$WORKSPACE" -r "$REPO" --json \
+    --jq '[.participants[] | select(.approved == true)] | length > 0')
 
-for pr_id in $approved_prs; do
-  echo "Attempting to merge PR #$pr_id..."
+  if [ "$is_approved" != "true" ]; then
+    sleep 1
+    continue
+  fi
 
   if bb pr merge "$pr_id" -w "$WORKSPACE" -r "$REPO" --strategy squash --close-source-branch; then
-    echo "Successfully merged PR #$pr_id"
+    echo "Merged PR #$pr_id"
   else
-    echo "Could not merge PR #$pr_id (may have conflicts or failing checks)"
+    echo "Could not merge PR #$pr_id (conflicts or failing checks)"
   fi
 
   sleep 2
 done
 ```
 
-### Generate Changelog from Merged PRs
+### Generate a changelog from merged PRs
 
 ```bash
 #!/bin/bash
@@ -396,30 +336,48 @@ SINCE_DATE=$(date -d '7 days ago' +%Y-%m-%d 2>/dev/null || \
 echo "# Changelog - Week of $(date +%Y-%m-%d)"
 echo ""
 
-bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --json | jq -r --arg since "$SINCE_DATE" '
+# External jq here because the program needs --arg; --jq takes no variables
+bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --all --json | jq -r --arg since "$SINCE_DATE" '
   .pullRequests[] |
   select(.updated_on >= $since) |
-  "- \(.title) (#\(.id)) by @\(.author.nickname // .author.display_name // \"unknown\")"
+  "- \(.title) (#\(.id)) by @\(.author.nickname // .author.display_name // "unknown")"
 '
 ```
 
 ---
 
-## Security Considerations
+## Exit codes and errors
 
-### Token Scopes
+Every command exits `0` on success and `1` on any failure. There is no per-error exit code — the specific `ErrorCode` lives in the error payload.
+
+Under `--json`, the error envelope is written to **stderr** as one compact line while stdout stays byte-clean JSON:
+
+```json
+{"name":"BBError","code":1001,"message":"Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN."}
+```
+
+401, 403, and 404 failures carry an extra `hint` string. See [Scripting & Automation](/guides/scripting/#exit-codes) and [Error Codes](/reference/error-codes/).
+
+---
+
+## Security considerations
+
+### Token scopes
 
 Create a dedicated CI/CD token with minimal permissions:
 
-| Use Case | Required Scopes |
+| Use case | Required scopes |
 |----------|----------------|
 | Verify identity | `read:user:bitbucket` |
 | Read-only checks | + `read:repository:bitbucket`, `read:pullrequest:bitbucket` |
 | Create/merge PRs | + `write:pullrequest:bitbucket` |
-| Create repos | + `write:repository:bitbucket` |
-| Delete repos | + `admin:repository:bitbucket` |
+| Report build statuses, write repository data | + `write:repository:bitbucket` |
+| Create repositories | + `admin:repository:bitbucket` |
+| Delete repositories | + `delete:repository:bitbucket` |
 
-### Secrets Management
+The `+` notation is cumulative for the read and write scopes only. `admin:repository:bitbucket` and `delete:repository:bitbucket` are separate scopes, not supersets of each other or of `write:repository:bitbucket` — grant each one you actually need. Full list: [Token Scopes](/reference/token-scopes/).
+
+### Secrets management
 
 <Tabs>
   <TabItem label="GitHub Actions">
@@ -431,59 +389,50 @@ Create a dedicated CI/CD token with minimal permissions:
   <TabItem label="Jenkins">
     Use **Credentials** plugin with Secret text type
   </TabItem>
+  <TabItem label="Bitbucket Pipelines">
+    Store as **secured** repository or workspace variables
+  </TabItem>
 </Tabs>
-
-### Audit Logging
-
-Track CLI usage in your pipelines:
-
-```bash
-echo "Running bb at $(date) by ${CI_USER:-unknown}"
-bb pr list -w workspace -r repo --json | tee pr-list-$(date +%s).json
-```
 
 ---
 
 ## Troubleshooting CI/CD
 
-### Authentication Fails
+### Authentication fails
 
+```text
+✗ Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.
 ```
-Error: Authentication required
-```
 
-**Check:**
-1. Environment variables are set correctly
-2. Secrets are available to the job
-3. Token hasn't expired
+Under `--json` the same failure appears on stderr as `{"name":"BBError","code":1001,...}`.
 
-**Debug:**
+Check that both variables reach the job, and that the token has not expired:
+
 ```bash
 echo "Username set: $([ -n "$BB_USERNAME" ] && echo 'yes' || echo 'no')"
 echo "Token set: $([ -n "$BB_API_TOKEN" ] && echo 'yes' || echo 'no')"
 ```
 
-### Rate Limiting in Loops
+### The auth step hangs
 
-Add delays between API calls:
+`bb auth login` only uses the API-token path when `BB_API_TOKEN` is set (or when you pass `-u`/`-p`/`--with-token`). Otherwise it starts the OAuth browser flow on `http://localhost:19872/callback` and blocks for five minutes. Set `BB_API_TOKEN` in the step's environment.
+
+### Rate limiting in loops
+
+Add a delay between API calls:
 
 ```bash
 for pr_id in $pr_ids; do
-  bb pr view "$pr_id" --json
-  sleep 2  # Prevent rate limiting
+  bb pr view "$pr_id" -w myworkspace -r myrepo --json
+  sleep 2
 done
 ```
 
-### Command Not Found
+### `bb: command not found`
 
-Ensure Bun and the CLI are installed:
+`bun install -g` puts binaries in `~/.bun/bin`, which is not on `PATH` in a fresh shell. Export it before calling `bb`, in the same shell invocation:
 
 ```bash
-# Install Bun (required runtime)
-curl -fsSL https://bun.sh/install | bash
 export PATH="$HOME/.bun/bin:$PATH"
-
-# Install CLI
-npm install -g @pilatos/bitbucket-cli
 bb --version
 ```

--- a/docs/src/content/docs/guides/repository-context.mdx
+++ b/docs/src/content/docs/guides/repository-context.mdx
@@ -5,18 +5,18 @@ description: How the CLI determines which workspace and repository to use
 
 import { FileTree } from '@astrojs/starlight/components';
 
-Many commands in the Bitbucket CLI need to know which workspace and repository you're working with. The CLI uses a sophisticated resolution system to determine this automatically, so you don't always need to specify them explicitly.
+Most commands need a workspace and a repository. If you don't pass `-w`/`-r`, the CLI works them out from your git remote, then `BB_WORKSPACE`, then your config file — in that order.
 
-## Context Resolution Order
+## Context resolution order
 
-The CLI checks multiple sources in this order:
+1. **`-w/--workspace` and `-r/--repo`** on the command line
+2. **The `origin` git remote** of the current repository
+3. **The `BB_WORKSPACE` environment variable**
+4. **`defaultWorkspace`** in the config file
 
-1. **Command-line flags** (`--workspace` and `--repo`)
-2. **Current Git repository** (automatically detected from your git remote URL)
-3. **Config file defaults** (`defaultWorkspace` setting)
-4. **Combinations** of the above sources
+Sources 3 and 4 only supply a workspace. A repository still has to come from `-r` or the git remote.
 
-### Typical Local Layout
+### Typical local layout
 
 <FileTree>
 - projects/
@@ -28,150 +28,179 @@ The CLI checks multiple sources in this order:
     - README.md
 </FileTree>
 
-When you run `bb` from `myworkspace-tools/`, the CLI reads the Bitbucket remote from `.git/` and uses that workspace/repo as context.
+When you run `bb` from `myworkspace-tools/`, the CLI reads the Bitbucket remote from `.git/` and uses that workspace and repository as context.
 
 ### Examples
 
-#### Scenario 1: Inside a Git Repository
+#### Scenario 1: inside a git repository
 
 ```bash
-# You're in /projects/myrepo, which has a Bitbucket remote
+# /projects/myrepo has a Bitbucket origin remote
 cd /projects/myrepo
-bb pr list  # ✅ Uses workspace/repo from git remote
+bb pr list  # workspace and repository come from the remote
 ```
 
 The CLI reads your `.git/config` and extracts the workspace and repository from the remote URL.
 
-#### Scenario 2: Using Command-Line Flags
+#### Scenario 2: using command-line flags
 
 ```bash
-# Explicit specification always takes precedence
-bb pr list -w myworkspace -r myrepo  # ✅ Uses specified values
+bb pr list -w myworkspace -r myrepo
 ```
 
-This works from anywhere, even outside a git repository.
+Flags always win, and they work from anywhere — no git repository required.
 
-#### Scenario 3: Using Config Defaults
+#### Scenario 3: using a default workspace
 
 ```bash
-# Set defaults once
+# Environment variable — useful in CI
+export BB_WORKSPACE=myworkspace
+
+# Or persist it in the config file
 bb config set defaultWorkspace myworkspace
 
-# Then use commands without flags
-bb repo list  # ✅ Uses defaultWorkspace from config
+bb repo list  # workspace-only command, no repository needed
 ```
 
-For PR commands, you still need repository context (from git remote or `-r`).
+`BB_WORKSPACE` wins over `defaultWorkspace`, so a pipeline can override a developer's persisted default without rewriting the config file.
 
-#### Scenario 4: Mixed Sources
+#### Scenario 4: mixed sources
 
 ```bash
-# Inside a git repo with workspace "gitworkspace/gitrepo"
+# Inside a clone of gitworkspace/gitrepo
 cd /projects/myrepo
 
 # Override just the workspace
-bb pr list -w anotherworkspace  # Uses "anotherworkspace/gitrepo"
+bb pr list -w anotherworkspace  # anotherworkspace/gitrepo
 
-# Override just the repo
-bb pr list -r anotherrepo  # Uses "gitworkspace/anotherrepo"
+# Override just the repository
+bb pr list -r anotherrepo  # gitworkspace/anotherrepo
 ```
 
-## Repository Argument Formats
+## Workspace-only vs repository-scoped commands
 
-Commands that accept a repository argument support multiple formats:
+The two classes fail differently when context is missing.
 
-### Full Format: `workspace/repo`
+| Class | Commands | Error when unresolved |
+|-------|----------|-----------------------|
+| Workspace-only | `bb repo list`, `bb repo create`, `bb repo clone`, `bb project *`, `bb snippet *`, `bb workspace view` | `6002 CONTEXT_WORKSPACE_NOT_FOUND` |
+| Repository-scoped | `bb pr *`, `bb pipeline *`, `bb issue *`, `bb commit *`, `bb status *`, `bb browse`, `bb repo view`, `bb repo delete`, `bb repo default-reviewers *` | `6001 CONTEXT_REPO_NOT_FOUND` |
+
+`bb api` falls in either class depending on the endpoint: it resolves a workspace only if the endpoint contains `{workspace}`, and a repository only if it contains `{repo}`.
+
+```bash
+# Placeholders are filled from the same resolution chain
+bb api /repositories/{workspace}/{repo}/pullrequests
+```
+
+If a placeholder can't be resolved you get `Endpoint uses {repo} but no repository could be resolved. Pass --repo or run inside a Bitbucket repo.`
+
+## Repository argument formats
+
+Commands that accept a repository argument support two formats.
+
+### Full format: `workspace/repo`
 
 ```bash
 bb repo view myworkspace/myrepo
 bb repo delete myworkspace/myrepo --yes
 ```
 
-This explicitly specifies both workspace and repository.
-
-### Short Format: `repo` only
+### Short format: `repo` only
 
 ```bash
-# Uses default workspace from config or git context
 bb repo view myrepo
 ```
 
-The CLI will:
-1. Check if you set a default workspace via `bb config set defaultWorkspace`
-2. Check if you're in a git repository and use its workspace
-3. Error if neither is available
+The workspace is resolved in the usual order:
 
-## Supported Remote URL Formats
+1. `-w/--workspace`, if you passed it
+2. Otherwise the workspace from the current git remote
+3. Otherwise `BB_WORKSPACE`
+4. Otherwise `defaultWorkspace` from the config file
+5. Otherwise error
 
-When detecting context from git, the CLI supports these remote URL formats:
+The git remote wins over your config. Running `bb repo view myrepo` inside a clone of `otherws/otherrepo` resolves to `otherws/myrepo`, even if `defaultWorkspace` is set to something else.
 
-### SSH Format
-```
+## Supported remote URL formats
+
+### SSH format
+```text
 git@bitbucket.org:workspace/repo.git
 git@bitbucket.org:workspace/repo
 ```
 
-### HTTPS Format
-```
+### HTTPS format
+```text
 https://bitbucket.org/workspace/repo.git
 https://bitbucket.org/workspace/repo
 https://username@bitbucket.org/workspace/repo.git
 ```
 
-## Error Messages
+### Limitations
 
-### "Could not determine repository"
+- Only the remote named `origin` is inspected. If your Bitbucket remote has another name, pass `-w`/`-r`.
+- Repository names containing a dot (`docs.example.com`, `my.repo`) are not parsed.
+- `ssh://git@bitbucket.org/workspace/repo.git` is not recognised — use the `git@bitbucket.org:workspace/repo` form.
 
-This error appears when the CLI can't figure out which workspace/repo to use.
+A dotted repository name or an `ssh://` URL fails with `Remote '<url>' is not a Bitbucket URL.` A differently-named remote fails with `Git repository has no remote configured.`
 
-**Solutions:**
-1. Use explicit flags: `-w myworkspace -r myrepo`
-2. Run from within a Bitbucket repository
-3. Set defaults: `bb config set defaultWorkspace myworkspace`
+## Error messages
+
+### Repository could not be resolved
+
+Three distinct messages, all error code `6001 CONTEXT_REPO_NOT_FOUND`. Under `--json` each sets a different `context.reason`.
+
+The working directory is not a git repository — `reason: not_a_git_repo`:
+
+```text
+✗ Not in a git repository. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
+```
+
+There is no `origin` remote — `reason: no_remote`:
+
+```text
+✗ Git repository has no remote configured. Add a Bitbucket remote with `git remote add origin <url>`, or use --workspace and --repo options, or run this command from within a Bitbucket repository.
+```
+
+`origin` points somewhere other than Bitbucket, or the repository name contains a dot — `reason: remote_not_bitbucket`:
+
+```text
+✗ Remote 'git@github.com:acme/tool.git' is not a Bitbucket URL. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
+```
+
+Fix any of them with explicit flags: `bb pr list -w myworkspace -r myrepo`.
+
+### No workspace specified
+
+```text
+✗ No workspace specified. Use --workspace option or set a default workspace with `bb config set defaultWorkspace <name>`.
+```
+
+Error code `6002 CONTEXT_WORKSPACE_NOT_FOUND`, thrown by workspace-only commands. Pass `-w`, export `BB_WORKSPACE`, or set `defaultWorkspace`.
 
 ### "Repository not found"
 
-The workspace/repo combination was determined but doesn't exist.
+The workspace and repository resolved, but the pair doesn't exist or your token can't see it. Check the spelling, your access, and that the repository lives in that workspace.
 
-**Check:**
-1. Spelling of workspace and repository names
-2. That you have access to the repository
-3. That the repository exists in that workspace
+See [Error Codes](/reference/error-codes/) for the full list.
 
-## Best Practices
+## Which approach to use
 
-### For Daily Work
+| Situation | Use |
+|-----------|-----|
+| Interactive work in a clone | Nothing — the git remote resolves it |
+| Scripts and automation | Explicit `-w`/`-r` on every command |
+| CI pipelines | `BB_WORKSPACE` plus `-r`, or explicit flags |
+| You live in one workspace | `bb config set defaultWorkspace <name>` |
 
-Set your default workspace if you primarily work with one:
+Don't set `defaultWorkspace` if you work across several workspaces — a stale default silently sends commands to the wrong place when you're outside a clone.
+
+## Checking what got resolved
+
 ```bash
-bb config set defaultWorkspace myworkspace
+bb repo view       # the resolved workspace/repository
+bb workspace view  # the resolved workspace
 ```
 
-Then work from within your git repositories - context will be automatic.
-
-### For Scripts
-
-Always use explicit flags for reliability:
-```bash
-#!/bin/bash
-WORKSPACE="myworkspace"
-REPO="myrepo"
-
-bb pr list -w "$WORKSPACE" -r "$REPO" --json
-```
-
-### For Multi-Workspace Teams
-
-Don't set a default workspace. Instead, use explicit flags or work from within cloned repositories:
-```bash
-# Each repository is self-contained
-cd project-a && bb pr list  # Uses project-a's workspace
-cd ../project-b && bb pr list  # Uses project-b's workspace
-```
-
-## Tips
-
-- Use `bb repo view` with no arguments to see what context the CLI detected
-- The `--json` flag works with most commands for scripting
-- Global flags (`--workspace`, `--repo`, `--json`, `--no-color`) are available across commands
-- The `-w` short flag always maps to `--workspace` globally
+Both accept `--json`, which every command in the CLI supports — see [JSON Output](/reference/json-output/). For the full list of global flags including `-w`/`-r`, see [Global Flags](/reference/global-flags/).

--- a/docs/src/content/docs/guides/scripting.mdx
+++ b/docs/src/content/docs/guides/scripting.mdx
@@ -3,13 +3,11 @@ title: Scripting & Automation - Bitbucket CLI for CI/CD Workflows
 description: Learn how to use Bitbucket CLI in automation scripts and CI/CD pipelines. JSON output, exit codes, error handling, and practical examples for DevOps workflows.
 ---
 
-import { Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
 
-The Bitbucket CLI is designed for both interactive use and automation. This guide covers JSON output, exit codes, and scripting patterns.
+## JSON output mode
 
-## JSON Output Mode
-
-All commands support the `--json` flag for machine-readable output:
+Add `--json` for machine-readable output:
 
 ```bash
 bb pr list --json
@@ -17,19 +15,42 @@ bb repo list --json
 bb pr view 42 --json
 ```
 
-For list-style commands, results are limited by default. Pass `--limit` when
-your automation needs more rows.
+<Aside type="caution">
+`--json` must come **after** the subcommand. Its field-list argument is
+optional, so `bb --json pr list` swallows `pr` as the field list, leaves `list`
+to be parsed as a top-level command, and exits 1 with error code 5002. Write
+`bb pr list --json`. If you need the flag before the subcommand, use the equals
+form: `bb --json=id,title pr list`.
+</Aside>
 
-### Built-in Field Selection and jq
+Paginated list commands return 25 rows by default. Pass `--all` to fetch every
+page, or `--limit <n>` for a specific cap — `--all` wins if you pass both.
+`--limit` must be a positive integer; anything else fails with `--limit must be
+a positive integer` (error code 5002). There is no `--page` flag; pagination is
+followed internally.
+
+```bash
+bb pr list --json --all
+bb pr list --json --limit 100
+```
+
+Twelve commands take `--limit` and `--all`: `repo list`, `pr list`,
+`pr activity`, `pr comments list`, `snippet list`, `snippet comments list`,
+`pipeline list`, `commit list`, `status list`, `issue list`, `workspace list`,
+`project list`. Other list-style commands return their full result set and
+accept neither flag — `bb pr reviewers list` and
+`bb repo default-reviewers list`, for example.
+
+### Field selection and `--jq`
 
 Two flags inspired by the [`gh` CLI](https://cli.github.com/manual/gh_help_formatting)
-let you slice and filter output without an external `jq` binary:
+slice and filter output without an external `jq` binary:
 
 ```bash
 # Project to a comma-separated field list
 bb pr list --json id,title,state
 
-# Pipe through embedded jq (requires --json)
+# Filter through the embedded jq (requires --json)
 bb pr list --json --jq '.pullRequests[].title'
 
 # Combine both
@@ -41,60 +62,55 @@ When `--json fields` is passed against a list-style command, the wrapper
 envelope is dropped and the field list is projected per-item — the result is
 a flat array. See [JSON Output reference](/reference/json-output/) for details.
 
-### Parsing with jq
-
-The built-in `--jq` matches the syntax of the standalone
-[jq](https://jqlang.github.io/jq/) binary, so existing expressions work
-either way:
+`--jq` matches the syntax of the standalone
+[jq](https://jqlang.github.io/jq/) binary, so existing expressions work either
+way. These two are equivalent:
 
 ```bash
-# Built-in (no external dependency, cross-platform)
 bb pr list --json --jq '.pullRequests[].title'
-
-# External jq (equivalent)
 bb pr list --json | jq '.pullRequests[].title'
-
-# Get PR count
-bb pr list --json --jq '.count'
-
-# Filter by state
-bb pr list -s MERGED --json --jq '.count'
-
-# Project specific fields
-bb pr list --json --jq '.pullRequests[] | {id, title, author: .author.display_name}'
-
-# Filter by author
-bb pr list --json --jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
-
-# PR URLs
-bb pr list --json --jq '.pullRequests[].links.html.href'
-
-# Web diff URL for a PR
-bb pr diff 42 --web --json --jq '.url'
 ```
 
-### Common jq Patterns
+### jq patterns
 
 ```bash
+# Open PR count (--state defaults to OPEN)
+bb pr list --json --all --jq '.count'
+
+# Merged PR count
+bb pr list -s MERGED --json --all --jq '.count'
+
+# Project specific fields
+bb pr list --json --all --jq '.pullRequests[] | {id, title, author: .author.display_name}'
+
+# Filter by author
+bb pr list --json --all --jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
+
+# PR web URLs
+bb pr list --json --all --jq '.pullRequests[].links.html.href'
+
+# Web diff URL for one PR
+bb pr diff 42 --web --json --jq '.url'
+
 # PRs updated in the last 7 days
-bb pr list --json | jq --arg date "$(date -d '7 days ago' -Iseconds 2>/dev/null || \
+bb pr list --json --all | jq --arg date "$(date -d '7 days ago' -Iseconds 2>/dev/null || \
   date -v-7d -Iseconds)" \
   '.pullRequests[] | select(.updated_on > $date)'
 
-# PRs targeting main branch
-bb pr list --json | jq '.pullRequests[] | select(.destination.branch.name == "main")'
+# PRs targeting main
+bb pr list --json --all | jq '.pullRequests[] | select(.destination.branch.name == "main")'
 
 # Group PRs by author
-bb pr list --json | jq '.pullRequests | group_by(.author.nickname // .author.display_name) | map({author: (.[0].author.nickname // .[0].author.display_name), count: length})'
+bb pr list --json --all | jq '.pullRequests | group_by(.author.nickname // .author.display_name) | map({author: (.[0].author.nickname // .[0].author.display_name), count: length})'
 ```
 
 ---
 
-## Raw API Access (Escape Hatch)
+## Raw API access (escape hatch)
 
 When no typed command covers what you need, [`bb api`](/commands/api/) calls any
-Bitbucket Cloud 2.0 endpoint through the same authenticated stack — so scripts
-are never blocked. Its output is already JSON, so `--jq` works without `--json`.
+Bitbucket Cloud 2.0 endpoint through the same authenticated stack. Its output is
+already JSON, so `--jq` works without `--json`.
 
 ```bash
 # Any endpoint, authenticated
@@ -116,71 +132,65 @@ checkout. See the [API command reference](/commands/api/) for every flag.
 
 ---
 
-## Exit Codes
-
-The CLI uses a deliberately small exit-code surface:
+## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
 | 1 | Any failure (authentication, API, validation, network, jq, …) |
 
-There is **no `2`/`3`/etc. mapping** — every failure exits with `1`. To branch
-on the specific failure mode in a script, parse the JSON error written to
-stderr and read its `code` field, which corresponds to one of the
-[error codes](/reference/error-codes/).
-
-```bash
-if ! bb pr view 999 --json > out.json 2> err.json; then
-  code=$(jq -r '.code' err.json)
-  case "$code" in
-    1001|1002|1003) echo "auth problem";;
-    2002)            echo "PR not found";;
-    *)               echo "other failure ($code)";;
-  esac
-fi
-```
-
-### Checking Exit Codes
-
-```bash
-#!/bin/bash
-
-if bb pr list -w myworkspace -r myrepo > /dev/null 2>&1; then
-  echo "Success"
-else
-  echo "Failed with exit code: $?"
-fi
-```
-
-### Error Handling Patterns
-
-```bash
-#!/bin/bash
-set -e  # Exit on any error
-
-# Or handle errors explicitly
-bb pr list --json > prs.json || {
-  echo "Failed to list PRs"
-  exit 1
-}
-```
-
-<Aside type="tip">
-In `--json` mode, success JSON is written to stdout and error JSON is written to stderr.
-Parse them separately in scripts.
-</Aside>
-
-```bash
-if ! bb config get invalidKey --json > out.json 2> err.json; then
-  jq '.' err.json
-  exit 1
-fi
-```
+There is **no `2`/`3`/etc. mapping** — every failure exits with `1`. To branch on
+the specific failure mode, read the `code` field of the JSON error envelope,
+which is one of the [error codes](/reference/error-codes/).
 
 ---
 
-## Environment Variables
+## Error handling
+
+In `--json` mode, success JSON goes to stdout and the error envelope goes to
+stderr. Redirect them separately:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+if ! bb pr view 999 -w myworkspace -r myrepo --json > out.json 2> err.json; then
+  code=$(jq -r '.code' err.json)
+  case "$code" in
+    1001|1002|1003) echo "auth problem";;
+    2002)           echo "PR not found";;
+    *)              echo "other failure ($code): $(jq -r '.message' err.json)";;
+  esac
+  exit 1
+fi
+```
+
+The error envelope carries:
+
+| Field | Notes |
+|-------|-------|
+| `name` | Error class — `BBError`, `AuthError`, `APIError`, … |
+| `code` | Numeric [error code](/reference/error-codes/) |
+| `message` | Human-readable failure description |
+| `context` | Extra detail (ids, keys, args); omitted when the error carries none |
+| `statusCode` | HTTP status — `APIError` only |
+| `response` | Raw API response body — `APIError` only, when non-empty |
+| `hint` | Remediation advice; optional, see below |
+
+`hint` appears only on API errors with status 401, 403, or 404, and is skipped
+on 404 when the message already names the missing resource. Treat it as
+optional in scripts.
+
+Argument-parsing failures are the exception. An unknown option, a missing
+argument, or too many arguments prints a **plain text** usage error to stderr
+and exits 1 even under `--json`, so `jq` cannot parse it. The one parse failure
+that still emits an envelope is an unknown top-level command — `bb bogus --json`
+returns code 5002, while `bb pr bogus --json` prints
+`error: unknown command 'bogus'` as plain text.
+
+---
+
+## Environment variables
 
 For non-interactive scripts, use environment variables:
 
@@ -196,80 +206,70 @@ See [Environment Variables Reference](/reference/environment-variables/) for det
 
 ---
 
-## Built-in Resilience
+## Built-in resilience
 
-The CLI handles common transient failures automatically — you don't need to implement this yourself in most cases.
+### Automatic retry
 
-### Automatic Retry
+API requests that fail with HTTP 429, 502, 503, or 504 are retried up to 3 times
+with exponential backoff. Add your own retry loop only if you need more than 3
+attempts.
 
-API requests that fail with transient errors (HTTP 429, 502, 503, 504) are retried automatically up to 3 times with exponential backoff. This means rate-limited or temporarily unavailable responses are handled without any extra scripting.
+### OAuth token refresh
 
-### OAuth Token Refresh
-
-OAuth access tokens expire after 2 hours. The CLI refreshes them automatically — both proactively (before expiry) and reactively (on 401 responses). Long-running scripts using OAuth don't need manual re-authentication.
-
-<Aside type="tip">
-The built-in retry covers most transient failures. Only add your own retry logic if you need custom behavior beyond 3 attempts.
-</Aside>
+OAuth access tokens expire after 2 hours. The CLI refreshes them automatically —
+proactively before expiry and reactively on 401 responses. Long-running OAuth
+scripts never need to re-authenticate manually.
 
 ---
 
-## Scripting Best Practices
+## Scripting best practices
 
-### Always Use Explicit Flags
+### Always pass `-w` and `-r`
 
-Don't rely on context detection in scripts:
+Workspace and repository detection reads the git remote of the current
+checkout. CI runners frequently check out with a non-Bitbucket remote, or no
+remote at all, so context detection fails there.
 
 ```bash
 # Good - explicit and reliable
 bb pr list -w myworkspace -r myrepo --json
 
-# Bad - may fail if context can't be detected
+# Bad - fails when the checkout has no Bitbucket remote
 bb pr list --json
 ```
 
-### Handle Persistent Failures
-
-The CLI retries transient errors automatically (see [Built-in Resilience](#built-in-resilience) above). For persistent failures, handle the exit code:
-
-```bash
-#!/bin/bash
-
-if ! bb pr list -w workspace -r repo --json > prs.json 2>error.json; then
-  echo "Failed to list PRs"
-  cat error.json
-  exit 1
-fi
-```
-
-### Add Delays in Loops
+### Add delays in loops
 
 When making many sequential API calls, add short delays to avoid hitting rate limits:
 
 ```bash
 #!/bin/bash
+set -euo pipefail
 
-for pr_id in $(bb pr list --json | jq -r '.pullRequests[].id'); do
-  bb pr view "$pr_id" --json
+WORKSPACE="myworkspace"
+REPO="myrepo"
+
+for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" --json --all | jq -r '.pullRequests[].id'); do
+  bb pr view "$pr_id" -w "$WORKSPACE" -r "$REPO" --json
   sleep 1
 done
 ```
 
 ---
 
-## Example Scripts
+## Example scripts
 
 :::tip[Looking for a recipe?]
 For ready-to-copy workflows — auto-merge on green CI, bulk reviewer assignment, fork sync, jq analytics, and retry wrappers — see the [Recipes section](/recipes/).
 :::
 
-### Batch PR Approval
+### Batch pull request approval
 
-Approve all open PRs from a specific author:
+Approve all open pull requests (PRs) from a specific author:
 
 ```bash
 #!/bin/bash
-set -e
+set -euo pipefail
 
 WORKSPACE="myworkspace"
 REPO="myrepo"
@@ -277,7 +277,7 @@ AUTHOR="trusted-bot"
 
 echo "Finding PRs from $AUTHOR..."
 
-pr_ids=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | \
+pr_ids=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --all | \
   jq -r --arg author "$AUTHOR" '.pullRequests[] | select((.author.nickname // .author.display_name) == $author) | .id')
 
 for pr_id in $pr_ids; do
@@ -289,12 +289,13 @@ done
 echo "Done!"
 ```
 
-### PR Status Report
+### PR status report
 
 Generate a markdown report of open PRs:
 
 ```bash
 #!/bin/bash
+set -euo pipefail
 
 WORKSPACE="myworkspace"
 REPO="myrepo"
@@ -304,7 +305,7 @@ echo ""
 echo "Generated: $(date)"
 echo ""
 
-bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[] |
+bb pr list -w "$WORKSPACE" -r "$REPO" --json --all | jq -r '.pullRequests[] |
   "## PR #\(.id): \(.title)\n" +
   "- **Author:** \(.author.display_name)\n" +
   "- **Branch:** \(.source.branch.name) → \(.destination.branch.name)\n" +
@@ -312,13 +313,13 @@ bb pr list -w "$WORKSPACE" -r "$REPO" --json | jq -r '.pullRequests[] |
   "- **Link:** \(.links.html.href)\n"'
 ```
 
-### Auto-Close Stale PRs
+### Auto-close stale PRs
 
 Decline PRs not updated in 30 days:
 
 ```bash
 #!/bin/bash
-set -e
+set -euo pipefail
 
 WORKSPACE="myworkspace"
 REPO="myrepo"
@@ -329,7 +330,7 @@ cutoff=$(date -d "$DAYS_OLD days ago" -Iseconds 2>/dev/null || \
 
 echo "Finding PRs older than $DAYS_OLD days..."
 
-stale_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json | \
+stale_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --all | \
   jq -r --arg cutoff "$cutoff" '.pullRequests[] | select(.updated_on < $cutoff) | .id')
 
 if [ -z "$stale_prs" ]; then
@@ -343,6 +344,3 @@ for pr_id in $stale_prs; do
   sleep 1
 done
 ```
-
-
-

--- a/docs/src/content/docs/help/changelog.mdx
+++ b/docs/src/content/docs/help/changelog.mdx
@@ -14,6 +14,98 @@ and is updated on every release.
   See [Configuration File](/reference/configuration/) for related settings.
 </Aside>
 
+## Unreleased — Typo suggestions and remediation hints
+
+- **"Did you mean …?"** on a mistyped command or enum value. Unknown top-level
+  commands (`bb prr` → `(Did you mean pr?)`), every `must be one of` option
+  (`--state`, `--kind`, `--priority`, `--sort`, `--status`, `--role`,
+  `--strategy`, `--color`), `bb config get|set <key>`, each bad token in
+  `bb pr activity --type`, and both HTTP-method forms of `bb api`. Matching
+  folds case, and a value that is right apart from its case gets its own
+  message: `(Values are case-sensitive — use OPEN.)`
+- **Remediation hints** on `401`, `403` and `404` failures — one actionable
+  line pointing at `bb auth login`, at
+  [Token Scopes](/reference/token-scopes/), or at the id/slug and
+  `--workspace`/`--repo` you passed. Under `--json` the text arrives as a new
+  optional top-level `hint` field; existing envelope keys are unchanged. The
+  `404` hint is suppressed where the message already names the missing resource
+  and for `bb api`, where you supplied the URL.
+- **`bb help <command>`** now works (`bb help pr`, `bb help pr comments`); it
+  previously failed with `too many arguments`.
+- **`bb --json pr list`** now explains that `--json` swallowed `pr` as its field
+  list and shows the correct flag position.
+- **Behavior change:** `bb pr diff --color <when>` validates its value. A typo
+  such as `--color alwyas` used to silently disable color and exit `0`; it now
+  fails with the valid values and a suggestion.
+
+Known limitation: `bb --json <typo>` with nothing following still prints root
+help and exits `0` — it is indistinguishable from a genuine field list.
+
+## 1.22.0 — Pull request comment threads
+
+Four new `bb pr comments` subcommands complete the surface, and `list` can now
+filter by resolution state.
+
+- **`bb pr comments view <pr-id> <comment-id>`** shows one comment with its
+  author, date, state (`[resolved]`/`[unresolved]`/`[pending]`) and raw content.
+- **`bb pr comments reply <pr-id> <comment-id> <message>`** posts a threaded
+  reply attached to the parent comment.
+- **`bb pr comments resolve` / `unresolve <pr-id> <comment-id>`** close and
+  reopen a thread. Bitbucket returns only a resolution record for `resolve` and
+  no body for `unresolve`, so their `--json` payloads carry identifiers rather
+  than the full comment — read it back with `bb pr comments view`.
+- **`bb pr comments list`** gained a `Status` column (`resolved`, `pending`, or
+  `open`) plus `--resolved` / `--unresolved` filters. The active filter is
+  echoed under `filters.resolution` in `--json`.
+
+```bash
+bb pr comments list 42 --unresolved
+bb pr comments reply 42 987654 "Fixed in the follow-up commit."
+bb pr comments resolve 42 987654
+```
+
+**Bug fixes:** `bb pr comments edit` and `reply` no longer fail with
+`Bad request` — the update payload was sending a `type` key the endpoint
+rejects. `bb pr comments resolve` now sends an empty JSON body, which that
+endpoint requires. API errors also carry Bitbucket's `error.fields` detail now,
+so a rejected payload reports `Bad request (type: extra keys not allowed)`
+instead of a bare `Bad request`.
+
+See the [PR comments reference](/commands/pr/comments/) for the full flag list.
+
+## 1.21.0 — Six new command groups
+
+**Commit & status** — `bb commit list` and `bb commit view <sha>` show commit
+history and details. `bb status list <sha>` lists build statuses for a commit;
+`bb status set <sha> --key <key> --state <state>` creates or updates a build
+status idempotently (CI re-runs can safely re-report the same key).
+
+**Issues** — `bb issue list`, `view`, `create`, `edit`, `close`, and `comment`
+mirror `gh issue` ergonomics. Filters include `--state`, `--kind`, `--assignee`,
+`--reporter`, and a raw `--query` escape hatch. Disabled issue trackers surface
+a clear 404 pointing to Repository settings.
+
+**Pipelines** — `bb pipeline list` (filter by `--status`/`--branch`, paginated),
+`bb pipeline view <id>` (details + per-step summary), `bb pipeline run`
+(trigger on branch, with `--commit`, custom `--pipeline`, and `--var key=value`),
+`bb pipeline stop <id>`, and `bb pipeline logs <id>` (`--step` by UUID or index).
+Pipeline IDs accept build numbers or UUIDs everywhere.
+
+**Workspace & project** — `bb workspace list` shows every workspace you can
+access (filter by `--role`); `bb workspace view [slug]` shows details.
+`bb project list`, `bb project view <key>`, and `bb project create --key <KEY>
+--name <name>` handle project discovery and creation.
+
+All six groups emit stable `--json` envelopes and integrate with repo-scoped
+context resolution.
+
+**Infrastructure** — Read requests now retry up to 3 times with exponential
+backoff on transient network failures (GET/HEAD/OPTIONS only). Concurrent
+OAuth token refreshes are serialized behind an in-flight lock so parallel
+requests share a single refresh. Shell completion is now derived from the live
+command tree and includes flag-value completion for enum options (e.g.
+`bb pr merge --strategy <Tab>` suggests valid strategies).
+
 ## 1.20.0 — `bb api`
 
 A raw, authenticated passthrough to **any** Bitbucket Cloud 2.0 API endpoint —
@@ -49,50 +141,26 @@ Patch releases in 1.20 added configurable request timeouts (`BB_HTTP_TIMEOUT`),
 completion. A drift-guard test now fails CI when the completion tables fall out
 of sync with the live command tree.
 
-## 1.21.0 — Six new command groups
+## 1.19.0 — `BB_WORKSPACE`
 
-This release is all about filling the gaps. Six new command groups land,
-covering most of the remaining Bitbucket Cloud surface.
-
-**Commit & status** — `bb commit list` and `bb commit view <sha>` show commit
-history and details. `bb status list <sha>` lists build statuses for a commit;
-`bb status set <sha> --key <key> --state <state>` creates or updates a build
-status idempotently (CI re-runs can safely re-report the same key).
-
-**Issues** — `bb issue list`, `view`, `create`, `edit`, `close`, and `comment`
-mirror `gh issue` ergonomics. Filters include `--state`, `--kind`, `--assignee`,
-`--reporter`, and a raw `--query` escape hatch. Disabled issue trackers surface
-a clear 404 pointing to Repository settings.
-
-**Pipelines** — `bb pipeline list` (filter by `--status`/`--branch`, paginated),
-`bb pipeline view <id>` (details + per-step summary), `bb pipeline run`
-(trigger on branch, with `--commit`, custom `--pipeline`, and `--var key=value`),
-`bb pipeline stop <id>`, and `bb pipeline logs <id>` (`--step` by UUID or index).
-Pipeline IDs accept build numbers or UUIDs everywhere.
-
-**Workspace & project** — `bb workspace list` shows every workspace you can
-access (filter by `--role`); `bb workspace view [slug]` shows details.
-`bb project list`, `bb project view <key>`, and `bb project create --key <KEY>
---name <name>` handle project discovery and creation.
-
-All six groups emit stable `--json` envelopes and integrate with repo-scoped
-context resolution.
-
-**Infrastructure** — Read requests now retry up to 3 times with exponential
-backoff on transient network failures (GET/HEAD/OPTIONS only). Concurrent
-OAuth token refreshes are serialized behind an in-flight lock so parallel
-requests share a single refresh. Shell completion is now derived from the live
-command tree and includes flag-value completion for enum options (e.g.
-`bb pr merge --strategy <Tab>` suggests valid strategies).
+- **`BB_WORKSPACE`** is now actually read. It slots into workspace resolution
+  between git context and the config file, so the full order is
+  `--workspace` → git remote → `BB_WORKSPACE` → `config.defaultWorkspace`.
+  Previously the variable was advertised in `.env.example` but consulted
+  nowhere.
+- New [Global Flags](/reference/global-flags/) reference page consolidating
+  every flag that works on every command.
+- The environment-variable reference gained rows for `BB_WORKSPACE`,
+  `BB_LOCALE`, and `BB_NO_UNICODE`, and clarified that `DEBUG` must be the
+  literal string `true`.
 
 ## 1.18.0 — Pagination hints and `--all`
 
 List commands now make truncation visible and let you opt out of pagination
 in one flag.
 
-- **`--all`** fetches every page and overrides `--limit`. Available on
-  `bb repo list`, `bb pr list`, `bb pr activity`, `bb pr comments list`,
-  `bb snippet list`, and `bb snippet comments list`.
+- **`--all`** fetches every page and overrides `--limit`. Available on every
+  `list`-style command.
 - When `--limit` truncates a list, a dim footer prints
   `Showing 25 repositories. Use --limit <n> or --all to see more.` — no more
   silently-clipped output. The hint is suppressed in `--json` mode.
@@ -100,12 +168,10 @@ in one flag.
   (e.g. a repo description with a line break) are now collapsed to a single
   space so rows stay aligned. Multi-line `text()` output is unaffected.
 
-See [Global Flags → `--all`](/reference/global-flags/#--all) for the full
+See [Global Flags → `--all`](/reference/global-flags/#--all) for the current
 list of supported commands.
 
 ## 1.17.0 — Locale, Unicode toggle, spinner, global `--no-truncate`
-
-A polish-heavy release focused on output ergonomics.
 
 - **Locale-aware dates** via `--locale <tag>` and `BB_LOCALE`. Resolution
   walks `--locale` → `BB_LOCALE` → `LC_TIME` → `LC_ALL` → `LANG` → `en-US`.
@@ -148,14 +214,16 @@ and examples.
 
 Patch releases in the 1.16 line tightened help text, made the API client's
 retry messages route through the output service (silenced in `--json` mode),
-and standardised the `--yes` confirmation prompt across destructive commands.
+and standardised the `--yes` confirmation gate across destructive commands:
+without `-y/--yes` they now fail uniformly with `Use --yes to confirm.` rather
+than prompting.
 
-## 1.15.0 — Stability and warnings polish
+## 1.15.0 — Output consistency
 
-Internal hardening and small UX improvements. Empty-result messages on list
-commands now use a consistent `ℹ` info icon, and dividers across framed
-output (`pr view`, `pr checks`, `snippet view`, the version-update banner)
-share a single helper for a uniform look.
+- Empty-result messages on list commands use a consistent `ℹ` info icon.
+- Dividers across framed output (`pr view`, `pr checks`, `snippet view`, the
+  version-update banner) share a single helper, so they all render at the same
+  width and colour.
 
 ## 1.14.0 — `--json <fields>` projection and `--jq <expression>`
 
@@ -163,7 +231,7 @@ Match the `gh` CLI's JSON formatting flags so muscle memory and scripts port
 over cleanly.
 
 - `--json [fields]` accepts an optional comma-separated field list
-  (e.g. `--json number,title,author.display_name`). Bare `--json` keeps the
+  (e.g. `--json id,title,author.display_name`). Bare `--json` keeps the
   existing full-object output for backwards compatibility.
 - `--jq <expression>` runs the JSON output through an embedded
   [`jq-wasm`](https://www.npmjs.com/package/jq-wasm) engine. Requires `--json`.
@@ -174,9 +242,9 @@ over cleanly.
 - Invalid jq expressions exit non-zero with the underlying jq error.
 
 ```bash
-bb pr list --json number,title,state
+bb pr list --json id,title,state
 bb pr list --json author --jq '.[].author.display_name'
-bb pr list --json number,title,state --jq '.[] | select(.state == "OPEN") | .title'
+bb pr list --json id,title,state --jq '.[] | select(.state == "OPEN") | .title'
 ```
 
 See the [Scripting & Automation guide](/guides/scripting/) for end-to-end

--- a/docs/src/content/docs/help/faq.mdx
+++ b/docs/src/content/docs/help/faq.mdx
@@ -15,25 +15,27 @@ No. This is an **unofficial**, community-maintained CLI tool. It is not affiliat
 
 ### How does this compare to GitHub CLI (gh)?
 
-The Bitbucket CLI is inspired by GitHub's excellent `gh` CLI and aims to provide a similar experience for Bitbucket users. It covers authentication, repository management, pull requests, snippets, configuration, and shell completion. Features without a dedicated command yet — issues, pipelines, branch permissions — can still be reached today through `bb api`, the raw API passthrough (the analog of `gh api`).
+`bb` follows `gh`'s command shapes for Bitbucket Cloud. It covers authentication, repositories, pull requests, issues, pipelines, commits and build statuses, snippets, workspaces and projects, browsing, configuration, and shell completion. Anything without a typed command — branch permissions, webhooks — is reachable through `bb api`, the analog of `gh api`.
 
 ---
 
 ### What Bitbucket features are supported?
 
-Currently supported:
-
 - **Authentication** - Login, logout, status, token display
 - **Repositories** - Clone, create, list, view, delete, default reviewers (list/add/remove)
-- **Pull Requests** - Create (with optional default-reviewer attachment), list, view, edit, merge, approve, decline, ready (mark draft ready), checkout, diff, activity log, CI/CD checks, comments (list/add/edit/delete), reviewers (list/add/remove)
+- **Pull requests** - Create (with optional default-reviewer attachment), list, view, edit, merge, approve, decline, ready (mark draft ready), checkout, diff, activity log, CI/CD checks, comments (list/add/edit/delete/view/reply/resolve/unresolve, with `--resolved`/`--unresolved` filters on list), reviewers (list/add/remove)
+- **Issues** - List, view, create, edit, close, comment
+- **Pipelines** - List, view, run (with `--var key=value`), stop, logs (`--step`)
+- **Commits & build statuses** - `bb commit list/view`, `bb status list/set`
+- **Workspaces & projects** - `bb workspace list/view`, `bb project list/view/create`
 - **Snippets** - List, view (with file contents), create, edit (metadata or file upload), delete, watch/unwatch, comments (list/add/edit/delete)
+- **Browse** - Open repository pages, PRs, files, commits, and pipelines in the browser
 - **Configuration** - Get, set, list settings
-- **Shell Completion** - Bash, Zsh, Fish
+- **Shell completion** - Bash, Zsh, Fish
 - **Raw API access** - `bb api` passthrough to any Bitbucket Cloud 2.0 endpoint
 
-Without a dedicated command yet (but reachable today via `bb api`):
-- Issues — e.g. `bb api /repositories/{workspace}/{repo}/issues`
-- Pipelines — e.g. `bb api /repositories/{workspace}/{repo}/pipelines`
+No typed command yet — use `bb api`:
+
 - Branch permissions
 - Webhooks
 
@@ -41,9 +43,9 @@ Without a dedicated command yet (but reachable today via `bb api`):
 
 ### Does this work with Bitbucket Server/Data Center?
 
-No. Currently, the CLI only supports **Bitbucket Cloud**. Bitbucket Server (self-hosted) uses a different API and is not supported.
+No. The CLI supports **Bitbucket Cloud** only. Bitbucket Server (self-hosted) uses a different API.
 
-If you need Bitbucket Server support, please [open an issue](https://github.com/0pilatos0/bitbucket-cli/issues) to let us know.
+If you need Bitbucket Server support, [open an issue](https://github.com/0pilatos0/bitbucket-cli/issues).
 
 ---
 
@@ -84,9 +86,7 @@ bb auth login -u your-username -p your-api-token
 
 ### How do I use multiple Bitbucket accounts?
 
-The CLI currently uses a single shared config file, so true per-session multi-account support is not available yet.
-
-Current workaround: switch accounts by re-running login when needed.
+One config file, one active account. Switch by logging in again:
 
 ```bash
 # Switch to account A
@@ -100,28 +100,37 @@ export BB_API_TOKEN=token-b
 bb auth login
 ```
 
-This updates the stored credentials each time you switch.
+Each login overwrites the credentials in the config file, so parallel shells cannot hold different accounts.
 
 ---
 
 ### What scopes does my token need?
 
-**OAuth users:** Scopes are requested automatically during authorization. No manual selection needed.
+**OAuth login requests one fixed set:** `account`, `repository`, `repository:admin`, `pullrequest`, `pullrequest:write`. You cannot change it. That covers auth, repositories, and pull requests, but **not** `bb repo delete`, `bb pipeline *`, `bb issue *`, `bb snippet *`, or `bb project *` — for those, log in with an API token carrying the scopes below.
 
-**API token users:** Minimum required scopes:
+**API token scopes:**
 
-| Scope | Required For |
+| Scope | Required for |
 |-------|-------------|
-| `read:user:bitbucket` | `bb auth status` |
-| `read:repository:bitbucket` | `bb repo list`, `bb repo view` |
-| `write:repository:bitbucket` | `bb repo create` |
-| `admin:repository:bitbucket` | `bb repo delete` |
-| `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view` |
-| `write:pullrequest:bitbucket` | `bb pr create`, `bb pr merge` |
+| `read:user:bitbucket` | `bb auth status`, plus the user lookups in `bb pr list --mine`, `bb pr create --reviewer`, and `bb pr reviewers add/remove` |
+| `read:repository:bitbucket` | `bb repo list`, `bb repo view`, `bb commit list/view`, `bb status list` |
+| `write:repository:bitbucket` | `bb status set` |
+| `admin:repository:bitbucket` | `bb repo create`, `bb repo default-reviewers add/remove` |
+| `delete:repository:bitbucket` | `bb repo delete` |
+| `read:pullrequest:bitbucket` | `bb pr list`, `bb pr view`, `bb repo default-reviewers list`, all `bb pr comments` subcommands |
+| `write:pullrequest:bitbucket` | `bb pr create`, `bb pr edit`, `bb pr merge`, `bb pr approve`, `bb pr decline`, `bb pr ready`, `bb pr reviewers add/remove` |
+| `read:pipeline:bitbucket` | `bb pipeline list/view/logs` |
+| `write:pipeline:bitbucket` | `bb pipeline run`, `bb pipeline stop` |
+| `read:issue:bitbucket` | `bb issue list`, `bb issue view` |
+| `write:issue:bitbucket` | `bb issue create/edit/close/comment` |
+| `read:snippet:bitbucket` | `bb snippet list`, `bb snippet view`, all `bb snippet comments` subcommands |
+| `write:snippet:bitbucket` | `bb snippet create/edit/watch/unwatch` |
+| `delete:snippet:bitbucket` | `bb snippet delete` |
+| `read:project:bitbucket` | `bb project list`, `bb project view` |
+| `admin:project:bitbucket` | `bb project create` |
+| `read:workspace:bitbucket` | `bb workspace list`, `bb workspace view` |
 
-<Aside type="tip">
-For full functionality, grant all repository and pull request scopes.
-</Aside>
+See [Token Scopes](/reference/token-scopes/) for the per-command breakdown.
 
 ---
 
@@ -129,16 +138,25 @@ For full functionality, grant all repository and pull request scopes.
 
 ### How do I avoid typing workspace/repo every time?
 
-**Option 1:** Set defaults
+Don't know your workspace slug? Run `bb workspace list`.
+
+**Option 1:** Set a default
 ```bash
 bb config set defaultWorkspace myworkspace
 ```
 
-**Option 2:** Work from cloned repositories
+**Option 2:** Work from a cloned repository
 ```bash
 cd /path/to/myrepo
-bb pr list  # Auto-detects from git remote
+bb pr list  # workspace and repo come from the git remote
 ```
+
+**Option 3:** Export `BB_WORKSPACE` for a shell session
+```bash
+export BB_WORKSPACE=myworkspace
+```
+
+Precedence: `-w/--workspace` beats the git remote, which beats `BB_WORKSPACE`, which beats `defaultWorkspace`.
 
 See [Repository Context](/guides/repository-context/) for details.
 
@@ -146,9 +164,17 @@ See [Repository Context](/guides/repository-context/) for details.
 
 ### Does bb support interactive mode?
 
-Not currently. All commands require flags or arguments. There's no interactive prompt mode like some other CLIs offer.
+Only `bb completion install`, which asks which shell you use. Every other command takes flags and arguments.
 
-If you'd like this feature, please [open an issue](https://github.com/0pilatos0/bitbucket-cli/issues).
+`bb auth login` is browser-interactive but never prompts in the terminal — it opens your browser and waits up to 5 minutes for the callback on `http://localhost:19872/callback`.
+
+Destructive commands don't prompt either. Without `-y/--yes` they fail with `Use --yes to confirm.`:
+
+```bash
+bb repo delete myworkspace/old-repo --yes
+```
+
+That gate applies to `bb repo delete`, `bb repo default-reviewers remove`, `bb pr comments delete`, `bb snippet delete`, and `bb snippet comments delete`.
 
 ---
 
@@ -188,50 +214,59 @@ bb pr diff 42 --stat
 
 ### Can I use bb in CI/CD pipelines?
 
-Yes! See the [CI/CD Integration Guide](/guides/cicd/) for complete examples.
+Yes. See the [CI/CD Integration Guide](/guides/cicd/) for complete examples.
 
 Quick setup:
 1. Store credentials as CI/CD secrets
-2. Set environment variables: `BB_USERNAME`, `BB_API_TOKEN`
-3. Install the CLI and run commands
+2. Set `BB_USERNAME` and `BB_API_TOKEN`
+3. Install the CLI and run `bb auth login` — those two variables are read only at login time, so every job needs the login step before any other command
 
 ---
 
 ### How do I pipe output to other commands?
 
-Use the `--json` flag for machine-readable output:
+`--json` emits machine-readable JSON. `--jq <expression>` filters it with an embedded jq, so no external `jq` binary is needed and it behaves the same on Windows.
 
 ```bash
-# List PR titles
-bb pr list --json | jq '.pullRequests[].title'
+# PR titles
+bb pr list --json --jq '.pullRequests[].title'
 
-# Get PR count
-bb pr list --json | jq '.count'
+# PR count
+bb pr list --json --jq '.count'
 
 # Filter by author
-bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
+bb pr list --json --jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
 ```
 
-For list commands, add `--limit` when you need more than the default result
-count.
+`--jq` requires `--json`. Field projection runs before jq and drops the envelope, so `--json id,title` hands jq a bare array:
+
+```bash
+bb pr list --json id,title --jq '.[] | .title'
+```
+
+List commands return 25 items by default. Pass `--limit <n>` for a different cap, or `--all` to fetch every page (`--all` overrides `--limit`).
 
 ---
 
 ### Can I use bb with git hooks?
 
-Yes! Example pre-push hook to check for open PRs:
+Yes. Example pre-push hook that warns when a PR already exists:
 
 ```bash
 #!/bin/bash
 # .git/hooks/pre-push
 
 branch=$(git branch --show-current)
-prs=$(bb pr list --json 2>/dev/null | jq --arg b "$branch" '[.pullRequests[] | select(.source.branch.name == $b)] | length')
+prs=$(bb pr list --json --jq "[.pullRequests[] | select(.source.branch.name == \"$branch\")] | length" 2>/dev/null)
 
 if [ "$prs" -gt 0 ]; then
   echo "Note: PR already exists for branch $branch"
 fi
 ```
+
+The branch name is interpolated by the shell, not read from the environment:
+the embedded jq runs in a sandbox where `env` and `$ENV` do not see your shell
+variables.
 
 ---
 
@@ -239,7 +274,7 @@ fi
 
 ### How can I contribute?
 
-We welcome contributions! See [CONTRIBUTING.md](https://github.com/0pilatos0/bitbucket-cli/blob/main/CONTRIBUTING.md) for:
+See [CONTRIBUTING.md](https://github.com/0pilatos0/bitbucket-cli/blob/main/CONTRIBUTING.md) for:
 
 - Development setup
 - Code style guidelines
@@ -269,15 +304,15 @@ We welcome contributions! See [CONTRIBUTING.md](https://github.com/0pilatos0/bit
 
 ---
 
-## Update Notifications
+## Update notifications
 
 ### How do I disable update notifications?
-
-The CLI automatically checks for updates when you run `bb` without any subcommands. To disable this:
 
 ```bash
 bb config set skipVersionCheck true
 ```
+
+The CLI checks for a newer published version after every command, then prints a one-time banner to stderr. The banner is suppressed in `--json` mode, when stderr is not a TTY, and in CI.
 
 ### How often does the CLI check for updates?
 
@@ -305,10 +340,11 @@ Both settings are stored as typed JSON values, so JSON output returns:
 ### Will update checks slow down the CLI?
 
 No. The check is:
-- Performed asynchronously after displaying help
+- Performed after the command's own output, on stderr
 - Cached for 24 hours (or your configured interval)
 - Skipped entirely in CI environments
-- Silently fails if npm registry is unreachable
+- Suppressed in `--json` mode and when stderr is not a TTY, so piped output stays clean
+- Swallowed silently when the npm registry is unreachable
 
 ### Does the CLI auto-update?
 

--- a/docs/src/content/docs/help/troubleshooting.mdx
+++ b/docs/src/content/docs/help/troubleshooting.mdx
@@ -5,43 +5,37 @@ banner:
   content: 'Bitbucket app passwords are deprecated and cannot be created. Use API tokens instead. <a href="https://bitbucket.org/account/settings/api-tokens/">Create an API token</a>.'
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+Find your error message below. Errors go to stderr and exit 1, with a `✗`
+prefix (`ERR` under `--no-unicode` or `BB_NO_UNICODE`). Under `--json` a
+failure becomes a single-line JSON object on stderr instead. Errors raised
+before the command runs — unknown command, unknown option — stay plain text
+with an `error:` prefix either way.
 
-This guide covers the most common issues users encounter and how to resolve them.
+## Authentication
 
-## Authentication Issues
+### Authentication required
 
-### "Authentication required" Error
-
-**Symptoms:**
+```text
+✗ Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.
 ```
-Error: Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.
-```
 
-**Causes:**
-- You haven't logged in yet
-- Your credentials were cleared
-- OAuth tokens expired and could not be refreshed
+No credentials are stored — you have not logged in, or `bb auth logout` cleared
+them.
 
-**Solution:**
 ```bash
 bb auth login
 ```
 
 ---
 
-### "OAuth token expired" Error
+### OAuth token expired
 
-**Symptoms:**
+```text
+✗ OAuth token expired. Run 'bb auth login' to re-authenticate.
 ```
-Error: OAuth token expired. Run 'bb auth login' to re-authenticate.
-```
 
-**Causes:**
-- The refresh token was revoked or expired
-- The OAuth consumer was deleted or modified
+The refresh token was revoked or expired, or the OAuth consumer was deleted.
 
-**Solution:**
 ```bash
 bb auth logout
 bb auth login
@@ -49,378 +43,342 @@ bb auth login
 
 ---
 
-### "Invalid credentials" Error
+### Invalid username or token
 
-**Symptoms:**
+`bb auth login` reports a rejected API token like this:
+
+```text
+✗ Invalid username or token: Unauthorized. Verify your Bitbucket username and that the API token is current and has the required scopes.
 ```
-Error: Invalid credentials
+
+On any other command a 401 shows Bitbucket's own message plus a dimmed
+remediation line:
+
+```text
+✗ Unauthorized
+Your Bitbucket credentials were rejected. Run `bb auth login` to re-authenticate.
 ```
 
-**Causes:**
-- Incorrect username (API token auth)
-- Invalid or expired API token
-- Using a password instead of API token
+If you authenticated with OAuth, re-authenticate:
 
-**Solution:**
+```bash
+bb auth logout
+bb auth login
+```
 
-<Steps>
+If you use an API token, mint a fresh one at
+[Bitbucket API Tokens](https://bitbucket.org/account/settings/api-tokens/) —
+scopes cannot be added to an existing token — then log in again, keeping the
+token out of shell history:
 
-1. If using OAuth, simply re-authenticate:
-   ```bash
-   bb auth logout
-   bb auth login
-   ```
-
-2. If using API tokens, verify your username and generate a fresh token:
-   - Go to [Bitbucket API Tokens](https://bitbucket.org/account/settings/api-tokens/)
-   - Create a new token with required scopes
-   - Re-authenticate:
-   ```bash
-   bb auth login -u myuser -p your-new-token
-   ```
-
-</Steps>
+```bash
+echo "$BB_API_TOKEN" | bb auth login -u myuser --with-token
+```
 
 ---
 
-### OAuth Browser Doesn't Open
+### `bb auth login` never opens a browser
 
-**Symptoms:** Running `bb auth login` shows a URL but doesn't open a browser.
+The most common cause is environmental, not network:
 
-**Causes:**
-- SSH session or headless environment
-- No default browser configured
-- WSL without browser integration
+- **`BB_API_TOKEN` is exported in your shell.** Its mere presence — even set to
+  an empty string — selects API-token auth and skips OAuth entirely. Run
+  `unset BB_API_TOKEN` and retry. (`-u`, `-p`, `--app-password`, and
+  `--with-token` select the same path, deliberately.)
+- SSH session, headless machine, or WSL without browser integration.
+- No default browser configured.
 
-**Solution:**
+When the browser cannot be opened, `bb` prints the authorization URL to stderr —
+copy it into any browser and the flow completes normally. Or skip OAuth:
 
-1. Copy the URL shown in the terminal and open it manually in any browser
-2. Or use API token auth instead:
-   ```bash
-   bb auth login -u myuser -p your-api-token
-   ```
-
----
-
-### "Port 19872 is already in use" Error
-
-**Causes:**
-- Another instance of `bb auth login` is running
-- Another application is using port 19872
-
-**Solution:**
-1. Close any other `bb auth login` processes
-2. Check what's using the port: `lsof -i :19872` (macOS/Linux)
-3. Close the conflicting application and retry
+```bash
+bb auth login -u myuser -p your-api-token
+```
 
 ---
 
-### Token Works in Browser but Not CLI
+### Port 19872 is already in use
 
-**Causes:**
-- Token might have wrong scopes
-- Token might be an app password (deprecated)
-- Encoding issues when pasting
+```text
+✗ Port 19872 is already in use. Close the application using it and try again.
+```
 
-**Solution:**
+The OAuth callback server binds `127.0.0.1:19872` and waits up to 5 minutes.
 
-1. Verify you're using an **API token** (not app password):
-   - API tokens are managed at [API Tokens page](https://bitbucket.org/account/settings/api-tokens/)
-   - App passwords are at a different URL (deprecated)
+```bash
+lsof -i :19872   # macOS/Linux
+```
 
-2. Check token scopes include:
-   - `read:user:bitbucket`
-   - `read:repository:bitbucket` and `write:repository:bitbucket`
-   - `read:pullrequest:bitbucket` and `write:pullrequest:bitbucket`
+Close the other `bb auth login` (or whatever holds the port) and retry.
 
-3. When pasting the token, ensure no extra whitespace:
+---
+
+### Token works in the browser but not in the CLI
+
+1. Confirm it is an **API token**, minted at
+   [Bitbucket API Tokens](https://bitbucket.org/account/settings/api-tokens/).
+   App passwords live at a different URL and are deprecated.
+
+2. Check the scopes cover what you are running — see
+   [Token Scopes](/reference/token-scopes/). A missing scope surfaces as a 403
+   with the hint `Your token may be missing a required scope.`
+
+3. Strip whitespace when pasting:
+
    ```bash
    # Good - token only
    bb auth login -u myuser -p ATBB_xxxxx
 
-   # Bad - extra space
+   # Bad - leading space inside the quotes
    bb auth login -u myuser -p " ATBB_xxxxx"
    ```
 
-4. Or switch to OAuth to avoid token management entirely:
-   ```bash
-   bb auth login
-   ```
+---
+
+### Config file has insecure permissions
+
+```text
+✗ Config file has insecure permissions (644); expected 600. Run: chmod 600 /home/me/.config/bb/config.json
+```
+
+On macOS and Linux, `bb` refuses to read a config file or directory that is
+readable by group or other. This usually follows copying a config between
+machines or restoring a dotfiles repository. Windows skips the check.
+
+```bash
+chmod 700 ~/.config/bb
+chmod 600 ~/.config/bb/config.json
+```
+
+A hand-edited file that no longer parses gives:
+
+```text
+✗ Config file is not valid JSON: /home/me/.config/bb/config.json. Fix the file by hand or remove it and run `bb auth login` again.
+```
+
+Both are error code 4001 (`CONFIG_READ_FAILED`).
 
 ---
 
-## Repository Context Issues
+## Repository context
 
-### "Could not determine repository" Error
+### Could not determine repository
 
-**Symptoms:**
+```text
+✗ Could not determine repository. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
 ```
-Error: Could not determine repository. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
+
+Three sibling messages name the specific reason:
+
+```text
+✗ Not in a git repository. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
+✗ Git repository has no remote configured. Add a Bitbucket remote with `git remote add origin <url>`, or use --workspace and --repo options, or run this command from within a Bitbucket repository.
+✗ Remote 'git@github.com:me/thing.git' is not a Bitbucket URL. Use --workspace and --repo options, or run this command from within a Bitbucket repository.
 ```
 
-**Causes:**
-- Not in a git repository
-- Git remote doesn't point to Bitbucket
-- No default workspace configured
+All four are code 6001 (`CONTEXT_REPO_NOT_FOUND`). Pick whichever fix suits:
 
-**Solutions:**
-
-**Option 1:** Use explicit flags
 ```bash
-bb pr list -w myworkspace -r myrepo
-```
-
-**Option 2:** Set defaults
-```bash
+bb pr list -w myworkspace -r myrepo     # explicit flags
 bb config set defaultWorkspace myworkspace
+cd /path/to/cloned-bitbucket-repo && bb pr list
 ```
 
-**Option 3:** Work from a cloned repository
+See [Repository Context](/guides/repository-context/) for the full precedence
+rules.
+
+---
+
+### Repository or resource not found
+
+Commands that know what they were looking for name it, and stop there:
+
+```text
+✗ Repository my-ws/typo not found.
+✗ Pull request #999 not found in my-ws/my-repo.
+```
+
+Everywhere else a 404 surfaces Bitbucket's own message with a dimmed
+remediation line appended — see
+[Failures that tell you the next step](#failures-that-tell-you-the-next-step).
+In `--json` mode that line arrives as a top-level `hint` string on the error
+envelope.
+
+Usual causes: a typo in the workspace or repository slug, a repository you have
+no access to, or one that was renamed. To check what you can actually see:
+
 ```bash
-cd /path/to/cloned-bitbucket-repo
-bb pr list  # Auto-detects from git remote
+bb workspace list
+bb repo list -w myworkspace
 ```
-
-See [Repository Context](/guides/repository-context/) for details.
 
 ---
 
-### "Repository not found" Error
+## Network
 
-**Symptoms:**
+### Cannot reach Bitbucket
+
+```text
+✗ Network error: Unable to reach Bitbucket API. Run with DEBUG=true for details. If you're behind a proxy or using a custom CA, check your environment.
 ```
-Error: Repository not found
+
+```bash
+curl -I https://api.bitbucket.org          # connectivity
+export HTTPS_PROXY=http://proxy.example.com:8080
+DEBUG=true bb repo list                    # [HTTP] tracing on stdout, secrets redacted
 ```
 
-**Causes:**
-- Typo in workspace or repository name
-- You don't have access to the repository
-- Repository was deleted or renamed
-
-**Solution:**
-
-1. Verify spelling:
-   ```bash
-   # Check what the CLI detected
-   bb repo view
-   ```
-
-2. List repositories you have access to:
-   ```bash
-   bb repo list -w myworkspace
-   ```
-
-3. Check Bitbucket web UI to confirm repository exists
+Bitbucket's own availability is at
+[status.bitbucket.org](https://status.bitbucket.org).
 
 ---
 
-## Network Issues
+### Request timed out
 
-### "API request failed" Error
-
-**Symptoms:**
-```
-Error: API request failed
+```text
+✗ Network error: Request to Bitbucket API timed out after 30000ms. The server accepted the connection but did not respond in time. Increase or disable the timeout via BB_HTTP_TIMEOUT (milliseconds; set BB_HTTP_TIMEOUT=0 to disable), or run with DEBUG=true for details.
 ```
 
-**Causes:**
-- No internet connection
-- Bitbucket is down
-- Firewall blocking requests
-- Proxy not configured
+The per-request timeout defaults to 30000 ms.
 
-**Solutions:**
-
-1. Check internet connection:
-   ```bash
-   curl -I https://api.bitbucket.org
-   ```
-
-2. Check Bitbucket status: [status.bitbucket.org](https://status.bitbucket.org)
-
-3. If behind a proxy, configure it:
-   ```bash
-   export HTTPS_PROXY=http://proxy.example.com:8080
-   ```
+```bash
+BB_HTTP_TIMEOUT=60000 bb pr list   # 60 seconds
+BB_HTTP_TIMEOUT=0 bb pr list       # no timeout
+```
 
 ---
 
-### Rate Limiting
+### Rate limiting
 
-**Symptoms:**
+A 429 is retried automatically. In human mode you see the attempts on stderr:
+
+```text
+⚠ Rate limited, retrying in 1.0s (attempt 1/3)...
 ```
-Error: Rate limit exceeded
-```
 
-**Causes:**
-- Too many API requests in a short period
-- Scripts making rapid sequential calls
+Retries cover HTTP 429, 502, 503, and 504, up to 3 attempts. On a 429 the
+`Retry-After` header sets the delay when Bitbucket sends one; otherwise the
+delay is exponential backoff from 1s. Transient network failures on GET, HEAD,
+and OPTIONS share the same 3-attempt budget. Once it is exhausted, the command
+fails with Bitbucket's own 429 message.
 
-**Solutions:**
+The retry warning is suppressed in `--json` mode, so scripts see only the final
+failure.
 
-1. The CLI automatically retries rate-limited requests (HTTP 429) up to 3 times with exponential backoff. If you still see this error, the rate limit is sustained.
+If the limit is sustained:
 
-2. Wait a few minutes and retry
+1. Wait a few minutes and retry.
+2. Add a delay between calls in loops:
 
-3. For scripts, add delays between calls:
    ```bash
    for pr_id in 1 2 3 4 5; do
      bb pr view $pr_id
-     sleep 1  # Add delay between requests
+     sleep 1
    done
    ```
 
-3. Use `--json` and process locally to reduce API calls:
+3. Fetch once and filter locally instead of calling per item:
+
    ```bash
-   # One API call, process locally
-   bb pr list --json | jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "me")'
+   bb pr list --json --jq '.pullRequests[] | select((.author.nickname // .author.display_name) == "alice")'
    ```
 
 ---
 
-## Git Integration Issues
+## Git integration
 
-### "Not a git repository" Error
+### Clone fails
 
-**Symptoms:**
+`bb repo clone` shells out to `git clone git@bitbucket.org:<workspace>/<repo>.git`,
+so the error text is git's own, verbatim:
+
+```text
+✗ git@bitbucket.org: Permission denied (publickey).
 ```
-Error: Not a git repository
+
+That is an SSH problem, not a `bb auth` problem — the CLI does not pass its
+token to git.
+
+```bash
+ssh -T git@bitbucket.org                                  # verify your key
+git clone https://bitbucket.org/myworkspace/myrepo.git    # HTTPS fallback
 ```
-
-**Causes:**
-- Running command outside a git repository
-- Git not initialized
-
-**Solutions:**
-
-1. Navigate to a git repository:
-   ```bash
-   cd /path/to/your/repo
-   ```
-
-2. Or use explicit flags:
-   ```bash
-   bb pr list -w workspace -r repo
-   ```
 
 ---
 
-### Clone Fails
+## Command-specific issues
 
-**Symptoms:**
+### Destructive commands do not prompt
+
+```text
+✗ This will permanently delete myworkspace/old-repo.
+Use --yes to confirm.
 ```
-Error: Failed to clone repository
+
+The `-y, --yes` help text says "Skip confirmation prompt", but there is no
+prompt — the command fails until you pass the flag. This affects
+`bb repo delete`, `bb repo default-reviewers remove`, `bb pr comments delete`,
+`bb snippet delete`, and `bb snippet comments delete`.
+
+```bash
+bb repo delete myworkspace/old-repo --yes
 ```
-
-**Causes:**
-- SSH keys not configured
-- Repository access denied
-- Invalid repository URL
-
-**Solutions:**
-
-1. Try HTTPS instead of SSH:
-   ```bash
-   # The CLI uses SSH by default
-   # Clone manually with HTTPS if SSH fails
-   git clone https://bitbucket.org/workspace/repo.git
-   ```
-
-2. Check SSH configuration:
-   ```bash
-   ssh -T git@bitbucket.org
-   ```
-
-3. Verify repository access in Bitbucket web UI
 
 ---
 
-## Command-Specific Issues
+### Pull request creation is rejected
 
-### PR Creation Fails
+A missing title is caught locally, before any request:
 
-**Symptoms:**
+```text
+✗ Pull request title is required. Use --title option.
 ```
-Error: Failed to create pull request
+
+Everything else is Bitbucket's own message, with any `error.fields` detail
+flattened in — for example:
+
+```text
+✗ Bad request (type: extra keys not allowed)
 ```
 
-**Common causes and solutions:**
-
-| Cause | Solution |
-|-------|----------|
+| Cause | Fix |
+|-------|-----|
 | Branch doesn't exist on remote | `git push -u origin your-branch` |
 | PR already exists for branch | Check `bb pr list` |
-| Branch protection rules | Check repository settings |
+| Branch restrictions block the destination | Check repository settings |
 | No changes between branches | Ensure commits exist |
 
 ---
 
-### PR Merge Fails
+### Merge is rejected
 
-**Symptoms:**
+Bitbucket returns the reason in the error message. Diagnose the rest without
+leaving the terminal:
+
+```bash
+bb pr checks 42     # failing builds
+bb pr view 42       # reviewer approvals and merge state
+bb pr activity 42   # who requested changes
 ```
-Error: Cannot merge pull request
-```
 
-**Common causes:**
-
-- Merge conflicts exist
-- Required approvals not met
-- Build checks failing
-- Branch protection rules
-
-**Solution:**
-Check PR status in Bitbucket web UI for specific blockers.
+Common blockers are merge conflicts, unmet required approvals, and failing
+build checks. Fall back to the web UI only for branch-restriction rules, which
+the API does not expose.
 
 ---
 
-### Diff Shows Nothing
+### Diff shows nothing
 
-**Symptoms:**
 ```bash
 bb pr diff 42
 # (empty output)
 ```
 
-**Causes:**
-- PR has no file changes
-- PR is already merged
-- API returned empty diff
-
-**Solutions:**
-
-1. Check PR status:
-   ```bash
-   bb pr view 42
-   ```
-
-2. View in browser:
-   ```bash
-   bb pr diff 42 --web
-   ```
-
----
-
-## Getting Debug Information
-
-When reporting issues, gather this information:
+The PR has no file changes, or the API returned an empty diff.
 
 ```bash
-# CLI version
-bb --version
-
-# OS information
-uname -a  # Linux/macOS
-systeminfo | findstr /B /C:"OS"  # Windows
-
-# Bun version (required runtime)
-bun --version
-
-# Auth status (masks token)
-bb auth status
-
-# Config (masks token)
-bb config list
+bb pr view 42        # check state and branches
+bb pr diff 42 --web  # compare against the web UI
 ```
 
 ---
@@ -464,9 +422,46 @@ it first:
 
 ```bash
 bb --json pr list
-# ✗ --json consumed 'pr' as its field list, so 'list' was parsed as a top-level command.
-# Put --json after the subcommand: bb pr list --json
 ```
+
+`--json` did parse, so the failure comes back as a JSON envelope on stderr:
+
+```text
+{"name":"BBError","code":5002,"message":"--json consumed 'pr' as its field list, so 'list' was parsed as a top-level command.\nPut --json after the subcommand: bb pr list --json"}
+```
+
+`bb --json=id,title pr list` works, because the `--flag=value` form does not eat
+the next token.
+
+### `--jq` needs `--json`
+
+```bash
+bb pr list --jq '.pullRequests[].title'
+# ✗ --jq requires --json
+```
+
+Because `--json` was never set, this failure renders as **plain text on stderr**,
+not as a JSON envelope — surprising in a script that only parses stdout.
+`bb api` is the one exception: it accepts `--jq` on its own.
+
+```bash
+bb pr list --json --jq '.pullRequests[].title'   # correct
+bb api /repositories/my-ws --jq '.values[].name' # allowed without --json
+```
+
+### Empty `--json` field list
+
+```bash
+bb pr list --json ""
+```
+
+```text
+{"name":"BBError","code":8002,"message":"--json field list cannot be empty"}
+```
+
+`--json ,,` fails the same way. Use bare `--json` for the full envelope.
+
+---
 
 ## Failures that tell you the next step
 
@@ -485,12 +480,38 @@ In `--json` mode the same text arrives as a `hint` field. See
 
 ---
 
-## Still Need Help?
+## Getting debug information
 
-If you've tried the solutions above and still have issues:
+When reporting an issue, gather this:
 
-1. Search [existing issues](https://github.com/0pilatos0/bitbucket-cli/issues)
-2. Open a [new issue](https://github.com/0pilatos0/bitbucket-cli/issues/new) with:
+```bash
+# CLI version
+bb --version
+
+# OS information
+uname -a  # Linux/macOS
+systeminfo | findstr /B /C:"OS"  # Windows
+
+# Bun version (required runtime)
+bun --version
+
+# Auth status (never prints the token; use bb auth token for that)
+bb auth status
+
+# Config (masks secrets)
+bb config list
+```
+
+`bb auth status` makes a live `GET /user` call, so it also fails when the
+network or proxy is the real problem.
+
+---
+
+## Still need help?
+
+1. Check the [FAQ](/help/faq/) for questions that come up often
+2. Search [existing issues](https://github.com/0pilatos0/bitbucket-cli/issues)
+3. Open a [new issue](https://github.com/0pilatos0/bitbucket-cli/issues/new) with:
    - CLI version (`bb --version`)
    - Operating system
    - Complete error message

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Bitbucket CLI
-description: A powerful command-line interface for Bitbucket Cloud
+description: Manage Bitbucket Cloud pull requests, repos, pipelines, and issues from the terminal. JSON output on every command.
 template: splash
 hero:
-  tagline: Clone repos, manage PRs, and automate workflows — all from your terminal. If you know GitHub's gh, you'll feel right at home.
+  tagline: Clone repositories, manage pull requests, and automate workflows from your terminal. If you know GitHub's gh, you'll feel right at home.
   actions:
     - text: Get Started
       link: /getting-started/quickstart/
@@ -47,7 +47,7 @@ Requires [Bun](https://bun.sh) 1.0+ runtime.
 
 ```bash
 bb auth login                          # authenticate
-bb repo clone myworkspace/myrepo       # clone a repo
+bb repo clone myworkspace/myrepo       # clone a repository
 bb pr create -t "My awesome feature"   # create a PR
 bb pr list                             # list open PRs
 ```
@@ -57,7 +57,7 @@ bb pr list                             # list open PRs
 ## What can you do?
 
 <CardGrid>
-  <Card title="Repository Management" icon="folder">
+  <Card title="Repository management" icon="folder">
     Clone, create, list, view, and delete repositories.
 
     ```bash
@@ -67,7 +67,7 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
-  <Card title="Pull Request Workflows" icon="document">
+  <Card title="Pull requests" icon="document">
     Full PR lifecycle — create, review, approve, merge.
 
     ```bash
@@ -77,7 +77,7 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
-  <Card title="Code Review" icon="open-book">
+  <Card title="Code review" icon="open-book">
     View diffs, checkout PR branches, inspect checks.
 
     ```bash
@@ -87,8 +87,8 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
-  <Card title="CI/CD from the Terminal" icon="approve-check">
-    Trigger, inspect, and stop Bitbucket Pipelines without leaving your shell.
+  <Card title="CI/CD pipelines" icon="approve-check">
+    Trigger, inspect, and stop Bitbucket Pipelines.
 
     ```bash
     bb pipeline run --branch main
@@ -97,7 +97,30 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
-  <Card title="Jump to the Web UI" icon="external">
+  <Card title="Workspaces and projects" icon="database">
+    Find the workspaces you belong to and the projects inside them.
+
+    ```bash
+    bb workspace list
+    bb project list
+    bb project view PROJ
+    ```
+  </Card>
+
+  <Card title="Issues, snippets, and commits" icon="notes">
+    Track issues, share snippets, read history, and publish build statuses.
+
+    ```bash
+    bb issue list --state open
+    bb snippet create -t notes -f a.txt
+    bb commit list --limit 10
+    bb status set abc1234 --key BB-DEPLOY --state SUCCESSFUL
+    ```
+
+    See [Issue commands](/commands/issue/) and [Snippet commands](/commands/snippet/).
+  </Card>
+
+  <Card title="Jump to the web UI" icon="external">
     Open Bitbucket pages — PRs, files, commits, settings — in your browser.
 
     ```bash
@@ -107,15 +130,19 @@ bb pr list                             # list open PRs
     ```
   </Card>
 
-  <Card title="Scripting & Automation" icon="setting">
-    JSON output on every command. Built for CI/CD.
+  <Card title="Scripting and automation" icon="setting">
+    Every command speaks JSON. `--json` projects to a field list, `--jq` filters in-process — no external `jq` binary, no shell pipe.
 
     ```bash
-    bb pr list --json | jq '.pullRequests[].title'
+    bb pr list --json id,title,author.display_name
+    bb pipeline run --branch main --json --jq '.build_number'
     ```
+
+    A field list returns a flat array of objects; dotted paths keep their full
+    name as the key. See the [Scripting guide](/guides/scripting/).
   </Card>
 
-  <Card title="Raw API Access" icon="rocket">
+  <Card title="Raw API access" icon="rocket">
     Reach any Bitbucket 2.0 endpoint not yet wrapped by a typed command.
 
     ```bash
@@ -128,30 +155,38 @@ bb pr list                             # list open PRs
 
 ---
 
-## PR Workflows
-
-Task-focused guides for the shortest path to a result.
+## PR workflows
 
 <CardGrid>
   <LinkCard
-    title="Create and update PRs"
+    title="Create, edit, and view"
     href="/commands/pr/create-and-edit/"
-    description="Open pull requests, edit titles and descriptions."
+    description="Open a PR, change its title or description, list PRs, inspect one."
   />
   <LinkCard
     title="Review and merge"
     href="/commands/pr/review-and-merge/"
-    description="Approve, decline, mark ready, merge with strategy controls."
+    description="Approve, decline, mark drafts ready, and merge with explicit strategy control."
   />
   <LinkCard
-    title="Diffs and checkout"
+    title="Diff and checkout"
     href="/commands/pr/diff-and-checkout/"
-    description="View patches, open browser diffs, checkout branches locally."
+    description="Review patch output, fetch PR branches locally, and open browser diffs."
   />
   <LinkCard
-    title="Comments and reviewers"
+    title="Activity and checks"
+    href="/commands/pr/activity-and-checks/"
+    description="Inspect activity history and CI/build status before approving or merging."
+  />
+  <LinkCard
+    title="Review comments"
     href="/commands/pr/comments/"
-    description="Script-friendly review comments and reviewer management."
+    description="List, add, view, edit, reply to, resolve, unresolve, and delete general or inline review comments."
+  />
+  <LinkCard
+    title="Reviewers"
+    href="/commands/pr/reviewers/"
+    description="Add and remove reviewers. Adding someone already assigned is a no-op, as is removing someone who is not."
   />
 </CardGrid>
 
@@ -163,19 +198,24 @@ Task-focused guides for the shortest path to a result.
 
 <CardGrid>
   <LinkCard
-    title="Command Reference"
-    href="/commands/pr/"
-    description="All commands and options."
-  />
-  <LinkCard
-    title="Scripting Guide"
+    title="Scripting guide"
     href="/guides/scripting/"
     description="JSON output, exit codes, shell patterns."
   />
   <LinkCard
-    title="CI/CD Integration"
+    title="CI/CD integration"
     href="/guides/cicd/"
     description="GitHub Actions, GitLab CI, Jenkins, and more."
+  />
+  <LinkCard
+    title="Recipes"
+    href="/recipes/"
+    description="Auto-merge on green CI, bulk reviewer assignment, fork sync, reporting, retry wrappers."
+  />
+  <LinkCard
+    title="AI agent integration"
+    href="/guides/ai-agents/"
+    description="Wire the CLI into coding agents and tool-calling loops."
   />
   <LinkCard
     title="Troubleshooting"

--- a/docs/src/content/docs/recipes/auto-merge-on-ci-green.mdx
+++ b/docs/src/content/docs/recipes/auto-merge-on-ci-green.mdx
@@ -5,11 +5,11 @@ description: Poll bb pr checks until all CI checks have passed, then merge the p
 
 import { Aside } from '@astrojs/starlight/components';
 
-The "merge approved PRs" pattern in the [CI/CD guide](/guides/cicd/#merge-approved-prs-automatically) only checks `participants[].approved` — it ignores the actual CI status. This recipe adds the missing piece: poll [`bb pr checks`](/commands/pr/activity-and-checks/#bb-pr-checks) until every status is `SUCCESSFUL`, then merge.
+The "merge approved PRs" pattern in the [CI/CD guide](/guides/cicd/#merge-approved-prs-automatically) only checks whether a pull request (PR) has `participants[].approved` set — it ignores the actual CI status. This recipe adds the missing piece: poll [`bb pr checks`](/commands/pr/activity-and-checks/#bb-pr-checks) until every status is `SUCCESSFUL`, then merge.
 
 ## What "all-green" means
 
-`bb pr checks <id> --json` returns a stable envelope. The relevant shape:
+`bb pr checks <id> --json` returns this envelope — each entry in `statuses` also carries `refname`, `createdOn` and `uuid`, trimmed here:
 
 ```json
 {
@@ -36,7 +36,18 @@ The "merge approved PRs" pattern in the [CI/CD guide](/guides/cicd/#merge-approv
 
 Possible `state` values: `SUCCESSFUL`, `FAILED`, `INPROGRESS`, `STOPPED`.
 
-A PR is considered all-green when **at least one check exists** *and* every status is `SUCCESSFUL`. Treat zero checks as "not ready" — most teams want at least one passing build before auto-merge fires.
+A PR is all-green when **at least one check exists** *and* every status is `SUCCESSFUL`. Treat zero checks as "not ready".
+
+`summary` counts only three of those states: `successful` for `SUCCESSFUL`, `failed` for `FAILED`, `pending` for `INPROGRESS`. Anything else — `STOPPED`, or any state Bitbucket adds later — is counted in none of them, so `summary.successful + failed + pending` can be less than `statuses | length`. Gate on `successful == total`, never on `failed == 0 and pending == 0`.
+
+<Aside type="caution">
+`bb pr checks` is not paginated. It issues one request and returns whatever Bitbucket puts on the first page — there is no `--limit` or `--all`. On a PR with more build statuses than fit one page, both `summary` and `statuses` are computed over a partial set, and an auto-merge gate can fire while a check you never saw is still failing. If a repository routinely posts more than a handful of statuses per PR, read them through `bb api` instead:
+
+```bash
+bb api "/repositories/$WORKSPACE/$REPO/pullrequests/42/statuses" --paginate --json \
+  | jq -r '(.values | length) > 0 and all(.values[]; .state == "SUCCESSFUL")'
+```
+</Aside>
 
 ### jq filter for all-green
 
@@ -82,6 +93,7 @@ while true; do
   checks_json=$(bb pr checks "$PR_ID" -w "$WORKSPACE" -r "$REPO" --json)
 
   failed=$(echo "$checks_json" | jq '.summary.failed')
+  successful=$(echo "$checks_json" | jq '.summary.successful')
   pending=$(echo "$checks_json" | jq '.summary.pending')
   total=$(echo "$checks_json" | jq '.statuses | length')
 
@@ -90,12 +102,16 @@ while true; do
     exit 1
   fi
 
-  if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+  # successful == total, not "no failures and nothing pending": a STOPPED
+  # check lands in none of the summary buckets, so the looser test would
+  # merge a PR whose only build was cancelled. A STOPPED check keeps this
+  # loop polling until TIMEOUT_SECONDS, which then exits 1.
+  if [ "$total" -gt 0 ] && [ "$successful" -eq "$total" ]; then
     echo "All $total checks passed for PR #$PR_ID — merging."
     break
   fi
 
-  echo "PR #$PR_ID: $pending pending / $total total — sleeping ${POLL_INTERVAL}s"
+  echo "PR #$PR_ID: $successful/$total passed, $pending pending — sleeping ${POLL_INTERVAL}s"
   sleep "$POLL_INTERVAL"
 done
 
@@ -114,6 +130,8 @@ WORKSPACE=myworkspace REPO=myrepo ./auto-merge-on-green.sh 42
 
 Run this on a schedule (cron, GitHub Actions cron trigger, Bitbucket Pipelines schedule). It merges every approved PR whose checks are all green and skips the rest silently.
 
+`--all` is load-bearing. `bb pr list` defaults to `--limit 25`, and the `Use --limit <n> or --all to see more.` hint is printed with table output only — under `--json` you get 25 rows and no warning, so older approved PRs would never be merged.
+
 ```bash
 #!/bin/bash
 # auto-merge-scan.sh - Merge every approved, all-green PR.
@@ -122,7 +140,7 @@ set -euo pipefail
 WORKSPACE="${WORKSPACE:-myworkspace}"
 REPO="${REPO:-myrepo}"
 
-open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '.pullRequests[].id')
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --all --json --jq '.pullRequests[].id')
 
 for pr_id in $open_prs; do
   approved=$(bb pr view "$pr_id" -w "$WORKSPACE" -r "$REPO" --json --jq '

--- a/docs/src/content/docs/recipes/bulk-reviewer-assignment.mdx
+++ b/docs/src/content/docs/recipes/bulk-reviewer-assignment.mdx
@@ -3,13 +3,17 @@ title: Bulk reviewer assignment
 description: Assign a list of reviewers across many open pull requests at once — useful for team rotations, onboarding, and review coverage policies.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+The [Scripting guide](/guides/scripting/#example-scripts) covers batch *approval*. Assigning reviewers across many pull requests (PRs) in one pass is a separate workflow — team rotations, onboarding new reviewers, and enforcing minimum reviewer coverage on existing PRs.
 
-The [Scripting guide](/guides/scripting/#example-scripts) covers batch *approval*, but assigning reviewers across many PRs in one pass is a separate workflow. This recipe handles team rotations, onboarding new reviewers, and enforcing minimum reviewer coverage on existing PRs.
+## Identifying reviewers
+
+`bb pr reviewers add` takes an **account ID** (`712020:3cfed7e0-…`) or a **braced UUID** (`{c1cb1bb5-…}`). Bitbucket Cloud no longer resolves login names here, so a pool of `alice bob charlie` fails with a 404 on every call. See [Identifying users](/commands/pr/reviewers/#identifying-users) for how to look the IDs up once.
+
+Pick one form and use it consistently — an account ID never equals a UUID, so a pool that mixes the two breaks any comparison you do against PR author fields.
 
 ## Recipe: assign a fixed reviewer list
 
-The script below adds every username in `REVIEWERS` to every open PR in `WORKSPACE/REPO`. Existing reviewers are not removed; if a reviewer is already assigned, [`bb pr reviewers add`](/commands/pr/reviewers/#bb-pr-reviewers-add) is a no-op.
+Adds every account ID in `REVIEWERS` to every open PR in `WORKSPACE/REPO`. Existing reviewers are not removed; if a reviewer is already assigned, [`bb pr reviewers add`](/commands/pr/reviewers/#bb-pr-reviewers-add) is a no-op.
 
 ```bash
 #!/bin/bash
@@ -18,14 +22,17 @@ set -euo pipefail
 
 WORKSPACE="${WORKSPACE:-myworkspace}"
 REPO="${REPO:-myrepo}"
-# Space-separated usernames (Bitbucket handles, not display names)
-REVIEWERS="${REVIEWERS:-alice bob charlie}"
+# Space-separated Bitbucket account IDs (not usernames, not display names).
+REVIEWERS="${REVIEWERS:?set REVIEWERS to space-separated account IDs}"
 
 # Optional: skip PRs authored by a reviewer (you can't review your own PR)
 SKIP_SELF_REVIEW="${SKIP_SELF_REVIEW:-true}"
 
-open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json \
-  --jq '.pullRequests[] | "\(.id)\t\(.author.nickname // .author.display_name)"')
+# --all: without it, bb pr list stops at 25 and says nothing about it under --json.
+# External `jq -r`: the built-in --jq has no raw mode, so this filter would
+# return a JSON-quoted string with a two-character \t instead of a real tab.
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --all --json \
+  | jq -r '.pullRequests[] | "\(.id)\t\(.author.account_id)"')
 
 while IFS=$'\t' read -r pr_id author; do
   [ -n "$pr_id" ] || continue
@@ -41,7 +48,7 @@ while IFS=$'\t' read -r pr_id author; do
          -w "$WORKSPACE" -r "$REPO" >/dev/null 2>&1; then
       echo "  + added $reviewer"
     else
-      echo "  ! failed to add $reviewer (user not found, or perms)" >&2
+      echo "  ! failed to add $reviewer (bad account ID, or permissions)" >&2
     fi
 
     sleep 1   # rate-limit cushion
@@ -53,17 +60,15 @@ done <<< "$open_prs"
 
 ```bash
 WORKSPACE=myworkspace REPO=myrepo \
-  REVIEWERS="alice bob charlie" \
+  REVIEWERS="712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f 712020:9ab1f22c-51de-4e7d-9f0e-2b7a10cd3311" \
   ./bulk-assign-reviewers.sh
 ```
 
-<Aside type="tip">
-`bb pr reviewers add` looks up the user via the Bitbucket API every call, which means each iteration costs one extra request. For very large workloads, fetch the UUIDs once and reuse them — see the next recipe.
-</Aside>
+Each `bb pr reviewers add` costs three API requests: one to resolve the user, then a GET and a PUT on the pull request. At `PRs × reviewers × 3` that adds up quickly — see [Handling rate limits](#handling-rate-limits) below.
 
 ## Recipe: rotation by hash bucket
 
-If you want each PR to get *one* reviewer from a pool — for a round-robin team rotation — hash the PR ID into the reviewer list. This produces a stable, reproducible assignment without a database.
+To give each PR *one* reviewer from a pool — a round-robin team rotation — hash the PR ID into the pool. The assignment is stable and reproducible without a database.
 
 ```bash
 #!/bin/bash
@@ -72,9 +77,14 @@ set -euo pipefail
 
 WORKSPACE="${WORKSPACE:-myworkspace}"
 REPO="${REPO:-myrepo}"
-POOL=(alice bob charlie dana)
+# Account IDs, same rule as above.
+POOL=(
+  "712020:3cfed7e0-0ed6-49fc-bb35-410a00ccee6f"
+  "712020:9ab1f22c-51de-4e7d-9f0e-2b7a10cd3311"
+  "712020:c40be5aa-7c19-4a0b-83f2-6d1e94ab7702"
+)
 
-open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '.pullRequests[].id')
+open_prs=$(bb pr list -w "$WORKSPACE" -r "$REPO" --all --json --jq '.pullRequests[].id')
 
 for pr_id in $open_prs; do
   idx=$(( pr_id % ${#POOL[@]} ))
@@ -90,8 +100,9 @@ done
 The CLI already retries 429 responses up to 3 times automatically. For *very* large bulk operations (hundreds of PRs × multiple reviewers), prefer:
 
 1. A larger sleep between PRs (`sleep 2` or `sleep 3`).
-2. Splitting the run across cron windows.
-3. Wrapping individual `bb` calls in the [retry wrapper](/recipes/retry-wrapper/) for the rare case of *persistent* 429s.
+2. Bounding each run: swap `--all` for `--limit 50` so one pass can't stretch for hours. There is no offset flag, so a plain re-run sees the same 50 PRs — record the IDs you have already handled and skip them next time.
+3. Splitting the run across cron windows.
+4. Wrapping individual `bb` calls in the [retry wrapper](/recipes/retry-wrapper/) for the rare case of *persistent* 429s.
 
 ## Related
 

--- a/docs/src/content/docs/recipes/fork-synchronization.mdx
+++ b/docs/src/content/docs/recipes/fork-synchronization.mdx
@@ -5,7 +5,7 @@ description: Keep a forked Bitbucket repository up to date with its upstream —
 
 import { Aside } from '@astrojs/starlight/components';
 
-Fork-based contribution is common in open-source workflows: you fork an upstream repo, work on a feature branch in your fork, and open a PR back to upstream. Forks drift quickly, so you need a routine sync. This recipe combines `bb repo view` to discover the upstream URL and plain `git` for the fetch/rebase/push.
+Forks drift from upstream fast. This recipe uses `bb repo view` to discover the upstream clone URL and plain `git` for the fetch, rebase and push.
 
 ## Prerequisites
 
@@ -26,9 +26,10 @@ UPSTREAM_REPO="${UPSTREAM_REPO:?set UPSTREAM_REPO}"
 BRANCH="${BRANCH:-main}"
 
 # 1. Look up the upstream clone URL via bb (HTTPS).
-upstream_url=$(bb repo view \
-  -w "$UPSTREAM_WORKSPACE" -r "$UPSTREAM_REPO" --json \
-  --jq '.links.clone[] | select(.name == "https") | .href')
+#    Pipe --json to external `jq -r`: the built-in --jq JSON-encodes its
+#    output, so the URL would come back wrapped in literal double quotes.
+upstream_url=$(bb repo view -w "$UPSTREAM_WORKSPACE" -r "$UPSTREAM_REPO" --json \
+  | jq -r '.links.clone[] | select(.name == "https") | .href')
 
 if [ -z "$upstream_url" ]; then
   echo "Could not resolve HTTPS clone URL for $UPSTREAM_WORKSPACE/$UPSTREAM_REPO" >&2
@@ -71,21 +72,24 @@ UPSTREAM_WORKSPACE=acme \
 The script rebases instead of merging. If `main` on your fork has commits that aren't on upstream, the rebase will rewrite their hashes — anyone else pulling from your fork's `main` will see history change. Use a merge instead (`git merge upstream/$BRANCH`) if your fork shares `main` with collaborators.
 </Aside>
 
-## Recipe: sync, then open a PR for a feature branch
+## Recipe: sync, then open a pull request for a feature branch
 
-A common follow-up: after syncing `main`, rebase your feature branch and open a cross-fork PR back to upstream. `bb pr create` accepts source branch + destination workspace/repo, so you can target the upstream from your fork.
+After syncing `main`, rebase your feature branch and open a pull request (PR) back to upstream.
+
+`bb pr create` cannot do this. Its `-s`/`--source` and `-d`/`--destination` are both plain branch names resolved inside the `-w`/`-r` repository, so it has no way to name your fork as the source — pointing it at upstream either 404s or opens a same-repo PR in upstream. Use [`bb api`](/guides/scripting/#raw-api-access-escape-hatch) to POST the cross-fork body yourself.
 
 ```bash
 #!/bin/bash
 # sync-and-pr.sh
 set -euo pipefail
 
-UPSTREAM_WORKSPACE="${UPSTREAM_WORKSPACE:?}"
-UPSTREAM_REPO="${UPSTREAM_REPO:?}"
-FORK_WORKSPACE="${FORK_WORKSPACE:?}"   # your workspace
-FORK_REPO="${FORK_REPO:?}"             # your fork's repo slug
-FEATURE_BRANCH="${FEATURE_BRANCH:?}"
+UPSTREAM_WORKSPACE="${UPSTREAM_WORKSPACE:?set UPSTREAM_WORKSPACE}"
+UPSTREAM_REPO="${UPSTREAM_REPO:?set UPSTREAM_REPO}"
+FORK_WORKSPACE="${FORK_WORKSPACE:?set FORK_WORKSPACE}"   # your workspace
+FORK_REPO="${FORK_REPO:?set FORK_REPO}"                  # your fork's repo slug
+FEATURE_BRANCH="${FEATURE_BRANCH:?set FEATURE_BRANCH}"
 TITLE="${TITLE:-Update from $FEATURE_BRANCH}"
+DESTINATION="${DESTINATION:-main}"
 
 # 1. Sync main, then rebase the feature branch onto fresh main.
 BRANCH=main ./sync-fork.sh
@@ -94,21 +98,46 @@ git checkout "$FEATURE_BRANCH"
 git rebase main
 git push --force-with-lease origin "$FEATURE_BRANCH"
 
-# 2. Open a PR in the upstream repo, sourced from the fork's branch.
-#    Bitbucket Cloud uses cross-repo PRs by passing the source as a fork.
-bb pr create \
-  -w "$UPSTREAM_WORKSPACE" -r "$UPSTREAM_REPO" \
-  -t "$TITLE" \
-  -s "$FEATURE_BRANCH" \
-  -d main
+# 2. Open a PR in the upstream repository, sourced from the fork's branch.
+#    Build the body with jq so a title containing quotes or backslashes
+#    can't break the JSON.
+jq -n \
+  --arg title "$TITLE" \
+  --arg source "$FEATURE_BRANCH" \
+  --arg fork "$FORK_WORKSPACE/$FORK_REPO" \
+  --arg destination "$DESTINATION" \
+  '{
+     title: $title,
+     source: {
+       branch: { name: $source },
+       repository: { full_name: $fork }
+     },
+     destination: { branch: { name: $destination } }
+   }' \
+  | bb api POST "/repositories/$UPSTREAM_WORKSPACE/$UPSTREAM_REPO/pullrequests" --input -
 ```
 
-<Aside type="tip">
-Cross-fork PR creation in Bitbucket Cloud requires that the upstream repo allows forks-as-sources and that you have read access. Check the Bitbucket UI once if `bb pr create` rejects the request — the error message from the API is forwarded as the CLI exit reason.
-</Aside>
+The path is fully interpolated from shell variables, so `bb api` has no `{workspace}`/`{repo}` placeholders left to substitute. Don't mix the two forms in one path.
+
+### Usage
+
+```bash
+UPSTREAM_WORKSPACE=acme UPSTREAM_REPO=widget \
+  FORK_WORKSPACE=myuser FORK_REPO=widget \
+  FEATURE_BRANCH=feat/login \
+  TITLE="Add login button" \
+  ./sync-and-pr.sh
+```
+
+Cross-fork PRs require that the upstream repository accepts forks as sources and that your token can read it. If Bitbucket rejects the request, its message is printed to stderr as `✗ …` and the CLI exits `1`. Re-run with `--json` to get the same error as one compact line on stderr:
+
+```json
+{"name":"APIError","code":2003,"message":"You do not have access to create a pull request","statusCode":403}
+```
 
 ## Related
 
 - [Repository Context](/guides/repository-context/) — how `bb` resolves workspace/repo from your git remote
 - [`bb repo view`](/commands/repo/) — used here to fetch the upstream HTTPS clone URL
-- [`bb pr create`](/commands/pr/create-and-edit/) — for the second recipe's cross-fork PR
+- [`bb pr create`](/commands/pr/create-and-edit/) — same-repository PRs, where the source branch lives in the target repository
+- [Raw API access](/guides/scripting/#raw-api-access-escape-hatch) — `bb api`, used here for the cross-fork POST

--- a/docs/src/content/docs/recipes/index.mdx
+++ b/docs/src/content/docs/recipes/index.mdx
@@ -5,9 +5,9 @@ description: Cookbook of common Bitbucket CLI workflows — auto-merge, bulk rev
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-A cookbook of ready-to-copy workflows that combine `bb` commands with `jq` and shell to solve the patterns we see most often. Each recipe is a complete, runnable script — drop it into a CI job or a dotfile and adjust workspace/repo names.
+Ready-to-copy workflows that combine `bb` with `jq` and shell. Each recipe is a complete, runnable script — drop it into a CI job or a dotfile and adjust the workspace and repository names.
 
-If you are looking for the *primitives* these recipes are built on, see the [Scripting & Automation guide](/guides/scripting/) and the [CI/CD Integration guide](/guides/cicd/).
+For the *primitives* these recipes are built on, see the [Scripting & Automation guide](/guides/scripting/) and the [CI/CD Integration guide](/guides/cicd/).
 
 ## Available recipes
 
@@ -20,7 +20,7 @@ If you are looking for the *primitives* these recipes are built on, see the [Scr
   <LinkCard
     title="Bulk reviewer assignment"
     href="/recipes/bulk-reviewer-assignment/"
-    description="Assign a fixed list of reviewers across many open PRs (team rotations, onboarding)."
+    description="Assign a fixed list of reviewers across many open pull requests (team rotations, onboarding)."
   />
   <LinkCard
     title="Fork synchronization"
@@ -41,7 +41,8 @@ If you are looking for the *primitives* these recipes are built on, see the [Scr
 
 ## Conventions used in these recipes
 
-- All recipes assume `bb auth login` has already succeeded (interactively or via `BB_USERNAME` / `BB_API_TOKEN` env vars).
-- `WORKSPACE` and `REPO` are referenced as shell variables — set them at the top of the script or export them from your CI environment.
-- The CLI already retries transient HTTP 429 / 5xx errors up to 3 times with exponential backoff. The [retry wrapper recipe](/recipes/retry-wrapper/) is only for failures that persist past that.
-- `--json` output shapes are stable; see the [JSON Output reference](/reference/json-output/) for the envelope structure of list-style commands.
+- All recipes assume `bb auth login` has already succeeded — interactively, or via the `BB_USERNAME` and `BB_API_TOKEN` env vars.
+- `WORKSPACE` and `REPO` are read from the environment with a `${VAR:-default}` fallback. Export them in CI, or edit the defaults at the top of the script.
+- List commands default to `--limit 25`. Pass `--all` wherever a recipe has to see every result — the `Showing 25 pull requests. Use --limit <n> or --all to see more.` hint is printed with table output only, never under `--json`.
+- The CLI already retries HTTP 429, 502, 503 and 504 up to 3 times with exponential backoff. It also retries `ECONNRESET`, `ETIMEDOUT`, `ECONNABORTED`, `EAI_AGAIN` and `EPIPE` on GET, HEAD and OPTIONS. Nothing else is retried — a 500 is not, and neither is `ENOTFOUND` or a TLS failure. The [retry wrapper recipe](/recipes/retry-wrapper/) is for failures that persist past that.
+- `--jq` JSON-encodes its output: strings come back with quotes around them. Pipe `--json` to external `jq -r` when you need a raw string for the shell. See the [JSON Output reference](/reference/json-output/) for the envelope structure of list-style commands.

--- a/docs/src/content/docs/recipes/reporting-analytics.mdx
+++ b/docs/src/content/docs/recipes/reporting-analytics.mdx
@@ -5,7 +5,7 @@ description: Count PRs per state, sum diff sizes, group by author, and export to
 
 import { Aside } from '@astrojs/starlight/components';
 
-The [Scripting guide](/guides/scripting/#common-jq-patterns) lists three starter jq patterns. This recipe expands that into a small analytics toolkit you can paste into a weekly report job.
+The [Scripting guide](/guides/scripting/#jq-patterns) lists starter jq patterns. This recipe expands them into a small analytics toolkit you can paste into a weekly report job.
 
 All recipes assume:
 
@@ -14,50 +14,71 @@ WORKSPACE=myworkspace
 REPO=myrepo
 ```
 
-## Count PRs per state
+Two things will bite you on this page if you skip them:
 
-`bb pr list` only returns one state at a time, so to count across all states fetch each separately and combine:
+- **`count` is what was fetched, not what exists.** `bb pr list` stops at `--limit 25` by default, so `.count` maxes out at 25 and the `Use --limit <n> or --all to see more.` hint is suppressed under `--json`. Pass `--all` whenever the number itself is the answer.
+- **`--jq` JSON-encodes its output.** There is no raw mode. When you need a bare string for the shell or a file, pipe `--json` into external `jq -r` instead.
+
+## Count pull requests per state
+
+`bb pr list` returns one state at a time, so fetch each separately and combine:
 
 ```bash
 for state in OPEN MERGED DECLINED SUPERSEDED; do
-  count=$(bb pr list -w "$WORKSPACE" -r "$REPO" -s "$state" --json --jq '.count')
+  count=$(bb pr list -w "$WORKSPACE" -r "$REPO" -s "$state" --all --json --jq '.count')
   printf "%-12s %s\n" "$state" "$count"
 done
 ```
 
 Sample output:
 
-```
+```text
 OPEN         12
 MERGED       340
 DECLINED     8
 SUPERSEDED   2
 ```
 
-If you only need a snapshot of currently open PRs grouped by state attribute, a one-liner suffices:
+The loop is not avoidable: `--state` takes one value and defaults to `OPEN`, so a single fetch can only ever contain one state and `group_by(.state)` would return one group. Grouping is still useful on other attributes of a single fetch — open PRs per target branch, for example:
 
 ```bash
-bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '
+bb pr list -w "$WORKSPACE" -r "$REPO" --all --json --jq '
   .pullRequests
-  | group_by(.state)
-  | map({ state: .[0].state, count: length })
+  | group_by(.destination.branch.name)
+  | map({ branch: .[0].destination.branch.name, count: length })
+  | sort_by(-.count)
 '
 ```
 
 ## Sum additions and deletions across PRs
 
-`pr list` does not include diff stats — they come from `bb pr diff <id> --json --stat` (or equivalent). For aggregate volume, walk every PR and sum:
+`bb pr list` does not include diff stats. `bb pr diff <id> --stat --json` does, and it already totals them for you:
+
+```json
+{
+  "workspace": "myworkspace",
+  "repoSlug": "myrepo",
+  "pullRequestId": 42,
+  "mode": "stat",
+  "files": [{ "path": "src/auth.ts", "additions": 31, "deletions": 4 }],
+  "filesChanged": 1,
+  "totalAdditions": 31,
+  "totalDeletions": 4
+}
+```
+
+The totals are per PR — there is no aggregate endpoint — so the outer loop still stands. Read `totalAdditions` and `totalDeletions` rather than re-summing `.files`:
 
 ```bash
 #!/bin/bash
 total_added=0
 total_deleted=0
 
-for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --json \
+for pr_id in $(bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --all --json \
                  --jq '.pullRequests[].id'); do
   stats=$(bb pr diff "$pr_id" -w "$WORKSPACE" -r "$REPO" --stat --json)
-  added=$(echo "$stats" | jq '[.files[].additions] | add // 0')
-  deleted=$(echo "$stats" | jq '[.files[].deletions] | add // 0')
+  added=$(echo "$stats" | jq '.totalAdditions')
+  deleted=$(echo "$stats" | jq '.totalDeletions')
   total_added=$(( total_added + added ))
   total_deleted=$(( total_deleted + deleted ))
   sleep 1
@@ -68,13 +89,13 @@ echo "Total deleted: $total_deleted"
 ```
 
 <Aside type="tip">
-This makes one HTTP request per PR. For a few dozen PRs it's fine; for hundreds, schedule it overnight or scope to a date range with `--jq '... | select(.updated_on >= "2025-01-01")'` before the inner loop.
+This makes one HTTP request per PR. For a few dozen PRs it's fine; for hundreds, schedule it overnight or scope to a date range with `--jq '... | select(.updated_on >= "2025-01-01")'` before the inner loop. That is a lexicographic string compare, which works because Bitbucket's timestamps are zero-padded ISO 8601.
 </Aside>
 
 ## Group by author with counts
 
 ```bash
-bb pr list -w "$WORKSPACE" -r "$REPO" --json --jq '
+bb pr list -w "$WORKSPACE" -r "$REPO" --all --json --jq '
   .pullRequests
   | group_by(.author.nickname // .author.display_name)
   | map({
@@ -107,10 +128,10 @@ bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --limit 200 --json --jq '
 
 ## CSV export
 
-To export an open-PRs report into a spreadsheet, use jq's `@csv`:
+Use jq's `@csv` — through **external** `jq -r`, not `--jq`. `@csv` produces a jq string, and `--jq` would JSON-encode it again, wrapping every line in a second pair of quotes and backslash-escaping the inner ones. The result is not valid CSV.
 
 ```bash
-bb pr list -w "$WORKSPACE" -r "$REPO" --limit 500 --json --jq '
+bb pr list -w "$WORKSPACE" -r "$REPO" --all --json | jq -r '
   ["id","title","author","state","created_on","source","destination"],
   (
     .pullRequests[]
@@ -132,32 +153,38 @@ head -3 prs.csv
 
 Sample output:
 
-```
+```text
 "id","title","author","state","created_on","source","destination"
-42,"Add login button","alice","OPEN","2025-01-04T09:11:00Z","feat/login","main"
-43,"Fix typo in README","bob","OPEN","2025-01-04T11:22:00Z","fix/typo","main"
+42,"Add login button","alice","OPEN","2025-01-04T09:11:00.993890+00:00","feat/login","main"
+43,"Fix typo in README","bob","OPEN","2025-01-04T11:22:41.118201+00:00","fix/typo","main"
 ```
 
 ## PR cycle time (created → merged)
 
+Bitbucket timestamps look like `2018-08-15T23:50:59.993890+00:00`. jq's `fromdateiso8601` is `strptime("%Y-%m-%dT%H:%M:%SZ")`, which rejects both the fractional seconds and the numeric offset — feeding it a raw Bitbucket timestamp fails the whole filter with `jq evaluation failed: …` (error code `8001`), it does not just skip a row. Strip both first:
+
 ```bash
 bb pr list -w "$WORKSPACE" -r "$REPO" -s MERGED --limit 100 --json --jq '
+  def ts: sub("\\.[0-9]+"; "") | sub("\\+00:00"; "Z") | fromdateiso8601;
   [
     .pullRequests[]
     | {
         id,
         title,
-        hours: (
-          (.updated_on  | fromdateiso8601)
-          - (.created_on | fromdateiso8601)
-        ) / 3600
+        hours: ((.updated_on | ts) - (.created_on | ts)) / 3600
       }
   ]
   | sort_by(.hours)
 '
 ```
 
-`updated_on` on a merged PR approximates the merge time; for exact merge time, walk `bb pr activity <id>` and find the merge event.
+The `sub("\\.[0-9]+"; "")` is a no-op on the fraction-less variant Bitbucket also emits, so `ts` handles both.
+
+`updated_on` on a merged PR approximates the merge time. For the exact timestamp, read the merge event:
+
+```bash
+bb pr activity 42 -w "$WORKSPACE" -r "$REPO" --type merge --json --jq '.activities[0].merge.date'
+```
 
 ## Related
 

--- a/docs/src/content/docs/recipes/retry-wrapper.mdx
+++ b/docs/src/content/docs/recipes/retry-wrapper.mdx
@@ -15,27 +15,24 @@ This recipe is for the cases where it isn't:
 
 ## What you'll see when retry kicks in
 
-The built-in retry is silent on success. On the third and final failure you'll see an error like:
+Each built-in retry announces itself on stderr — `⚠ Rate limited, retrying in 1.0s (attempt 1/3)...` — unless you passed `--json`, which suppresses the chatter so it can't pollute a structured pipeline. After the third and final failure, the CLI prints Bitbucket's own message to stderr, prefixed with a red `✗` (or `ERR ` under `--no-unicode`). For a rate limit that is typically:
 
-```
-Error: API request failed: 429 Too Many Requests
+```text
+✗ Rate limit for this resource has been exceeded
 ```
 
-If you also pass `--json`, the structured error shape on stderr looks like:
+The HTTP status number does not appear in text mode. To branch on it, pass `--json`: the error envelope goes to stderr as a single compact line.
 
 ```json
-{
-  "error": {
-    "code": "API_ERROR",
-    "message": "API request failed: 429 Too Many Requests"
-  }
-}
+{"name":"APIError","code":2004,"message":"Rate limit for this resource has been exceeded","context":{"status":429},"statusCode":429,"response":{"type":"error","error":{"message":"Rate limit for this resource has been exceeded"}}}
 ```
 
-That JSON shape is stable — see the [Error Codes reference](/reference/error-codes/). If you see this and the operation is idempotent, retrying is safe.
+The envelope is flat — there is no `error` wrapper object — and `code` is a number from the [Error Codes reference](/reference/error-codes/), here `2004` (`API_RATE_LIMITED`). `statusCode` and `response` appear on API errors only; a validation or config error has neither, and `context` on an API error also carries `method` and `url` (trimmed above). A `hint` string is added for 401, 403 and 404 responses; a 429 gets no hint.
+
+If the operation is idempotent, retrying is safe.
 
 <Aside type="caution">
-**Don't blanket-retry mutating commands.** `bb pr create`, `bb pr merge`, `bb pr approve`, and similar can succeed *server-side* even when the response read fails. A retry might create a duplicate PR or re-approve. Limit the wrapper below to read-only commands or commands you've made idempotent (e.g., check existence before creating).
+**Don't blanket-retry mutating commands.** `bb pr create`, `bb pr merge`, `bb pr approve`, and similar can succeed *server-side* even when the response read fails. A retry might create a duplicate pull request (PR) or re-approve. Limit the wrapper below to read-only commands or commands you've made idempotent (e.g., check existence before creating).
 </Aside>
 
 ## Recipe: bb-with-retry wrapper
@@ -62,9 +59,10 @@ attempt=1
 delay="$INITIAL_DELAY"
 
 while true; do
-  if bb "$@"; then
-    exit 0
-  fi
+  # `bb "$@" && exit 0`, not `if bb "$@"; then exit 0; fi` — after a
+  # non-taken `if` branch, $? is the status of the `if` itself (always 0),
+  # so the wrapper would report "exit 0" and exit 0 on total failure.
+  bb "$@" && exit 0
   exit_code=$?
 
   if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
@@ -100,11 +98,16 @@ MAX_ATTEMPTS=10 INITIAL_DELAY=5 ./bb-retry.sh pr view 42 --json
 
 ## Recipe: retry only on a specific error code
 
-If you only want to retry on rate-limit errors and *not* on, say, authentication failures, parse the structured error:
+To retry rate limits but *not* authentication failures, run the command with `--json` and read `statusCode` off the error envelope. Do not grep the text-mode message for `429`: that message is Bitbucket's own prose and usually contains no digits at all, while any PR title containing "502" would match.
 
 ```bash
 #!/bin/bash
 # bb-retry-on-rate-limit.sh
+#
+# Usage:
+#   ./bb-retry-on-rate-limit.sh pr list -w myworkspace -r myrepo
+#
+# Appends --json so the error envelope is machine-readable.
 set -euo pipefail
 
 MAX_ATTEMPTS=5
@@ -113,30 +116,32 @@ delay=2
 
 while true; do
   err_file=$(mktemp)
-  if bb "$@" 2> "$err_file"; then
-    rm -f "$err_file"
-    exit 0
-  fi
+  bb "$@" --json 2> "$err_file" && { rm -f "$err_file"; exit 0; }
 
   err_msg=$(cat "$err_file")
   rm -f "$err_file"
 
+  # statusCode exists on API errors only; empty for validation/config errors.
+  status=$(printf '%s' "$err_msg" | jq -r '.statusCode // empty' 2>/dev/null || true)
+
   # Retry only on rate-limit / transient gateway errors.
-  if echo "$err_msg" | grep -qE '429|502|503|504'; then
-    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+  case "$status" in
+    429|502|503|504)
+      if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        echo "$err_msg" >&2
+        exit 1
+      fi
+      echo "HTTP $status, retrying in ${delay}s..." >&2
+      sleep "$delay"
+      delay=$(( delay * 2 ))
+      attempt=$(( attempt + 1 ))
+      ;;
+    *)
+      # Non-transient (or no statusCode at all): fail fast.
       echo "$err_msg" >&2
       exit 1
-    fi
-    echo "Transient error, retrying in ${delay}s..." >&2
-    sleep "$delay"
-    delay=$(( delay * 2 ))
-    attempt=$(( attempt + 1 ))
-    continue
-  fi
-
-  # Non-transient: fail fast.
-  echo "$err_msg" >&2
-  exit 1
+      ;;
+  esac
 done
 ```
 
@@ -144,14 +149,14 @@ done
 
 The wrappers above are the right answer when the built-in retry has been exhausted. They are *not* the right answer for:
 
-- **Auth failures** (`Authentication required`) — retrying won't help; fix the credentials.
-- **404 / not-found errors** — these don't get more found over time.
-- **Validation errors** (`requireOption()` failures) — these are bugs in your script, not transient.
+- **Auth failures** — `Authentication required. Run 'bb auth login' or set BB_USERNAME and BB_API_TOKEN.` (`code: 1001`). Retrying won't help; fix the credentials.
+- **404 / not-found errors** (`code: 2002`) — these don't get more found over time.
+- **Validation errors** (`code: 5001` or `5002`, e.g. `Option --title is required`) — bugs in your script, not transient.
 
-The CLI exits with code `1` for all of these, same as for transient errors. Use the JSON error shape on stderr (`.error.code`) to distinguish them rather than retrying everything.
+The CLI exits `1` for all of these, same as for transient errors. Branch on the JSON envelope instead. Use `jq -r '.statusCode // .code'`: `statusCode` is present on API errors, and `code` covers the rest.
 
 ## Related
 
 - [Scripting & Automation: Built-in Resilience](/guides/scripting/#built-in-resilience)
-- [Error Codes reference](/reference/error-codes/) — the stable `.error.code` values to branch on
+- [Error Codes reference](/reference/error-codes/) — the numeric `code` values to branch on
 - [JSON Output reference](/reference/json-output/) — the success/error envelope shapes

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -5,9 +5,11 @@ description: Complete reference for the bb configuration file
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-The Bitbucket CLI stores configuration in a JSON file. This page documents the file format, location, and available settings.
+All persistent settings live in one JSON file, written by `bb auth login` and
+`bb config set`. This page documents the file itself; for the commands that read
+and write it, see the [Config command reference](/commands/config/).
 
-## File Location
+## File location
 
 <Tabs>
   <TabItem label="macOS / Linux">
@@ -26,9 +28,9 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 
 ---
 
-## Configuration Schema
+## Configuration schema
 
-| Key | Type | Description | Set By |
+| Key | Type | Description | Set by |
 |-----|------|-------------|--------|
 | `authMethod` | `"basic"` \| `"oauth"` | Active authentication method | `bb auth login` |
 | `username` | string | Your Bitbucket username (API token auth) | `bb auth login -u` |
@@ -41,10 +43,10 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 | `defaultWorkspace` | string | Default workspace | `bb config set defaultWorkspace` |
 | `skipVersionCheck` | boolean | Disable update notifications | `bb config set` |
 | `versionCheckInterval` | number | Days between update checks (default: 1) | `bb config set` |
-| `prCreateIncludeDefaultReviewers` | boolean | Auto-add the repo's default reviewers on `bb pr create` (default: false) | `bb config set` |
+| `prCreateIncludeDefaultReviewers` | boolean | Auto-add the repository's default reviewers on `bb pr create` (default: false) | `bb config set` |
 | `lastVersionCheck` | string | Timestamp of last update check | Automatic |
 
-### Example Configuration (OAuth)
+### Example configuration (OAuth)
 
 ```json
 {
@@ -56,7 +58,7 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 }
 ```
 
-### Example Configuration (API Token)
+### Example configuration (API token)
 
 ```json
 {
@@ -71,38 +73,46 @@ The Bitbucket CLI stores configuration in a JSON file. This page documents the f
 
 ---
 
-## Managing Configuration
+## Managing configuration
 
-### View All Settings
+### View all settings
 
 ```bash
 bb config list
 ```
 
 Output:
-```
+```text
 Config file: /Users/you/.config/bb/config.json
 
 KEY               VALUE
-----------------  ------------------------
+----------------  -----------
 username          myuser
-apiToken          ********
 defaultWorkspace  myworkspace
+apiToken          ********
 skipVersionCheck  false
+
+Settable keys: defaultWorkspace, skipVersionCheck, versionCheckInterval, prCreateIncludeDefaultReviewers. Run 'bb config set --help' for details.
 ```
 
-<Aside type="note">
-The API token is masked for security. Use `bb auth token` to see the actual token.
-</Aside>
+The API token is masked. Use `bb auth token` to see the real value.
 
-### Get a Specific Value
+### Get a specific value
 
 ```bash
 bb config get defaultWorkspace
 # Output: myworkspace
 ```
 
-### Set a Value
+Values are stored as native JSON types, so for the typed keys `--json` returns
+a real boolean or number rather than a quoted string:
+
+```bash
+bb config get skipVersionCheck --json
+# {"key":"skipVersionCheck","value":true}
+```
+
+### Set a value
 
 ```bash
 bb config set defaultWorkspace myworkspace
@@ -110,11 +120,11 @@ bb config set skipVersionCheck true
 bb config set versionCheckInterval 7
 ```
 
-#### Settable Keys
+#### Settable keys
 
-`bb config set` only accepts these four keys (the full list lives in
-`SETTABLE_CONFIG_KEYS` in `src/types/config.ts`). Everything else is either
-managed by the auth flow or written automatically by the CLI.
+`bb config set` accepts these four keys; `bb config list` prints the current
+list as a footer. Everything else is written by `bb auth login` or by the CLI
+itself.
 
 | Key | Type | Example |
 |-----|------|---------|
@@ -123,17 +133,28 @@ managed by the auth flow or written automatically by the CLI.
 | `versionCheckInterval` | integer (days, ≥ 1) | `bb config set versionCheckInterval 7` |
 | `prCreateIncludeDefaultReviewers` | boolean | `bb config set prCreateIncludeDefaultReviewers true` |
 
-Typed key validation:
+`skipVersionCheck` and `prCreateIncludeDefaultReviewers` accept only `true` or
+`false`. `versionCheckInterval` accepts only positive integers (`>= 1`).
 
-- `skipVersionCheck` accepts only `true` or `false`
-- `versionCheckInterval` accepts only positive integers (`>= 1`)
-- `prCreateIncludeDefaultReviewers` accepts only `true` or `false`
+#### Readable keys
+
+`bb config get` has its own allowlist, and it is not the same one:
+
+```text
+username, defaultWorkspace, skipVersionCheck, versionCheckInterval, prCreateIncludeDefaultReviewers
+```
+
+`username` is readable but not settable — change it with `bb auth login -u`.
+`bb config get apiToken` refuses:
+
+```text
+Cannot display 'apiToken' - it is part of your authentication credentials, not config. Use 'bb auth token' to retrieve credentials, or run 'bb config list' to see readable keys.
+```
+
+Any other key throws `Unknown config key '<key>'` with the valid list and a
+suggestion, e.g. `(Did you mean defaultWorkspace?)`.
 
 #### `prCreateIncludeDefaultReviewers` and the `--default-reviewers` flag
-
-The config key sets the default behavior for `bb pr create`. The per-command
-flag — `--default-reviewers` or `--no-default-reviewers` — always wins when
-present, so you can opt in or out for a single PR without changing the config.
 
 | Config | Flag | Result |
 |--------|------|--------|
@@ -142,23 +163,11 @@ present, so you can opt in or out for a single PR without changing the config.
 | unset / `false` | `--default-reviewers` | Default reviewers are added |
 | `true` | `--no-default-reviewers` | Default reviewers are **not** added |
 
-In short: the flag is an explicit override; the config is only consulted when
-neither `--default-reviewers` nor `--no-default-reviewers` is passed.
+### Protected keys
 
-Values are stored as native JSON types, so `bb config get <key> --json` returns booleans/numbers for these keys.
+These keys cannot be set with `bb config set`:
 
-Example:
-
-```bash
-bb config get skipVersionCheck --json
-# {"key":"skipVersionCheck","value":true}
-```
-
-### Protected Keys
-
-Some configuration keys cannot be set directly:
-
-| Key | Reason | How to Set |
+| Key | Reason | How to set |
 |-----|--------|------------|
 | `username` | Tied to authentication | Use `bb auth login -u` |
 | `apiToken` | Security-sensitive | Use `bb auth login -p` |
@@ -169,86 +178,86 @@ Some configuration keys cannot be set directly:
 
 ---
 
-## Update Notifications
+## Update notifications
 
-The CLI opportunistically checks for updates after any command, so you stay current with the latest features and bug fixes without it getting in the way of scripts.
+After every command the CLI checks npm for a newer version, at most once per
+`versionCheckInterval` days (default 1). The notice goes to stderr, and only
+when stderr is a TTY, so `--json` and piped output stay clean. It is skipped
+entirely in CI and when `skipVersionCheck` is true.
 
-### How It Works
+### Example notification
 
-- Checks npm registry for the latest version
-- Compares with your installed version
-- Shows a notification if an update is available
-- Caches the check result for 24 hours (configurable)
-- Prints the notice to **stderr**, and only in an interactive terminal — so `--json` and piped output stay clean
-- Skips checks in CI environments automatically
+```text
 
-### Example Notification
-
-```
-⚠ A new version is available: 1.12.0 (you have 1.11.0)
+──────────────────────────────────────────────────
+A new version is available: <latest> (you have <current>)
   Run 'bun install -g @pilatos/bitbucket-cli' to update
   Or disable with 'bb config set skipVersionCheck true'
+──────────────────────────────────────────────────
+
 ```
 
-### Disable Notifications
+There is no warning glyph. The separator rules are 50 box-drawing dashes, or
+50 ASCII hyphens under `--no-unicode`.
 
-To permanently disable update notifications:
+### Disable notifications
 
 ```bash
 bb config set skipVersionCheck true
 ```
 
-### Change Check Frequency
+### Change check frequency
 
-To check less frequently (e.g., once per week):
+`versionCheckInterval` is in days. Once per week:
 
 ```bash
 bb config set versionCheckInterval 7
 ```
 
-<Aside type="tip">
-The `versionCheckInterval` value is in days. Set it to a higher number if you prefer fewer interruptions.
-</Aside>
+---
+
+## Configuration precedence
+
+Command-line flags beat the git remote, which beats `BB_WORKSPACE`, which beats
+the config file:
+
+```bash
+bb pr list -w otherworkspace -r otherrepo   # flags win
+cd /path/to/cloned-repo && bb pr list       # git remote
+BB_WORKSPACE=myworkspace bb repo list       # env var
+bb config set defaultWorkspace myworkspace  # config file
+```
+
+The full order, including which commands skip the git-remote step, is in
+[Environment Variables](/reference/environment-variables/#resolution-order).
+[Understanding Repository Context](/guides/repository-context/) has worked
+examples.
+
+Some runtime behavior is tuned only with environment variables, not config
+keys — `BB_HTTP_TIMEOUT` for the API request timeout, for example.
 
 ---
 
-## Configuration Precedence
+## File permissions
 
-When determining workspace and repository, the CLI checks sources in this order:
+The config file holds your API token, so the CLI creates the directory `0700`
+and the file `0600`, and writes atomically (temp file, then rename).
 
-1. **Command-line flags** (highest priority)
-   ```bash
-   bb pr list -w otherworkspace -r otherrepo
-   ```
+| Platform | Directory | File |
+|----------|-----------|------|
+| macOS/Linux | `0700` (owner only) | `0600` (owner read/write only) |
+| Windows | Inherits user profile permissions | Inherits user profile permissions |
 
-2. **Git repository remote** (if in a git repo)
-   ```bash
-   cd /path/to/cloned-repo
-   bb pr list  # Uses workspace/repo from git remote
-   ```
+On macOS and Linux the CLI also *verifies* both on every read. If any group or
+other bit is set, every command fails with error 4001 until you fix it:
 
-3. **Configuration file** (lowest priority)
-   ```bash
-   bb config set defaultWorkspace myworkspace
-   bb pr list  # Uses config default
-   ```
+```text
+Config file has insecure permissions (644); expected 600. Run: chmod 600 /Users/you/.config/bb/config.json
+Config directory has insecure permissions (755); expected 700. Run: chmod 700 /Users/you/.config/bb
+```
 
-See [Understanding Repository Context](/guides/repository-context/) for detailed examples.
-
-<Aside type="note">
-Some runtime behavior is tuned with environment variables rather than config-file keys — for example `BB_HTTP_TIMEOUT` for the API request timeout. See [Environment Variables](/reference/environment-variables/).
-</Aside>
-
----
-
-## File Permissions
-
-The configuration file contains sensitive data (API token). The CLI sets appropriate permissions automatically:
-
-| Platform | Permissions |
-|----------|-------------|
-| macOS/Linux | `0600` (owner read/write only) |
-| Windows | Inherits user profile permissions |
+Windows skips the check, and a path that does not exist yet is not checked, so
+a fresh install never hits this.
 
 <Aside type="caution" title="Security">
 Never share your config file or commit it to version control. The API token grants access to your Bitbucket account.
@@ -256,21 +265,21 @@ Never share your config file or commit it to version control. The API token gran
 
 ---
 
-## Reset Configuration
+## Reset configuration
 
-### Clear Authentication Only
+### Clear authentication only
 
 ```bash
 bb auth logout
 ```
 
-This removes authentication credentials (OAuth tokens or API token) but keeps `defaultWorkspace` and other settings. For OAuth, it also revokes the token on Bitbucket's side.
+This removes authentication credentials (OAuth tokens or API token) but keeps
+`defaultWorkspace` and other settings. For OAuth, it also revokes the token on
+Bitbucket's side.
 
-It does not perform a full config reset.
+### Full reset
 
-### Full Reset
-
-Delete the configuration file entirely:
+Delete the config file entirely:
 
 <Tabs>
   <TabItem label="macOS / Linux">
@@ -295,36 +304,47 @@ bb auth login
 
 ## Troubleshooting
 
-### "Cannot read config file"
+### "Config file is not valid JSON"
 
-The file may be corrupted. Delete and recreate it:
+Fix the file by hand, or delete it and log in again:
 
 ```bash
 rm ~/.config/bb/config.json
 bb auth login
 ```
 
-### "Cannot write config file"
+### "Config file has insecure permissions"
 
-Check directory permissions:
+```bash
+chmod 700 ~/.config/bb
+chmod 600 ~/.config/bb/config.json
+```
+
+### "Failed to read config file"
+
+The path exists but is unreadable. Check ownership and permissions:
 
 ```bash
 ls -la ~/.config/bb/
 ```
 
-Create the directory if it doesn't exist:
+### "Failed to write config file" / "Failed to create config directory"
+
+The parent directory is missing or not writable:
 
 ```bash
 mkdir -p ~/.config/bb
+ls -ld ~/.config/bb
 ```
 
-### Config Not Being Used
+### Config not being used
 
 Verify the CLI is reading from the expected location:
 
 ```bash
 bb config list
-# Check the "Configuration file:" line
+# Check the "Config file:" line
 ```
 
-Remember that command-line flags and git context take precedence over config file settings.
+Command-line flags, git context and `BB_WORKSPACE` all take precedence over
+config file settings.

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -3,79 +3,105 @@ title: Environment Variables
 description: Configure Bitbucket CLI using environment variables
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Environment variables allow you to configure the CLI without storing credentials in files. This is especially useful for CI/CD pipelines and automation scripts.
+Every environment variable the CLI reads. `bb --help` lists the main ones in
+its footer.
 
-## Available Variables
+## Available variables
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `BB_USERNAME` | Your Bitbucket username (fallback for `bb auth login`) | `myuser` |
 | `BB_API_TOKEN` | Your Bitbucket API token (fallback for `bb auth login`; forces API token auth when set) | `ATBB...` |
-| `BB_WORKSPACE` | Default workspace. Overrides `config.defaultWorkspace`; `--workspace` and git context still win. | `myworkspace` |
+| `BB_WORKSPACE` | Default workspace. Overrides `config.defaultWorkspace`. `--workspace` always wins; the git remote wins too, but only on repository-scoped commands — see [Resolution order](#resolution-order). | `myworkspace` |
 | `BB_LOCALE` | BCP-47 locale tag for date/time formatting. `--locale` takes precedence; falls back to `LC_TIME`/`LC_ALL`/`LANG`, then `en-US`. | `de-DE` |
-| `BB_NO_UNICODE` | When set to any non-empty value, use ASCII fallbacks for separators, arrows, and status icons. Equivalent to the global `--no-unicode` flag. | `1` |
-| `NO_COLOR` | Disable color output globally when set to any value | `1` |
+| `BB_NO_UNICODE` | When set to any non-empty value, use ASCII fallbacks for separators, arrows, and status icons. Same effect as the global `--no-unicode` flag, but it cannot be overridden per command: `--unicode` is accepted and does nothing while this is set. Unset the variable instead. | `1` |
+| `NO_COLOR` | Disable color output globally. Triggers on any value, including the empty string. | `1` |
 | `FORCE_COLOR` | Force-enable color output globally (any value except `0`) | `1` |
 | `DEBUG` | Enable HTTP debug logging (request method, URL, status, response body for every API call). Must equal the literal string `true`. | `true` |
-| `BB_HTTP_TIMEOUT` | Per-request HTTP timeout in **milliseconds** for Bitbucket API calls. Prevents the CLI from hanging forever when a server accepts a connection but never responds (critical in CI/scripts). Defaults to `30000` (30s). Set to `0` to disable the timeout entirely. Invalid or negative values fall back to the default. A timed-out request is reported as a network error. | `60000` |
+| `BB_HTTP_TIMEOUT` | Per-request HTTP timeout in **milliseconds** for Bitbucket API calls. Prevents the CLI from hanging forever when a server accepts a connection but never responds. Defaults to `30000` (30s). Set to `0` to disable the timeout entirely. Invalid or negative values fall back to the default. A timed-out request is reported as a network error. | `60000` |
 
 <Aside type="caution" title="BB_HTTP_TIMEOUT is in milliseconds">
-`BB_HTTP_TIMEOUT` is measured in **milliseconds**, not seconds. `BB_HTTP_TIMEOUT=60` means 60 milliseconds (almost every request will fail), not 60 seconds. For a 60-second timeout use `BB_HTTP_TIMEOUT=60000`. Set `BB_HTTP_TIMEOUT=0` to disable the timeout (useful for very large clones/exports), but avoid this in CI where a hung request has no human to Ctrl-C.
+`BB_HTTP_TIMEOUT=60` means 60 milliseconds, so almost every request fails. For
+a 60-second ceiling use `BB_HTTP_TIMEOUT=60000`. In CI, set something short
+like `BB_HTTP_TIMEOUT=15000` so a stalled call fails fast instead of hanging
+the pipeline. `BB_HTTP_TIMEOUT=0` disables the timeout — useful for very large
+clones or exports, but a hung request in CI has no human to Ctrl-C.
 </Aside>
 
-### Internal / System Variables
+### POSIX locale variables
 
-These variables are read by the CLI but are normally set by the runtime, your
-shell, or your operating system rather than by you. They are documented here
-so they aren't surprising during troubleshooting.
+If neither `--locale` nor `BB_LOCALE` is set, the CLI reads the standard POSIX
+locale variables — `LC_TIME`, then `LC_ALL`, then `LANG` — and falls back to
+`en-US` if none is usable. `LC_TIME` is deliberately checked **before**
+`LC_ALL`, which is the reverse of the usual POSIX override order, so setting
+both means `LC_TIME` wins.
 
-| Variable | Set By | Description |
+Values are normalised before use: a `.UTF-8` codeset suffix and an `@euro`-style
+modifier are stripped, `_` becomes `-` (`de_DE.UTF-8` → `de-DE`), and the `C`
+and `POSIX` locales map to `en-US`. Unset them, or pass `--locale`, to pin
+formatting explicitly.
+
+### CI detection
+
+The update check is skipped when any of these is set to any value:
+
+`CI`, `CONTINUOUS_INTEGRATION`, `BUILD_ID`, `BUILD_NUMBER`, `DRONE`,
+`GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `TRAVIS`, `JENKINS_URL`,
+`HUDSON_URL`
+
+Set `CI=1` to get the same behavior locally.
+
+### Internal / system variables
+
+Set by the runtime, your shell, or your operating system rather than by you.
+Documented so they aren't surprising during troubleshooting.
+
+| Variable | Set by | Description |
 |----------|--------|-------------|
 | `NODE_ENV` | Test runners | When set to `test`, the CLI suppresses `process.exitCode = 1` on errors so a single failing test cannot cascade into later tests. Don't set this in production. |
 | `COMP_LINE` | tabtab / your shell | Set automatically while shell completion is being computed (`bb completion`). Its presence triggers the completion path; you should not set it manually. |
 | `APPDATA` | Windows | Used to locate the config file at `%APPDATA%\bb\config.json` on Windows. The CLI falls back to `%USERPROFILE%\AppData\Roaming\bb\config.json` if it isn't set. |
 
-## Configuration Priority
+## Resolution order
 
-Repository context is resolved in this order (highest priority first):
+Workspace and repository, highest priority first:
 
 1. **Command-line flags** (`--workspace`, `--repo`)
-2. **Git repository context** (detected from remote URL)
-3. **`BB_WORKSPACE` environment variable**
-4. **Configuration file** (`defaultWorkspace`)
+2. **Git repository context** (detected from the remote URL)
+3. **`BB_WORKSPACE`** (workspace only)
+4. **Configuration file** (`defaultWorkspace`, workspace only)
 
-Authentication credentials are resolved from:
+Step 2 does not apply to workspace-only commands — `bb workspace view`, every
+`bb project` and `bb snippet` command, `bb repo list`, `bb repo create`,
+`bb repo clone`, and `bb api` filling a `{workspace}` placeholder go straight
+from the flag to `BB_WORKSPACE` to `defaultWorkspace`.
 
-1. **Configuration file** (`~/.config/bb/config.json` on macOS/Linux, `%APPDATA%\bb\config.json` on Windows)
-2. **Environment variables** (`BB_USERNAME`, `BB_API_TOKEN`) when running `bb auth login` — setting `BB_API_TOKEN` automatically uses API token auth instead of OAuth
+Color, highest priority first. The default with none of them set is colors on:
 
-For color output, precedence is:
+1. `--color` — matched by a raw scan of argv, so `bb pr diff 42 --color never`
+   still turns global color on
+2. `FORCE_COLOR` (any value except `0`)
+3. `--no-color`
+4. `NO_COLOR` (any value, including the empty string)
 
-1. `--color` (force color on — only available on `bb pr diff`, not a global flag)
-2. `FORCE_COLOR`
-3. `--no-color` (global flag, available on all commands)
-4. `NO_COLOR`
+Credentials are **not** a chain. `bb pr list` and every other API call read the
+username and token from the config file only; if nothing is stored there the
+command fails with error 1001 even when `BB_USERNAME` and `BB_API_TOKEN` are
+exported. Those two variables are read by `bb auth login` and nowhere else —
+run it once and it writes the config file.
 
----
+Inside `bb auth login`:
 
-## Authentication with Environment Variables
+- `--username` / `-u` beats `BB_USERNAME`.
+- `--with-token` (token on stdin) beats `--password` / `-p`, which beats
+  `BB_API_TOKEN`. Combining `--with-token` with `--password` is an error.
+- Setting `BB_API_TOKEN` at all selects API token auth instead of OAuth.
 
-### Login from Environment Variables
+## Authentication with environment variables
 
-When environment variables are set, `bb auth login` uses them automatically:
-
-```bash
-export BB_USERNAME=myuser
-export BB_API_TOKEN=ATBB_your_token_here
-
-bb auth login  # Uses env vars, no prompts
-```
-
-### Non-Interactive Usage
-
-For scripts and CI/CD, set both variables before running commands:
+`bb auth login` picks up both variables, so it runs without prompts:
 
 ```bash
 export BB_USERNAME=myuser
@@ -85,104 +111,66 @@ bb auth login
 bb pr list -w myworkspace -r myrepo
 ```
 
-<Aside type="caution" title="Security Warning">
-Never commit environment variables containing tokens to version control. Use your CI/CD platform's secrets management instead.
-</Aside>
-
----
-
-## Shell Configuration
-
-### Bash
-
-Add to `~/.bashrc` or `~/.bash_profile`:
+Or inline, without exporting:
 
 ```bash
-export BB_USERNAME="your-username"
-export BB_API_TOKEN="your-api-token"
+BB_USERNAME=myuser BB_API_TOKEN=ATBB_token bb auth login
 ```
 
-Then reload:
-```bash
-source ~/.bashrc
-```
-
-### Zsh
-
-Add to `~/.zshrc`:
-
-```zsh
-export BB_USERNAME="your-username"
-export BB_API_TOKEN="your-api-token"
-```
-
-Then reload:
-```bash
-source ~/.zshrc
-```
-
-### Fish
-
-Add to `~/.config/fish/config.fish`:
-
-```fish
-set -gx BB_USERNAME "your-username"
-set -gx BB_API_TOKEN "your-api-token"
-```
-
-Then reload:
-```bash
-source ~/.config/fish/config.fish
-```
-
-### PowerShell
-
-Add to your PowerShell profile (`$PROFILE`):
-
-```powershell
-$env:BB_USERNAME = "your-username"
-$env:BB_API_TOKEN = "your-api-token"
-```
-
----
-
-## Temporary Session
-
-Set variables for a single terminal session:
+To keep the token out of shell history and `ps` output, pipe it instead:
 
 ```bash
-# Linux/macOS
-export BB_USERNAME=myuser
-export BB_API_TOKEN=ATBB_token
-
-# Windows Command Prompt
-set BB_USERNAME=myuser
-set BB_API_TOKEN=ATBB_token
-
-# Windows PowerShell
-$env:BB_USERNAME = "myuser"
-$env:BB_API_TOKEN = "ATBB_token"
+echo "$BB_API_TOKEN" | bb auth login -u myuser --with-token
 ```
 
-Or inline with a single command:
+## Shell configuration
 
-```bash
-BB_USERNAME=myuser BB_API_TOKEN=ATBB_token bb auth login && bb pr list -w workspace -r repo
-```
+Add to your shell's startup file, then reload it or open a new terminal:
 
----
+<Tabs>
+  <TabItem label="Bash">
+    `~/.bashrc` or `~/.bash_profile`:
 
-## Docker Usage
+    ```bash
+    export BB_USERNAME="your-username"
+    export BB_API_TOKEN="your-api-token"
+    ```
+  </TabItem>
+  <TabItem label="Zsh">
+    `~/.zshrc`:
 
-Pass environment variables to containers:
+    ```zsh
+    export BB_USERNAME="your-username"
+    export BB_API_TOKEN="your-api-token"
+    ```
+  </TabItem>
+  <TabItem label="Fish">
+    `~/.config/fish/config.fish`:
+
+    ```fish
+    set -gx BB_USERNAME "your-username"
+    set -gx BB_API_TOKEN "your-api-token"
+    ```
+  </TabItem>
+  <TabItem label="PowerShell">
+    Your profile (`$PROFILE`):
+
+    ```powershell
+    $env:BB_USERNAME = "your-username"
+    $env:BB_API_TOKEN = "your-api-token"
+    ```
+  </TabItem>
+</Tabs>
+
+## Docker
 
 ```bash
 docker run -e BB_USERNAME=myuser \
            -e BB_API_TOKEN=ATBB_token \
-           your-image sh -lc "bb auth login && bb pr list -w workspace -r repo"
+           your-image sh -lc "bb auth login && bb pr list -w workspace -r myrepo"
 ```
 
-Or use an env file:
+Or an env file:
 
 ```bash
 # .env.bb (not committed to git!)
@@ -191,14 +179,13 @@ BB_API_TOKEN=ATBB_token
 ```
 
 ```bash
-docker run --env-file .env.bb your-image sh -lc "bb auth login && bb pr list -w workspace -r repo"
+docker run --env-file .env.bb your-image sh -lc "bb auth login && bb pr list -w workspace -r myrepo"
 ```
 
----
+## CI/CD examples
 
-In CI, set `BB_HTTP_TIMEOUT` (milliseconds) so a stalled API call fails fast instead of hanging the pipeline — e.g. `BB_HTTP_TIMEOUT=15000` for a 15s ceiling.
-
-## CI/CD Examples
+The package is published to npm but runs on Bun — `bb` exits immediately under
+Node — so every runner needs Bun on `PATH`.
 
 ### GitHub Actions
 
@@ -224,6 +211,7 @@ jobs:
         env:
           BB_USERNAME: ${{ secrets.BB_USERNAME }}
           BB_API_TOKEN: ${{ secrets.BB_API_TOKEN }}
+          BB_HTTP_TIMEOUT: 15000
         run: |
           bb auth login
           bb pr list -w myworkspace -r myrepo --json
@@ -237,8 +225,9 @@ check-prs:
   variables:
     BB_USERNAME: $BB_USERNAME
     BB_API_TOKEN: $BB_API_TOKEN
+    BB_HTTP_TIMEOUT: 15000
   script:
-    - npm install -g @pilatos/bitbucket-cli
+    - bun install -g @pilatos/bitbucket-cli
     - bb auth login
     - bb pr list -w myworkspace -r myrepo --json
 ```
@@ -253,36 +242,17 @@ pipelines:
     - step:
         name: Check PRs
         script:
-          - npm install -g @pilatos/bitbucket-cli
+          - bun install -g @pilatos/bitbucket-cli
           - bb auth login
           - bb pr list -w $BITBUCKET_WORKSPACE -r $BITBUCKET_REPO_SLUG --json
 ```
 
-<Aside type="tip">
-In Bitbucket Pipelines, `BITBUCKET_WORKSPACE` and `BITBUCKET_REPO_SLUG` are automatically available.
-</Aside>
+`BITBUCKET_WORKSPACE` and `BITBUCKET_REPO_SLUG` are provided by Bitbucket
+Pipelines automatically.
 
----
+## Keeping tokens safe
 
-## Security Best Practices
-
-1. **Never commit tokens to git**
-   - Add `.env*` to your `.gitignore`
-   - Use CI/CD secrets management
-
-2. **Use minimal token scopes**
-   - Only grant permissions your script needs
-   - Read-only tokens for read-only operations
-
-3. **Rotate tokens regularly**
-   - Especially after team member departures
-   - Use short-lived tokens when possible
-
-4. **Use secrets managers in production**
-   - HashiCorp Vault
-   - AWS Secrets Manager
-   - Azure Key Vault
-
-5. **Audit token usage**
-   - Review which tokens are active
-   - Revoke unused tokens
+- Add `.env*` to `.gitignore` and pass tokens through your CI platform's
+  secrets store. Never commit them.
+- Grant the token only the scopes the script uses. See
+  [Token Scopes](/reference/token-scopes/) for the scope each command needs.

--- a/docs/src/content/docs/reference/error-codes.mdx
+++ b/docs/src/content/docs/reference/error-codes.mdx
@@ -3,11 +3,11 @@ title: Error Codes
 description: Complete reference of error codes and their meanings
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+Every failure carries a numeric `code` in the `--json` error payload
+(`{"code": 2002, …}`). The process exit status is always `1`, so branch on
+`code`, not on the exit status. Ctrl-F the number below.
 
-When commands fail, the CLI returns structured errors with specific error codes. Understanding these codes helps you diagnose issues quickly.
-
-## Error Code Ranges
+## Error code ranges
 
 | Range | Category | Description |
 |-------|----------|-------------|
@@ -23,7 +23,7 @@ When commands fail, the CLI returns structured errors with specific error codes.
 
 ---
 
-## Authentication Errors (1xxx)
+## Authentication errors (1xxx)
 
 ### 1001 - AUTH_REQUIRED
 
@@ -67,18 +67,27 @@ The CLI prints this next step alongside the error:
 
 ---
 
-## API Errors (2xxx)
+## API errors (2xxx)
 
 ### 2001 - API_REQUEST_FAILED
 
 **Message:** API request failed
 
-**Cause:** General network or API failure.
+**Cause:** Bitbucket answered with an unexpected HTTP status below 500 that
+isn't 401/403/404/429 — typically 400 (malformed request body) or 409
+(conflict, e.g. merging a pull request that is already merged). The server did
+respond, so this is not a connectivity problem.
 
-**Solution:**
-- Check your internet connection
-- Verify Bitbucket status at [status.bitbucket.org](https://status.bitbucket.org)
-- Retry the command
+**Solution:** Read `message` and `response` in the JSON error payload; they
+carry Bitbucket's own explanation.
+
+```bash
+bb pr merge 42 --json 2> err.json
+jq '.statusCode, .message, .response' err.json
+```
+
+Connection failures are [7001](#7001---network_error); server faults are
+[2005](#2005---api_server_error).
 
 ### 2002 - API_NOT_FOUND
 
@@ -123,12 +132,16 @@ API doesn't distinguish the two, hence the hedged wording.
 
 **Message:** Rate limit exceeded
 
-**Cause:** You've made too many API requests in a short period.
+**Cause:** Bitbucket returned 429 and the CLI's three automatic retries — which
+honour the `Retry-After` header — were all exhausted.
 
-**Solution:**
-- Wait a few minutes before retrying
-- For scripts, implement exponential backoff
-- Consider caching results when possible
+**Solution:** Reduce request volume. Prefer `--limit` over `--all`, and batch
+with `bb api --paginate` instead of looping single calls:
+
+```bash
+bb pr list --limit 25 --json
+bb api /repositories/myworkspace/myrepo/pullrequests --paginate --json
+```
 
 ### 2005 - API_SERVER_ERROR
 
@@ -142,17 +155,13 @@ API doesn't distinguish the two, hence the hedged wording.
 
 ---
 
-## Git Errors (3xxx)
+## Git errors (3xxx)
 
 ### 3001 - GIT_NOT_REPOSITORY
 
-**Message:** Not a git repository
-
-**Cause:** The current directory is not a git repository, but the command requires one.
-
-**Solution:**
-- Navigate to a git repository directory, or
-- Use explicit flags: `-w <workspace> -r <repo>`
+Reserved. No code path currently emits `3001` — running outside a git
+repository surfaces as [6001 CONTEXT_REPO_NOT_FOUND](#6001---context_repo_not_found).
+Don't branch on `3001` in scripts.
 
 ### 3002 - GIT_COMMAND_FAILED
 
@@ -180,7 +189,7 @@ git remote add origin git@bitbucket.org:workspace/repo.git
 
 ---
 
-## Config Errors (4xxx)
+## Config errors (4xxx)
 
 ### 4001 - CONFIG_READ_FAILED
 
@@ -216,22 +225,34 @@ bb auth login
 
 **Message:** Invalid configuration key
 
-**Cause:** Attempted to get/set an unknown configuration key.
+**Cause:** Attempted to get or set an unknown configuration key.
 
-**Solution:**
-Valid configuration keys are:
-- `defaultWorkspace` - Default workspace
-- `skipVersionCheck` - Disable update notifications
-- `versionCheckInterval` - Days between update checks
+**Solution:** Use a valid key. `bb config set` accepts four:
+
+| Key | Meaning |
+|-----|---------|
+| `defaultWorkspace` | Workspace used when `-w` is omitted |
+| `skipVersionCheck` | Disable update notifications |
+| `versionCheckInterval` | Days between update checks |
+| `prCreateIncludeDefaultReviewers` | Add the repository's default reviewers on `bb pr create` |
+
+`bb config get` accepts those four plus `username`.
 
 ```bash
 bb config set defaultWorkspace myworkspace
+bb config get username
 bb config list
 ```
 
+Two keys get a distinct message instead of the unknown-key one. `bb config set
+username` and `bb config set apiToken` point you at `bb auth login`; `bb config
+get apiToken` points you at `bb auth token`. Every other credential field
+(`oauthAccessToken` and friends) is not a config key at all and falls through to
+the unknown-key message above.
+
 ---
 
-## Validation Errors (5xxx)
+## Validation errors (5xxx)
 
 ### 5001 - VALIDATION_REQUIRED
 
@@ -259,12 +280,26 @@ top-level command was given.
 **Solution:**
 - Check the expected format in command help
 - Common issues:
-  - PR ID must be a number
+  - Pull request ID must be a number
   - State must be one of: OPEN, MERGED, DECLINED, SUPERSEDED
   - An unknown command (`bb prr`)
+  - `--json` placed before the subcommand, so it ate the subcommand as its
+    field list — see [Troubleshooting](/help/troubleshooting/)
 
-When a value or command name is close to a valid one, the CLI suggests the
-correction:
+The misplaced-`--json` case names the token it swallowed. Because `--json` did
+take effect, it comes back as an error envelope on stderr:
+
+```bash
+bb --json pr list
+```
+
+```json
+{"name":"BBError","code":5002,"message":"--json consumed 'pr' as its field list, so 'list' was parsed as a top-level command.\nPut --json after the subcommand: bb pr list --json","context":{"command":"pr","args":["list"]}}
+```
+
+When a value or name is close to a valid one, the CLI suggests the correction.
+This fires for unknown commands, enum option values, config keys, `bb pr
+activity --type` tokens, and `bb api` HTTP methods:
 
 ```bash
 bb prr
@@ -274,6 +309,10 @@ bb prr
 bb pr list --state opne
 # ✗ --state must be one of: OPEN, MERGED, DECLINED, SUPERSEDED
 # (Did you mean OPEN?)
+
+bb config set defaultWorkspce foo
+# ✗ Unknown config key 'defaultWorkspce'. Valid keys: defaultWorkspace, skipVersionCheck, versionCheckInterval, prCreateIncludeDefaultReviewers
+# (Did you mean defaultWorkspace?)
 ```
 
 Enum values are matched **case-sensitively**, so a value that is right apart
@@ -289,17 +328,33 @@ bb pr list --state open
 
 **Message:** File not found: `<path>`
 
-**Cause:** A file referenced by an option (e.g. `--file` for `bb snippet create`/`edit`, `--body-file` for `bb pr edit`) doesn't exist on disk, or a named file isn't present inside a snippet.
+**Cause:** A file referenced by an option (`--file` on `bb snippet create`/`edit`,
+`--body-file` on `bb pr edit`/`bb issue create`, `-F key=@file` or `--input` on
+`bb api`) doesn't exist on disk, or a named file isn't present inside a snippet.
 
 **Solution:**
 - Verify the path is correct relative to the current working directory
 - For `bb snippet view --file <name>`, list snippet files first to confirm the name
 
-The `context` field on this error includes the missing path under `file` (or `bodyFile`), which scripts can key on to differentiate it from a generic `VALIDATION_INVALID`.
+The `context` field carries the offending path, so scripts can tell this apart
+from a generic `VALIDATION_INVALID`. The key depends on the command:
+
+| Key | Set by |
+|-----|--------|
+| `file` | `bb snippet create/edit/view`, `bb issue create --body-file` |
+| `bodyFile` | `bb pr edit --body-file` only |
+| `path` | `bb api -F key=@file`, `bb api --input <file>` |
+
+`bb snippet view --file` also attaches `available`, the list of filenames the
+snippet actually contains.
+
+`bb pr edit --body-file` only reports `5003` when the read failed with `ENOENT`.
+Any other read failure (a permission error, or pointing at a directory) is
+reported as [9999 UNKNOWN](#9999---unknown).
 
 ---
 
-## Context Errors (6xxx)
+## Context errors (6xxx)
 
 ### 6001 - CONTEXT_REPO_NOT_FOUND
 
@@ -338,24 +393,37 @@ bb config set defaultWorkspace myworkspace
 
 ---
 
-## Network Errors (7xxx)
+## Network errors (7xxx)
 
 ### 7001 - NETWORK_ERROR
-
-**Message:** Network error: Unable to reach Bitbucket API
 
 **Cause:** The request failed before an HTTP response was received (offline, DNS issue, proxy/TLS issue, etc.).
 
 Transient failures (dropped connections, temporary DNS errors, timeouts) on read requests are automatically retried up to 3 times with exponential backoff before this error surfaces. Permanent-looking failures (e.g. unknown host, connection refused) and write requests fail immediately.
 
+`7001` has two distinct messages. The connectivity one:
+
+> Network error: Unable to reach Bitbucket API. Run with DEBUG=true for details. If you're behind a proxy or using a custom CA, check your environment.
+
+And the timeout one, when the server accepted the connection but never answered:
+
+> Network error: Request to Bitbucket API timed out after 30000ms. The server accepted the connection but did not respond in time. Increase or disable the timeout via BB_HTTP_TIMEOUT (milliseconds; set BB_HTTP_TIMEOUT=0 to disable), or run with DEBUG=true for details.
+
 **Solution:**
 - Check internet and DNS connectivity
 - Verify proxy/TLS settings if applicable
-- Retry the command after connectivity is restored
+- If the message says *timed out*, raise or remove the 30-second default:
+
+```bash
+BB_HTTP_TIMEOUT=60000 bb pr list   # 60 seconds
+BB_HTTP_TIMEOUT=0 bb pr list       # no timeout
+```
+
+See [Environment Variables](/reference/environment-variables/) for the full list.
 
 ---
 
-## Output Formatting Errors (8xxx)
+## Output formatting errors (8xxx)
 
 ### 8001 - JQ_FAILED
 
@@ -373,16 +441,31 @@ bb pr list --json | jq '<expression>'
 
 ### 8002 - JSON_FORMAT_INVALID
 
-**Message:** `--jq requires --json` or similar formatting validation failure.
+`8002` has exactly two messages.
 
-**Cause:** Incompatible combination of output flags.
+**`--jq requires --json`** — add `--json`, with or without a field list:
 
-**Solution:**
-- `--jq` requires `--json`. Add `--json` (with or without a field list).
+```bash
+bb pr list --json --jq '.count'
+```
+
+`bb api` is exempt, because its output is already JSON: `bb api /repositories/my-ws --jq '.values[].name'` needs no `--json`.
+
+This one prints as plain text on stderr (`✗ --jq requires --json`) rather than
+as a JSON envelope, because JSON mode was never enabled — scripts cannot parse
+`.code` for it.
+
+**`--json field list cannot be empty`** — triggered by `--json ""` or `--json ,,,`.
+Drop the argument to get the full output, or name at least one field:
+
+```bash
+bb pr list --json
+bb pr list --json id,title
+```
 
 ---
 
-## Shell Completion Errors (9xxx)
+## Shell completion errors (9001–9002)
 
 ### 9001 - COMPLETION_INSTALL_FAILED
 
@@ -407,7 +490,7 @@ bb pr list --json | jq '<expression>'
 
 ---
 
-## Unknown Errors (9xxx)
+## Unknown errors (9999)
 
 ### 9999 - UNKNOWN
 
@@ -425,47 +508,40 @@ DEBUG=true bb <your-command> 2>&1
 
 ---
 
-## Exit Codes and Error Codes
+## Exit codes and error codes
 
-The process exit code is intentionally minimal — `0` for success and `1` for
-any failure. The numeric error code on this page lives in the JSON error
-payload's `code` field, not in the exit status. To branch on a specific
-failure mode in a script, parse stderr JSON and read `.code`.
+`0` on success, `1` on any failure. The exit status never carries the error
+code — read it from the stderr payload instead:
+
+```bash
+bb pr view 999 --json 2> err.json || jq -r '.code' err.json
+# 2002
+```
+
+That payload is a single-line JSON object:
+
+```json
+{"name":"APIError","code":2002,"message":"Pull request 999 not found in acme/demo.","context":{"status":404,"method":"GET","url":"/repositories/acme/demo/pullrequests/999"},"statusCode":404}
+```
 
 See [Exit Codes in the scripting guide](/guides/scripting/#exit-codes) for a
-full example.
+worked example, and [JSON Output](/reference/json-output/) for every payload
+field and the `context` shape per code.
 
-## Handling Errors in Scripts
+## Handling errors in scripts
 
-When using the CLI in scripts, check the exit code and handle errors appropriately:
+Keep stdout and stderr on separate files. Folding stderr into the data file
+(`> prs.json 2>&1`) puts the error envelope — and any warning the CLI prints —
+inside `prs.json`, which breaks `jq` on the next line.
 
 ```bash
 #!/bin/bash
-set -e
+set -euo pipefail
 
-if ! bb pr list -w myworkspace -r myrepo --json > prs.json 2>&1; then
-  echo "Failed to list PRs"
+if ! bb pr list -w myworkspace -r myrepo --json > prs.json 2> pr-error.json; then
+  echo "Failed to list PRs: $(jq -r '.message // "unknown error"' pr-error.json)"
   exit 1
 fi
 
-# Process prs.json...
+jq -r '.pullRequests[].title' prs.json
 ```
-
-For JSON output, errors are emitted to stderr and include the error code:
-
-```bash
-bb pr view 999 --json 2>&1
-# {"name":"APIError","code":2002,"message":"Pull request 999 not found in acme/demo.","context":{"status":404,"method":"GET","url":"/repositories/acme/demo/pullrequests/999"},"statusCode":404}
-```
-
-Typical JSON error payload fields:
-
-- `name` - Error class name
-- `code` - Numeric CLI error code
-- `message` - Human-readable message
-- `context` - Optional structured metadata
-- `hint` - Optional actionable next step (`401`, `403`, `404` only)
-- `statusCode` / `response` - `APIError` only: the upstream HTTP status and its
-  response body
-
-See [JSON output](/reference/json-output/) for the full envelope.

--- a/docs/src/content/docs/reference/global-flags.mdx
+++ b/docs/src/content/docs/reference/global-flags.mdx
@@ -3,28 +3,32 @@ title: Global Flags
 description: Flags accepted by every bb command
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
-These flags can be passed to any `bb` command. They are resolved before the
-command-specific options, so they work uniformly whether you're running
-`bb pr list` or `bb config get`.
+These flags are accepted by every `bb` command — the same set `bb --help`
+prints. `--limit` and `--all` look global but are not; see
+[List-command flags](#list-command-flags).
 
 ## Quick reference
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--json [fields]` | optional CSV | _off_ | Emit machine-readable JSON. Pass a comma-separated field list to project the output. |
-| `--jq <expression>` | string | _off_ | Run the JSON output through an in-process `jq` filter. Requires `--json`. |
-| `--no-color` | boolean | auto | Disable ANSI colors. Also honoured: `NO_COLOR` env var. |
-| `--no-unicode` | boolean | auto | Use ASCII fallbacks for separators, arrows, and status icons. Also honoured: `BB_NO_UNICODE` env var. |
+| `--jq <expression>` | string | _off_ | Run the JSON output through an in-process `jq` filter. Requires `--json` everywhere except `bb api`. |
+| `--no-color` | boolean | colors on | Disable ANSI colors. Also honoured: `NO_COLOR`, `FORCE_COLOR`. |
+| `--no-unicode` | boolean | Unicode on | Use ASCII fallbacks for separators, arrows, and status icons. Also honoured: `BB_NO_UNICODE`. |
 | `--no-truncate` | boolean | _off_ | Show full values in table output without truncating long cells. |
-| `--limit <n>` | integer | command-specific | Cap the number of items returned by list commands. |
-| `--all` | boolean | _off_ | Fetch every page (overrides `--limit`). Available on list commands. |
-| `--locale <tag>` | BCP-47 | system | Locale for date/time formatting (e.g. `de-DE`, `ja-JP`). Falls back to `BB_LOCALE`, then `LC_TIME`/`LC_ALL`/`LANG`, then `en-US`. |
-| `-w, --workspace <name>` | string | git remote / env / config | Override the workspace. |
-| `-r, --repo <slug>` | string | git remote | Override the repository. |
+| `--locale <locale>` | BCP-47 | system | Locale for date/time formatting (e.g. `de-DE`, `ja-JP`). Falls back to `BB_LOCALE`, then `LC_TIME`/`LC_ALL`/`LANG`, then `en-US`. |
+| `-w, --workspace <workspace>` | string | git remote / env / config | Override the workspace. |
+| `-r, --repo <repo>` | string | git remote | Override the repository. |
 | `-h, --help` | boolean | — | Print help for the command. |
 | `-V, --version` | boolean | — | Print the CLI version. |
+
+The positive forms `--color`, `--unicode` and `--truncate` are also accepted,
+even though `bb --help` does not list them. Only `--color` changes anything —
+see [Precedence summary](#precedence-summary).
+
+`bb help <command>` is equivalent to `bb <command> --help` and works at every
+depth (`bb help pr`, `bb help pr comments`). The root `Commands:` list does not
+show `help`, but it is there.
 
 ## Output flags
 
@@ -41,6 +45,19 @@ bb pr list --json id,title,state
 JSON mode also disables spinners, colors, and progress notes so the output is
 safe to pipe.
 
+`--json` takes an optional value, so a bare `--json` swallows the next plain
+token. Put it after the subcommand:
+
+```bash
+bb pr list --json           # correct
+bb --json=id,title pr list  # correct — the '=' form swallows nothing
+bb --json pr list           # error 5002
+```
+
+The last one fails with `--json consumed 'pr' as its field list, so 'list' was
+parsed as a top-level command.` — rendered as a JSON envelope, since `--json`
+was set. The other global flags are not position-sensitive in this way.
+
 ### `--jq <expression>`
 
 Filter the JSON output through a `jq` expression. The filter runs in-process
@@ -51,26 +68,82 @@ Requires `--json`:
 bb pr list --json --jq '.pullRequests[] | select(.state == "OPEN") | .title'
 ```
 
+`bb api` is the one exception. Its output is already JSON, so it takes `--jq`
+on its own:
+
+```bash
+bb api /repositories/my-ws --jq '.values[].name'
+```
+
+Everywhere else, `--jq` without `--json` fails with `--jq requires --json`
+(error 8002), printed as plain text on stderr rather than as a JSON envelope.
+
+Field projection runs *before* jq and drops the wrapper key, so when you
+combine `--json <fields>` with `--jq` the filter sees a flat array — start it
+with `.[]`, not `.pullRequests[]`:
+
+```bash
+bb pr list --json id,title --jq '.[] | .title'
+```
+
+### `--no-truncate`
+
+Show table cells in full. By default, long values (pull request descriptions,
+comment bodies, branch names) are truncated to keep rows on one line. `--no-truncate`
+disables that for the current invocation:
+
+```bash
+bb pr comments list 42 --no-truncate
+```
+
+The truncation suffix is the three ASCII characters `...` and it counts against
+the column budget, so a 50-character cap yields 47 characters plus `...`.
+`--no-truncate` affects table output only — JSON payloads are never truncated,
+so passing it alongside `--json` does nothing.
+
 ### `--no-color` and `--no-unicode`
 
 `--no-color` disables ANSI colors. `--no-unicode` swaps Unicode separators
 and status glyphs for plain ASCII equivalents — useful for log aggregators
 that mangle Unicode, or terminals that don't render the symbols cleanly.
 
-Both flags have environment-variable equivalents (`NO_COLOR`,
-`BB_NO_UNICODE`). They're auto-disabled when stdout is not a TTY, so piping
-to a file or another process already gives you plain output.
+Colors switch off on their own when stdout is not a TTY, so piping to a file
+already gives you plain text. Unicode does not: `bb pr list > out.txt` still
+writes the `─` separator rules, `→` branch arrows and `✓`/`✗`/`○` status
+glyphs. Pass `--no-unicode` or set `BB_NO_UNICODE` if you need ASCII in a
+redirect.
 
-## Pagination flags
+Tables themselves are already ASCII — the header underline is plain `-`
+characters and there are no vertical bars or outer border — so `--no-unicode`
+does not change the table frame.
+
+The two environment variables are not symmetric:
+
+- `NO_COLOR` triggers on any value, including the empty string. Both
+  `FORCE_COLOR` (any value except `0`) and a literal `--color` in argv
+  override it.
+- `BB_NO_UNICODE` triggers on any non-empty value and cannot be overridden per
+  command. `--unicode` is accepted but has no effect while `BB_NO_UNICODE` is
+  set — unset the variable instead.
+
+## List-command flags
+
+`--limit` and `--all` are options on list commands, not global flags.
+`bb pr view --limit 5` fails with `error: unknown option '--limit'`.
 
 ### `--limit <n>`
 
-Cap the number of items returned. Most list commands default to a small,
-useful page size (e.g. 25); pass `--limit 100` to fetch more in one shot.
+Cap the number of items returned. The default is 25 on every list command.
+
+This caps items, not pages. The CLI fetches up to 50 items per request and
+keeps paging until the cap is met, so `--limit 200` makes four round trips.
+Values below 1 fail with `--limit must be a positive integer`.
 
 ### `--all`
 
-Fetch every page. Available on:
+Fetch every page. `--all` overrides `--limit`.
+
+Both flags are available on these twelve commands:
 
 - `bb repo list`
 - `bb pr list`
@@ -78,37 +151,52 @@ Fetch every page. Available on:
 - `bb pr comments list`
 - `bb snippet list`
 - `bb snippet comments list`
+- `bb pipeline list`
+- `bb commit list`
+- `bb status list`
+- `bb issue list`
+- `bb workspace list`
+- `bb project list`
 
-`--all` overrides `--limit`. When the output is truncated by `--limit`, the
-CLI prints a hint suggesting `--limit <n>` or `--all` so the truncation is
-never silent.
+`bb pr checks`, `bb pr reviewers list`, `bb repo default-reviewers list` and
+`bb config list` are single-request and accept neither. `bb api` uses
+`--paginate` instead.
 
-### `--no-truncate`
+When `--limit` cuts a table short, the CLI prints a hint:
 
-Show table cells in full. By default, long values (PR descriptions, comment
-bodies, branch names) are truncated to keep rows on one line. `--no-truncate`
-disables that for the current invocation:
-
-```bash
-bb pr comments list 42 --no-truncate
+```text
+Showing 25 pull requests. Use --limit <n> or --all to see more.
 ```
+
+That hint is table output only. Under `--json` nothing is printed, so compare
+the envelope's `count` against your limit yourself.
 
 ## Context flags
 
 ### `-w, --workspace` and `-r, --repo`
 
-Override the workspace and repository for the current command. The
-resolution order is documented in detail in
-[Repository Context](/guides/repository-context/), but in short:
+Override the workspace and repository for the current command:
 
-1. `--workspace` / `--repo` flags
-2. Git remote of the current directory
-3. `BB_WORKSPACE` environment variable (workspace only)
-4. `defaultWorkspace` in the config file (workspace only)
+```bash
+bb pr list -w myworkspace -r myrepo
+```
+
+Repository-scoped commands fall back to the git remote of the current
+directory. Workspace-only commands never look at git — they resolve
+`--workspace`, then `BB_WORKSPACE`, then `defaultWorkspace`, and fail with
+`No workspace specified.` if none is set. That covers `bb workspace view`,
+every `bb project` and `bb snippet` command, `bb repo list`, `bb repo create`,
+`bb repo clone`, and `bb api` when it fills a `{workspace}` placeholder. Being
+inside a Bitbucket clone is not enough for those.
+
+The full order is in
+[Environment Variables](/reference/environment-variables/#resolution-order),
+with worked examples in
+[Understanding Repository Context](/guides/repository-context/).
 
 ## Locale flag
 
-### `--locale <tag>`
+### `--locale <locale>`
 
 Pin a BCP-47 locale tag for date/time formatting. This affects every
 human-readable date the CLI prints — PR timestamps, activity entries,
@@ -119,23 +207,32 @@ bb pr list --locale de-DE
 bb pr view 42 --locale ja-JP
 ```
 
-If `--locale` is unset, the CLI walks `BB_LOCALE`, then the standard POSIX
-chain (`LC_TIME` → `LC_ALL` → `LANG`), then falls back to `en-US`.
+If `--locale` is unset, the CLI walks `BB_LOCALE`, then the POSIX locale
+variables in the order `LC_TIME` → `LC_ALL` → `LANG`, then falls back to
+`en-US`. Note that `LC_TIME` is checked *before* `LC_ALL`, which is the reverse
+of the usual POSIX override order — if you set both, `LC_TIME` wins here.
+
+Values are normalised before use: a `.UTF-8` codeset or `@euro` modifier suffix
+is stripped, `_` becomes `-`, and `C` / `POSIX` map to `en-US`. An invalid
+BCP-47 tag never errors — it silently falls back to `en-US`.
 
 ## Precedence summary
 
-For settings that can come from multiple sources, the order is always:
+For settings that can come from multiple sources, the order is usually:
 
 1. Command-line flag
 2. Environment variable
 3. Config file
 4. Built-in default
 
-<Aside type="note">
-For boolean toggles like `--no-color`, the inverse flag (`--color`) is
-not a global flag — it only exists on `bb pr diff`. Use `FORCE_COLOR=1` to
-force color globally instead.
-</Aside>
+Two documented exceptions: `FORCE_COLOR` beats `--no-color`, and `--unicode`
+cannot override `BB_NO_UNICODE`.
+
+Color has one more wrinkle. `--color` is the highest-precedence color input of
+all — ahead of `FORCE_COLOR`, `--no-color` and `NO_COLOR` — and it is matched
+by a raw scan of argv. So `bb pr diff 42 --color never` turns global color on
+even though it leaves the diff body uncolored, because `bb pr diff` takes
+`--color <when>` with the choices `auto`, `always` and `never`.
 
 ## See also
 

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -8,9 +8,11 @@ import { Aside } from '@astrojs/starlight/components';
 All commands support the global `--json` flag, with optional field selection
 and a built-in `--jq` filter modeled on the [`gh` CLI](https://cli.github.com/manual/gh_help_formatting).
 
-Use JSON mode for automation, scripts, and CI/CD pipelines.
+In `--json` mode stdout carries the JSON document and nothing else. The
+update-available banner and automatic-retry notices are suppressed, and errors
+go to stderr — so `bb … --json > out.json` is safe.
 
-## Quick Usage
+## Quick usage
 
 ```bash
 # Full JSON output
@@ -33,7 +35,7 @@ bb <command> --json 2>/dev/null | jq .
 ```
 </Aside>
 
-## Field Selection (`--json fields`)
+## Field selection (`--json fields`)
 
 Pass a comma-separated field list to project the output to just those fields,
 matching the way `gh` CLI handles `--json`:
@@ -50,9 +52,19 @@ bb pr list --json id,title,author.display_name
   including dotted paths (`author.display_name` becomes the literal key
   `"author.display_name"`).
 - Dotted paths traverse nested objects; missing intermediates yield `null`.
-- For collection commands (`pr list`, `repo list`, etc.), the wrapper envelope
-  is dropped and the field list is projected per-item — the result is a flat
-  array. This matches `gh` CLI semantics.
+- If the output is already an array, each item is projected.
+- If the output is an envelope object, the CLI looks for the first of these
+  keys holding an **array** and projects that array instead, dropping the
+  envelope — the result is a flat array. This matches `gh` CLI semantics.
+
+  ```text
+  pullRequests  repositories  snippets  comments  reviewers  activities
+  statuses      files         pipelines commits   issues     workspaces
+  projects      values
+  ```
+
+- If no key in that list holds an array, the envelope object itself is
+  projected.
 
 #### Example: `bb pr list --json id,title,author.display_name`
 
@@ -72,6 +84,7 @@ bb pr list --json id,title,author.display_name
   "workspace": "myworkspace",
   "repoSlug": "myrepo",
   "state": "OPEN",
+  "filters": { "mine": false },
   "count": 2,
   "pullRequests": [
     {
@@ -97,6 +110,48 @@ The same command with `--json id,title,state` drops the envelope and projects ea
 
 This is why `--jq` filters use `.[]` after projection (`.[] | select(...)`) but `.pullRequests[]` against the full envelope.
 
+#### Trap: envelopes whose array key is not in the list
+
+`bb pipeline view` returns `{ workspace, repoSlug, pipeline, steps }`. `steps`
+is not a wrapper key, so nothing is unwrapped and the field list is applied to
+the envelope — where `build_number` does not exist:
+
+```bash
+bb pipeline view 7 --json build_number
+```
+
+```json
+{
+  "build_number": null
+}
+```
+
+Use `--jq` to reach into the envelope instead:
+
+```bash
+bb pipeline view 7 --json --jq '.pipeline.build_number'
+```
+
+`bb pipeline logs` (without `--step`) puts its array under `steps` too. `bb
+snippet view --files` returns `files` as an **object**, not an array, so it is
+not unwrapped either.
+
+The reverse trap also exists. `bb pr view` returns a bare pull request, and that
+payload carries a `reviewers` array — a wrapper key — so `bb pr view 42 --json
+links.html.href` projects the reviewers instead of the pull request. Use `--jq`
+against the full output:
+
+```bash
+bb pr view 42 --json --jq '.links.html.href'
+```
+
+`bb api --paginate` merges every page into `{"values": [...]}`, and `values`
+**is** a wrapper key, so projection does unwrap it:
+
+```bash
+bb api /repositories/my-ws --paginate --json name,full_name
+```
+
 ## Built-in jq (`--jq`)
 
 The `--jq <expression>` flag pipes the JSON output through an embedded jq
@@ -104,7 +159,7 @@ engine ([jq-wasm](https://www.npmjs.com/package/jq-wasm)) — no external `jq`
 binary required, no `bash` pipe to fail on Windows.
 
 ```bash
-# Strings, one per line
+# One value per line (strings come out quoted — see the raw-output note below)
 bb pr list --json --jq '.pullRequests[].title'
 
 # Combine with field selection (jq runs after projection)
@@ -113,12 +168,24 @@ bb pr list --json id,title,state --jq '.[] | select(.state == "OPEN") | .title'
 # Aggregate
 bb pr list --json --jq '.count'
 
-# Project + format with jq string interpolation
+# Repository names
+bb repo list --json --jq '.repositories[].full_name'
+
+# Diff file paths
+bb pr diff 42 --stat --json --jq '.files[].path'
+
+# Auth status as a bare boolean
+bb auth status --json --jq '.authenticated'
+
+# Project + format with jq string interpolation (external jq -r for raw TSV)
 bb pr list --json id,title,author.display_name \
-  --jq '.[] | "\(.id)\t\(.["author.display_name"])\t\(.title)"'
+  | jq -r '.[] | "\(.id)\t\(.["author.display_name"])\t\(.title)"'
+
+# Pull request URLs
+bb pr list --json --jq '.pullRequests[].links.html.href'
 
 # Project a nested URL out of a single resource
-bb pr view 42 --json links.html.href --jq '.["links.html.href"]'
+bb repo view --json links.html.href --jq '.["links.html.href"]'
 
 # Top open PRs by author with built-in jq (no projection — full shape)
 bb pr list --json --jq '.pullRequests | group_by(.author.display_name)
@@ -126,10 +193,33 @@ bb pr list --json --jq '.pullRequests | group_by(.author.display_name)
   | sort_by(-.count)'
 ```
 
+Every expression above also works with an external `jq` binary — pipe the full
+output instead: `bb pr list --json | jq '.pullRequests[].title'`.
+
 **Rules:**
 
-- `--jq` requires `--json`. Using `--jq` alone exits non-zero with a clear
-  error (`✗ --jq requires --json`).
+- There is no raw-output switch. `--jq` behaves like `jq` **without** `-r`, so
+  string results keep their quotes:
+
+  ```bash
+  bb pr list --json --jq '.pullRequests[].title'
+  # "Add feature"
+  # "Fix bug"
+  ```
+
+  When a script needs unquoted text, pipe the full JSON to an external `jq -r`:
+
+  ```bash
+  bb pr list --json | jq -r '.pullRequests[].title'
+  # Add feature
+  # Fix bug
+  ```
+
+- `--jq` requires `--json`. Using `--jq` alone exits non-zero with `✗ --jq
+  requires --json`. That message prints as plain text on stderr, not as a JSON
+  envelope, because JSON mode was never enabled.
+- `bb api` is the exception: its output is already JSON, so `bb api
+  /repositories/my-ws --jq '.values[].name'` works without `--json`.
 - jq runs *after* field projection, so `.` refers to the projected shape — a
   flat array when both `--json fields` and a wrapper-style command are
   involved.
@@ -141,22 +231,22 @@ The embedded jq is jq 1.8.x. Module imports (`include`, `import`) and
 filesystem-dependent features are not supported.
 </Aside>
 
-## Output Patterns
+## Output patterns
 
-The CLI uses a small number of consistent output patterns. Understanding these patterns lets you predict the JSON shape of any command.
+### Pattern 1: collection (list commands)
 
-### Pattern 1: Collection (List Commands)
+Used by: `pr list`, `repo list`, `pr comments list`, `pr activity`,
+`snippet list`, `snippet comments list`, `pipeline list`, `commit list`,
+`status list`, `issue list`, `workspace list`, `project list`
 
-Used by: `pr list`, `repo list`, `pr comments list`, `pr activity`, `pr reviewers list`, `pr checks`, `pipeline list`, `commit list`, `status list`, `issue list`, `workspace list`, `project list`, `snippet list`
-
-Returns an envelope with metadata and a named array:
+Returns an envelope with metadata, a `count`, and a named array:
 
 ```json
 {
   "workspace": "myworkspace",
   "repoSlug": "myrepo",
   "state": "OPEN",
-  "filters": {},
+  "filters": { "mine": false },
   "count": 2,
   "pullRequests": [...]
 }
@@ -166,11 +256,11 @@ Returns an envelope with metadata and a named array:
 
 | Field | Type | Present in |
 |-------|------|-----------|
-| `workspace` | string | Repository- and workspace-scoped collections (PR, repo, pipeline, commit, status, issue, project) |
-| `repoSlug` | string | Repository-scoped collections (PR, pipeline, commit, status, issue) |
+| `workspace` | string | All collections except `workspace list` (whose slugs live in the items) |
+| `repoSlug` | string | Repository-scoped collections: `pr list`, `pr comments list`, `pr activity`, `pipeline list`, `commit list`, `status list`, `issue list` |
 | `count` | number | All collections |
 | `state` | string | `pr list` |
-| `filters` | object | `pr list` (when `--mine` is used), `pr activity`, `pr comments list`, `issue list`, `workspace list` |
+| `filters` | object | `pr list`, `pr activity`, `pr comments list`, `issue list`, `workspace list` — always present, with an unset value inside (`{"mine": false}`, `{"types": []}`, `{"resolution": null}`) or `{}` |
 | `commit` | string | `status list` |
 | `sort` | string | `pipeline list` |
 
@@ -182,8 +272,6 @@ Returns an envelope with metadata and a named array:
 | `repo list` | `repositories` |
 | `pr comments list` | `comments` |
 | `pr activity` | `activities` |
-| `pr reviewers list` | `reviewers` |
-| `pr checks` | `statuses` (inside a `summary` + `statuses` structure) |
 | `pipeline list` | `pipelines` |
 | `commit list` | `commits` |
 | `status list` | `statuses` |
@@ -191,6 +279,16 @@ Returns an envelope with metadata and a named array:
 | `workspace list` | `workspaces` |
 | `project list` | `projects` |
 | `snippet list` | `snippets` |
+| `snippet comments list` | `comments` |
+
+Three commands return collections without going through the shared list
+plumbing. They are not paginated and have no `--limit`/`--all`:
+
+| Command | Shape |
+|---------|-------|
+| `pr reviewers list` | `{ workspace, repoSlug, pullRequestId, count, reviewers }` |
+| `repo default-reviewers list` | `{ workspace, repoSlug, mode, count, reviewers }` |
+| `pr checks` | `{ pullRequestId, workspace, repoSlug, summary, statuses }` — **no `count`** |
 
 #### Example: `bb pr list --json`
 
@@ -199,6 +297,7 @@ Returns an envelope with metadata and a named array:
   "workspace": "myworkspace",
   "repoSlug": "myrepo",
   "state": "OPEN",
+  "filters": { "mine": false },
   "count": 2,
   "pullRequests": [
     {
@@ -244,9 +343,11 @@ Returns an envelope with metadata and a named array:
 
 ---
 
-### Pattern 2: Resource (View/Create Commands)
+### Pattern 2a: bare resource
 
-Used by: `pr view`, `repo view`, `pr create`, `pr edit`, `pr comments view`
+Used by: `pr view`, `pr create`, `pr edit`, `pr comments view`, `repo view`,
+`repo create`, `snippet view` (no `--file`/`--files`), `snippet create`,
+`snippet edit`
 
 Returns the raw Bitbucket API resource object directly, with no envelope:
 
@@ -271,11 +372,33 @@ bb pr view 42 --json | jq 'keys'
 ```
 </Aside>
 
+### Pattern 2b: enveloped resource
+
+The rest of the single-resource commands wrap the payload in a context
+envelope. Read the resource from the named key, not from the root:
+
+| Command | Shape |
+|---------|-------|
+| `commit view` | `{ workspace, repoSlug, commit }` |
+| `issue view`, `issue create`, `issue edit`, `issue close` | `{ workspace, repoSlug, issue }` |
+| `project view`, `project create` | `{ workspace, project }` |
+| `workspace view` | `{ workspace }` (the workspace object) |
+| `status set` | `{ workspace, repoSlug, commit, status }` |
+| `pipeline view` | `{ workspace, repoSlug, pipeline, steps }` |
+| `pipeline run` | `{ workspace, repoSlug, pipeline }` |
+| `pipeline logs --step <uuid>` | `{ workspace, repoSlug, pipelineId, stepUuid, log }` |
+| `pipeline logs` (no `--step`) | `{ workspace, repoSlug, pipelineId, count, steps }` |
+| `snippet view --file <name>` | `{ file, content }` |
+| `snippet view --files` | `{ snippet, files }` (`files` is an object keyed by filename) |
+
+`pipeline view` and `pipeline logs` put their array under `steps`, which is not
+a projection wrapper key — see the trap above.
+
 ---
 
-### Pattern 3: Action (Approve/Merge/Decline Commands)
+### Pattern 3: action (approve/merge/decline commands)
 
-Used by: `pr approve`, `pr decline`, `pr merge`, `pr ready`, `pr comments add/edit/delete/reply/resolve/unresolve`, `pr reviewers add/remove`, `auth login`, `auth logout`
+Used by: `pr approve`, `pr decline`, `pr merge`, `pr ready`, `pr comments add/edit/delete/reply/resolve/unresolve`, `pr reviewers add/remove`, `auth logout`
 
 Returns a success indicator plus resource identifiers:
 
@@ -296,9 +419,18 @@ Some action commands include the full resource in the response:
 }
 ```
 
+Two action-style commands do **not** emit `success` — branch on their own key
+instead:
+
+- `auth login` → `{ "authenticated": true, "method": "oauth" | "api_token", "user": {...} }`
+- `pipeline stop` → `{ "workspace": "...", "repoSlug": "...", "pipelineId": "...", "stopped": true }`
+
+(`auth logout` does emit `success`: `{ "authenticated": false, "success": true }`,
+plus `"revokeFailed": true` when the OAuth token could not be revoked.)
+
 ---
 
-### Pattern 4: Mode-Based (Diff Command)
+### Pattern 4: mode-based (diff command)
 
 Used by: `pr diff` (with `--stat`, `--web`, `--name-only`, or default diff mode)
 
@@ -329,10 +461,11 @@ writing to a `.patch` file.
 }
 ```
 
-Extract just the diff text in scripts:
+Extract just the diff text in scripts. Use an external `jq -r` here — the
+built-in `--jq` would emit the value as a quoted, escaped JSON string:
 
 ```bash
-bb pr diff 42 --json --jq '.diff' > pr-42.patch
+bb pr diff 42 --json | jq -r '.diff' > pr-42.patch
 ```
 
 #### `bb pr diff 42 --stat --json`
@@ -378,7 +511,7 @@ bb pr diff 42 --json --jq '.diff' > pr-42.patch
 
 ---
 
-### Pattern 5: Auth & Config (Custom)
+### Pattern 5: auth & config (custom)
 
 These commands have unique output shapes:
 
@@ -387,20 +520,41 @@ These commands have unique output shapes:
 ```json
 {
   "authenticated": true,
+  "method": "oauth",
   "user": {
     "username": "myuser",
     "displayName": "My Name",
     "accountId": "70121:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  }
+  },
+  "defaultWorkspace": "myworkspace",
+  "tokenExpiresAt": 1767225600
 }
 ```
 
-#### `bb auth token --json`
+`tokenExpiresAt` (a Unix timestamp in seconds) is present only for OAuth
+credentials. When no credentials are stored the whole payload is:
 
 ```json
-{
-  "token": "base64-encoded-username:apiToken"
-}
+{ "authenticated": false }
+```
+
+`method` is spelled differently by the two commands. `auth status` reports the
+stored value, `"basic"` or `"oauth"`; `auth login` reports `"api_token"` or
+`"oauth"` for the same credentials. Match on `"oauth"` versus everything else
+rather than on the literal `"api_token"`.
+
+#### `bb auth token --json`
+
+OAuth credentials return the access token:
+
+```json
+{ "token": "<access token>", "type": "bearer" }
+```
+
+API-token credentials return the base64 of `username:apiToken`:
+
+```json
+{ "token": "<base64 of username:apiToken>", "type": "basic" }
 ```
 
 #### `bb config list --json`
@@ -410,8 +564,8 @@ These commands have unique output shapes:
   "configPath": "/Users/you/.config/bb/config.json",
   "config": {
     "username": "myuser",
-    "apiToken": "********",
     "defaultWorkspace": "myworkspace",
+    "apiToken": "********",
     "skipVersionCheck": false
   }
 }
@@ -428,42 +582,15 @@ These commands have unique output shapes:
 
 ---
 
-## jq Examples
-
-The same expressions work with the built-in `--jq` flag or with an external
-`jq` binary. The built-in form avoids the dependency and works identically on
-Windows, macOS, and Linux.
-
-```bash
-# Print PR titles (built-in)
-bb pr list --json --jq '.pullRequests[].title'
-
-# Print PR titles (external jq, equivalent)
-bb pr list --json | jq -r '.pullRequests[].title'
-
-# Count PRs
-bb pr list --json --jq '.count'
-
-# Repository names
-bb repo list --json --jq '.repositories[].full_name'
-
-# Diff file paths
-bb pr diff 42 --stat --json --jq '.files[].path'
-
-# PR URLs
-bb pr list --json --jq '.pullRequests[].links.html.href'
-
-# Auth status
-bb auth status --json --jq '.authenticated'
-```
-
-## Scripting Notes
+## Scripting notes
 
 - Prefer `--json` in scripts rather than parsing text output.
 - Do not rely on text formatting symbols (`✓`, table separators, colors).
 - Prefer the built-in `--jq` and `--json fields` over external pipes — they
   avoid an extra binary dependency and behave identically across platforms.
-- If you need stable fields, prefer command-specific documented keys (`pullRequests`, `repositories`, `files`, `success`).
+- Envelope keys (`count`, `pullRequests`, `repositories`, `success`) are owned
+  by the CLI and stable. Item fields come straight from the Bitbucket API, so
+  read `.pullRequests[].id` rather than assuming a shape for the whole item.
 - `pr list` returns lightweight PR objects. Use `pr view <id>` for full details including `participants` and `reviewers`.
 
 ## Errors
@@ -517,7 +644,7 @@ present, the shape is:
 | `1002` AUTH_INVALID | `status` (HTTP status, OAuth verification failures only) |
 | `1003` AUTH_EXPIRED | `status` (HTTP status from the token endpoint) |
 | `2001`–`2005` API_* | `status`, `method`, `url` — plus the top-level `statusCode` and `response` fields described above. `url` is the request path only; pagination and filter parameters the CLI sends are not part of it, though a query string you write yourself (`bb api '/repositories/acme?role=owner'`) is |
-| `3001` GIT_NOT_REPOSITORY | _(none)_ |
+| `3001` GIT_NOT_REPOSITORY | _(none — never thrown)_ |
 | `3002` GIT_COMMAND_FAILED | `command`, `exitCode` |
 | `3003` GIT_REMOTE_NOT_FOUND | `remote` |
 | `4001` CONFIG_READ_FAILED | _(none)_ |
@@ -525,11 +652,14 @@ present, the shape is:
 | `4003` CONFIG_INVALID_KEY | `key` |
 | `5001` VALIDATION_REQUIRED | `field` (when thrown by `ValidationError`) |
 | `5002` VALIDATION_INVALID | varies — usually `{ key, value }`, the offending option name, or the rejected ID |
+| `5003` FILE_NOT_FOUND | `file` (`snippet create/edit/view`, `issue create --body-file`), `bodyFile` (`pr edit --body-file`), or `path` (`bb api -F key=@file` / `--input`). `snippet view --file` also attaches `available`, the list of filenames in the snippet |
 | `6001` CONTEXT_REPO_NOT_FOUND | _(none)_ |
 | `6002` CONTEXT_WORKSPACE_NOT_FOUND | _(none)_ |
 | `7001` NETWORK_ERROR | _(usually none; OAuth revoke failures include `status`, `body`)_ |
 | `8001` JQ_FAILED | `expression`, optional `exitCode` |
 | `8002` JSON_FORMAT_INVALID | _(none)_ |
+| `9001` COMPLETION_INSTALL_FAILED | _(none)_ |
+| `9002` COMPLETION_UNINSTALL_FAILED | _(none)_ |
 | `9999` UNKNOWN | _(none)_ |
 
 In automation, always check the process exit code before parsing stdout JSON.

--- a/docs/src/content/docs/reference/token-scopes.mdx
+++ b/docs/src/content/docs/reference/token-scopes.mdx
@@ -6,29 +6,35 @@ description: Required Bitbucket API token scopes for each bb command
 import { Aside } from '@astrojs/starlight/components';
 
 When you authenticate with an [API token](/getting-started/authentication/#api-token-for-cicd-and-headless-environments),
-you choose which scopes the token grants. This page maps every `bb` command to
-the minimum scope required to run it, so you can mint a token with exactly the
-permissions a workflow needs and nothing more.
+you pick the scopes it grants. This page maps every `bb` command to the minimum
+scope it needs, so you can mint a token for one workflow and nothing more.
+Generate tokens at [Bitbucket API tokens](https://bitbucket.org/account/settings/api-tokens/).
 
-<Aside type="tip">
-OAuth logins (`bb auth login` without `-u`/`-p`) request a fixed scope set up
-front and don't need this table. Use this reference when generating an API
-token at [Bitbucket API tokens](https://bitbucket.org/account/settings/api-tokens/).
+<Aside type="caution" title="OAuth grants a fixed, narrower set">
+`bb auth login` uses OAuth only when none of `--app-password`, `--with-token`,
+`-u` or `-p` are passed **and** `BB_API_TOKEN` is unset. The OAuth flow requests
+a hardcoded scope set — `account repository repository:admin pullrequest
+pullrequest:write` (legacy scope names, not the `<action>:<resource>:bitbucket`
+names used below) — and you cannot widen it, not even with a custom consumer.
+That covers repository, pull request, commit, build-status and workspace
+commands. It does **not** cover `bb pipeline`, `bb issue`, `bb snippet`,
+`bb project`, or `bb repo delete`. Use an API token for those.
 </Aside>
 
-## Scope Reference
+## Scope reference
 
 Bitbucket Cloud API token scopes follow the format `<action>:<resource>:bitbucket`.
 The CLI uses these scopes:
 
 | Scope | Grants |
 |-------|--------|
-| `read:user:bitbucket` | Read your own user profile (required by `bb auth status`, used to verify any login) |
-| `read:repository:bitbucket` | List and view repositories, commits, and commit build statuses; list default reviewers |
-| `write:repository:bitbucket` | Create repositories, manage default reviewers, set commit build statuses |
-| `admin:repository:bitbucket` | Delete repositories |
-| `read:pullrequest:bitbucket` | List, view, and diff pull requests; read comments, activity, checks, and reviewers |
-| `write:pullrequest:bitbucket` | Create, edit, approve, decline, merge, and mark PRs ready; add/edit/delete comments; add/remove reviewers |
+| `read:user:bitbucket` | Read user profiles — verifies any login, resolves your UUID for `bb pr list --mine`, and covers `bb workspace list` |
+| `read:repository:bitbucket` | List and view repositories, commits, and commit build statuses |
+| `write:repository:bitbucket` | Set commit build statuses |
+| `admin:repository:bitbucket` | Create repositories; add and remove default reviewers |
+| `delete:repository:bitbucket` | Delete repositories |
+| `read:pullrequest:bitbucket` | List, view, and diff pull requests; read comments, activity, checks, reviewers, and default reviewers |
+| `write:pullrequest:bitbucket` | Create, edit, approve, decline, merge, and mark pull requests ready; add/remove reviewers; add, edit, and delete comments |
 | `read:pipeline:bitbucket` | List and view pipelines and their steps, read step logs |
 | `write:pipeline:bitbucket` | Trigger and stop pipelines |
 | `read:issue:bitbucket` | List and view issues |
@@ -36,10 +42,10 @@ The CLI uses these scopes:
 | `read:workspace:bitbucket` | List and view workspaces |
 | `read:project:bitbucket` | List and view projects |
 | `admin:project:bitbucket` | Create projects |
-| `read:snippet:bitbucket` | List and view snippets |
-| `write:snippet:bitbucket` | Create, edit, and delete snippets |
+| `read:snippet:bitbucket` | List and view snippets, read snippet comments |
+| `write:snippet:bitbucket` | Create, edit, and delete snippets; watch and unwatch; add, edit, and delete snippet comments |
 
-## Command → Scope Map
+## Command → scope map
 
 ### Auth (`bb auth …`)
 
@@ -56,45 +62,46 @@ The CLI uses these scopes:
 |---------|-----------------|
 | `bb repo list` | `read:repository:bitbucket` |
 | `bb repo view` | `read:repository:bitbucket` |
-| `bb repo clone` | `read:repository:bitbucket` (plus your normal git auth) |
-| `bb repo create` | `write:repository:bitbucket` |
-| `bb repo delete` | `admin:repository:bitbucket` |
-| `bb repo default-reviewers list` | `read:repository:bitbucket` |
-| `bb repo default-reviewers add` | `write:repository:bitbucket` |
-| `bb repo default-reviewers remove` | `write:repository:bitbucket` |
+| `bb repo create` | `admin:repository:bitbucket` |
+| `bb repo delete` | `delete:repository:bitbucket` |
+| `bb repo default-reviewers list` | `read:pullrequest:bitbucket` |
+| `bb repo default-reviewers add` | `admin:repository:bitbucket` |
+| `bb repo default-reviewers remove` | `admin:repository:bitbucket` |
 
-### Pull Requests (`bb pr …`)
+`admin:` and `delete:` are separate scopes. A token with
+`admin:repository:bitbucket` can create repositories but cannot delete them.
 
-Read-only PR commands — `list`, `view`, `diff`, `checkout`, `activity`,
-`checks`, `comments list`, `reviewers list` — only need
-`read:pullrequest:bitbucket` (plus `read:repository:bitbucket` for repository
-context).
+Default reviewers live under the pull request resource in Bitbucket's API,
+which is why reading them needs a pull request scope while changing them needs
+the repository admin scope. `add` and `remove` also resolve the target account
+via `GET /users/{user}` first — that endpoint carries no scope of its own, but a
+token that cannot see the account will fail there.
 
-| Command | Required scopes |
-|---------|-----------------|
-| `bb pr list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr view` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr diff` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr checkout` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr activity` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr checks` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments view` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr reviewers list` | `read:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr create` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr edit` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr ready` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr approve` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr decline` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr merge` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments add` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments edit` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments reply` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments resolve` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments unresolve` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr comments delete` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr reviewers add` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
-| `bb pr reviewers remove` | `write:pullrequest:bitbucket`, `read:repository:bitbucket` |
+### Pull requests (`bb pr …`)
+
+`read:pullrequest:bitbucket` covers `list`, `view`, `diff`, `checkout`,
+`activity`, `checks`, `comments list`, `comments view` and `reviewers list`.
+
+`write:pullrequest:bitbucket` covers `create`, `edit`, `ready`, `approve`,
+`decline`, `merge`, `reviewers add|remove`, and the comment mutations
+(`comments add|edit|reply|resolve|unresolve|delete`). Bitbucket's API spec still
+maps the comment endpoints to the read scope, so a read-only token may be enough
+for `bb pr comments add` — grant the write scope anyway, that is the one to rely
+on.
+
+`bb pr list --mine` also needs `read:user:bitbucket` — it calls `GET /user` to
+resolve your UUID before filtering. So do the commands that take a `<user>`
+argument: `bb pr create --reviewer`, `bb pr reviewers add|remove`, and
+`bb repo default-reviewers add|remove` all resolve the handle you pass through
+`GET /users/{selected_user}` before making the change. Add `read:user:bitbucket`
+to any token that runs those.
+
+`bb pr checkout` runs `git fetch` and `git checkout` locally after reading the
+pull request, so it uses your normal git credentials too.
+
+No `bb pr` command needs `read:repository:bitbucket`. The CLI resolves the
+workspace and repository from your git remote (or `--workspace`/`--repo`), not
+from the API.
 
 ### Pipelines (`bb pipeline …`)
 
@@ -106,22 +113,12 @@ context).
 | `bb pipeline run` | `write:pipeline:bitbucket` |
 | `bb pipeline stop` | `write:pipeline:bitbucket` |
 
-### Commits (`bb commit …`)
-
-Commits are part of the repository resource, so commit commands reuse the
-repository scopes:
+### Commits and build statuses (`bb commit …`, `bb status …`)
 
 | Command | Required scopes |
 |---------|-----------------|
 | `bb commit list` | `read:repository:bitbucket` |
 | `bb commit view` | `read:repository:bitbucket` |
-
-### Build Statuses (`bb status …`)
-
-Commit build statuses also live under the repository resource:
-
-| Command | Required scopes |
-|---------|-----------------|
 | `bb status list` | `read:repository:bitbucket` |
 | `bb status set` | `write:repository:bitbucket` |
 
@@ -140,8 +137,14 @@ Commit build statuses also live under the repository resource:
 
 | Command | Required scopes |
 |---------|-----------------|
-| `bb workspace list` | `read:workspace:bitbucket` |
-| `bb workspace view` | `read:workspace:bitbucket` |
+| `bb workspace list` | `read:workspace:bitbucket`, `read:user:bitbucket` |
+| `bb workspace view` | _(none — the endpoint is unscoped)_ |
+
+`bb workspace list` calls `GET /workspaces`, which Bitbucket's API spec scopes
+to `account` — the legacy name for `read:user:bitbucket`. Grant it alongside
+`read:workspace:bitbucket`. `GET /workspaces/{workspace}` carries no scope at
+all, so `bb workspace view` works with whatever grant already makes the
+workspace visible to you.
 
 ### Projects (`bb project …`)
 
@@ -160,50 +163,70 @@ Commit build statuses also live under the repository resource:
 | `bb snippet create` | `write:snippet:bitbucket` |
 | `bb snippet edit` | `write:snippet:bitbucket` |
 | `bb snippet delete` | `write:snippet:bitbucket` |
+| `bb snippet watch` | `write:snippet:bitbucket` |
+| `bb snippet unwatch` | `write:snippet:bitbucket` |
+| `bb snippet comments list` | `read:snippet:bitbucket` |
+| `bb snippet comments add` | `write:snippet:bitbucket` |
+| `bb snippet comments edit` | `write:snippet:bitbucket` |
+| `bb snippet comments delete` | `write:snippet:bitbucket` |
+
+As with pull request comments, Bitbucket's API spec maps snippet comment writes
+to the read scope. Grant `write:snippet:bitbucket` anyway — that is the scope to
+rely on.
+
+### Raw API (`bb api`)
+
+`bb api` needs whatever scope the endpoint you call requires — look the endpoint
+up in Atlassian's Bitbucket Cloud API reference. A `403` from `bb api` means the
+token is missing that endpoint's scope, not that the path is wrong.
 
 ### Local-only commands
 
 These don't hit the API and don't need any scope:
 
+- `bb repo clone` (builds the clone URL from workspace and repository names, then shells out to git — uses your normal git credentials)
+- `bb browse` (builds the URL from local git context)
 - `bb config` (all subcommands)
 - `bb completion`
 - `bb` (root, including the version-check)
 
-## Common Profiles
-
-Pick the profile that matches your workflow and grant only those scopes when
-creating the token.
+## Common profiles
 
 ### Read-only automation (status checks, dashboards)
 
-```
+```text
 read:user:bitbucket
 read:repository:bitbucket
 read:pullrequest:bitbucket
 read:pipeline:bitbucket
 ```
 
-### Bot account that creates and merges PRs
+### Bot account that creates and merges pull requests
 
-```
+```text
 read:user:bitbucket
-read:repository:bitbucket
 read:pullrequest:bitbucket
 write:pullrequest:bitbucket
 ```
 
+Add `read:repository:bitbucket` only if the bot also runs `bb repo`,
+`bb commit` or `bb status` commands.
+
 ### Repo provisioning automation
 
-```
+```text
 read:user:bitbucket
 read:repository:bitbucket
-write:repository:bitbucket
 admin:repository:bitbucket
+delete:repository:bitbucket
 ```
+
+Drop `delete:repository:bitbucket` unless the automation actually tears
+repositories down.
 
 ### CI/CD automation (trigger pipelines, report build statuses)
 
-```
+```text
 read:user:bitbucket
 read:repository:bitbucket
 write:repository:bitbucket
@@ -213,27 +236,24 @@ write:pipeline:bitbucket
 
 ### Issue triage bot
 
-```
+```text
 read:user:bitbucket
 read:repository:bitbucket
 read:issue:bitbucket
 write:issue:bitbucket
 ```
 
-<Aside type="caution" title="Principle of least privilege">
-Don't grant `write:` or `admin:` scopes to a token unless the script that uses
-it actually needs them. A leaked read-only token is far less damaging than a
-leaked admin token.
-</Aside>
-
 ## Troubleshooting
 
 If a command exits with [`2003` API_FORBIDDEN](/reference/error-codes/#2003---api_forbidden),
-your token is missing the scope listed in the table above. Mint a new token
-with the required scope (you can't add scopes to an existing token) and
-re-authenticate:
+your token is missing the scope listed above. You can't add scopes to an
+existing token — mint a new one and re-authenticate:
 
 ```bash
 bb auth logout
-bb auth login -u your-username -p new-token
+echo "$NEW_TOKEN" | bb auth login -u your-username --with-token
 ```
+
+`--with-token` reads the token from stdin, keeping it out of your shell history
+and out of `ps` output. `-p new-token` works too, but writes the secret into
+both.


### PR DESCRIPTION
Closes #303.

Sweeps every page of the docs site for drift against the current CLI, and rewrites the prose to be skimmable.

**235 verified accuracy fixes across all 43 pages.** Each was found by auditing a page against the real command tree and source, then independently re-verified before being applied. A further 46 candidate claims were checked and dropped as wrong, so what's here survived a deliberate attempt to refute it.

## The drift that mattered

- **`completion.mdx`** hard-coded the completable command list in two places, both missing `pipeline`, `commit`, `status`, `issue`, `workspace`, and `project` — two lines below a sentence claiming completions "always reflect the commands the CLI actually ships, there is no separate list to fall out of date". Fixed by deleting the enumeration rather than writing a third list that rots. The same page documented `bb completion install` as auto-detecting your shell; it actually prompts interactively through tabtab, which means the `--json` example it showed could never work in CI. Now says so.
- **Global flags** were listed site-wide as `--json`, `--no-color`, `--workspace`, `--repo`, `--help`. `--jq`, `--no-unicode`, `--no-truncate` and `--locale` were missing from every page that enumerated them.
- **FAQ** still told readers that issues and pipelines had no dedicated command and had to be reached through `bb api`. Both shipped in 1.21.0.
- **Changelog** had 1.20.0 sorted above 1.21.0, and was missing 1.19.0 and 1.22.0 entirely. Reordered and backfilled from `CHANGELOG.md`.
- **Token scopes** troubleshooting told users to run `bb auth login -u user -p <token>`, leaking the token into shell history and `ps`. Switched to the stdin `--with-token` form used everywhere else.
- **`bb pr create --no-default-reviewers`** was documented nowhere.
- **`reference/global-flags.mdx`** claimed redirected output "still writes the box rules" (the tables have no box-drawing characters at all) and called `LC_TIME` → `LC_ALL` → `LANG` "the standard POSIX chain" — `src/services/locale.ts` checks `LC_TIME` first, the reverse of POSIX override order.

## Readability

The classic filler vocabulary was largely already absent — "powerful" appeared once site-wide; "seamlessly", "robust", "leverage" zero times. The problem was structural, and it was uneven: moderate on 9 page groups, minor on 9, heavy on none. Pages already written directly, the landing page among them, were deliberately left alone.

Non-table prose grew 28%, mostly from documenting things that were missing. Flag tables shrank by 480 words — those deletions are per-subcommand boilerplate (`| --json | Output as JSON |`, `| id | Pull request ID |`) replaced with real JSON envelopes and runnable scripts.

## Verification

- `bun run docs:build` — clean, 44 pages
- `bun run lint:docs` — passes (25 error codes in sync, 5 env vars documented)
- `bun run format:check` — clean
- All **192 internal links and anchors** resolve. This caught a real regression where a renamed heading orphaned an inbound anchor from `guides/cicd.mdx`.
- Every `--flag` token in the docs was diffed against a dump of `--help` for all 73 leaf commands, to catch invented flags. No hits.
- Specific behavioural claims were checked against the running CLI rather than assumed — e.g. the `bb --json pr list` failure text and its `5002` code match the documented string verbatim.

No changeset: this is docs-only, matching prior docs commits (`6e92afc`, `b643a44`).

## Follow-ups, not addressed here

- **No page lists all 14 top-level command groups.** That list exists only as the sidebar in `astro.config.mjs`; there is no `commands/index.mdx`. The landing page papered over this with a "Command Reference / All commands and options" card pointing at the PR-only page — a promise its target couldn't keep. The false card is removed, but filling the gap needs a new page plus a sidebar entry, which is site restructuring and was ruled out of scope for this pass.
- **Two token-scope claims are unverified against the live API-token system** and were left rather than guessed: whether `bb snippet delete` requires `delete:snippet:bitbucket` (the vendored spec only carries the legacy `snippet:write`), and whether `bb workspace view` is genuinely unscoped. Both need one live call with a real token to settle.
- The `Unreleased` changelog heading needs renaming to the real version when `.changeset/did-you-mean-and-error-hints.md` is consumed by `bun run version`.
- Only error codes and env vars have docs lint guards. A third guard over the global-flag table and `CONFIG_KEYS` would cheaply catch most of what this pass found by hand.