### PR TITLE
test: strengthen thinnest suites + hermetic test job (#269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ coverage/
 .cache/
 
 specs
+
+.opencode/

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -149,6 +149,21 @@ type ApiClientCtor<T> = new (
 ) => T;
 
 /**
+ * One `registerCommand` row, exported for the bootstrap tests to assert the
+ * positional `deps` array matches the constructor's parameter count exactly.
+ * `as never[]` (see {@link registerCommand}) makes a wrong-length or
+ * wrong-order wiring compile fine, so the tests pin the real contract here
+ * rather than reflecting over resolved instances.
+ */
+export interface CommandRegistration {
+  token: string;
+  ctor: Ctor<unknown>;
+  deps: readonly string[];
+}
+
+export const commandRegistrations: CommandRegistration[] = [];
+
+/**
  * Register a generated OpenAPI client. Each client resolves the shared axios
  * instance lazily and is constructed with `new Ctor(undefined, undefined, axios)`.
  */
@@ -175,6 +190,11 @@ function registerCommand<T>(
   ctor: Ctor<T>,
   deps: readonly string[]
 ): void {
+  commandRegistrations.push({
+    token,
+    ctor: ctor as Ctor<unknown>,
+    deps,
+  });
   container.register(token, () => {
     const resolved = deps.map((dep) => container.resolve(dep)) as never[];
     return new ctor(...resolved);

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -22,15 +22,21 @@ const DEFAULT_GIT_TIMEOUT_MS = 60_000;
 export class GitService implements IGitService {
   private readonly cwd: string;
   private readonly timeoutMs: number;
+  private readonly env?: Record<string, string>;
 
-  constructor(cwd?: string, options: { timeoutMs?: number } = {}) {
+  constructor(
+    cwd?: string,
+    options: { timeoutMs?: number; env?: Record<string, string> } = {}
+  ) {
     this.cwd = cwd ?? process.cwd();
     this.timeoutMs = options.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS;
+    this.env = options.env;
   }
 
   private async exec(args: string[], cwd?: string): Promise<GitExecResult> {
     const proc = Bun.spawn(['git', ...args], {
       cwd: cwd ?? this.cwd,
+      env: this.env,
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -142,6 +148,9 @@ export class GitService implements IGitService {
    * Create a new instance with a different working directory
    */
   public withCwd(cwd: string): GitService {
-    return new GitService(cwd, { timeoutMs: this.timeoutMs });
+    return new GitService(cwd, {
+      timeoutMs: this.timeoutMs,
+      env: this.env,
+    });
   }
 }

--- a/tests/cli-unknown-command.test.ts
+++ b/tests/cli-unknown-command.test.ts
@@ -7,13 +7,16 @@
  * tests/cli.test.ts already reconfigures that same instance via
  * `configureOutput()` without restoring it — so keeping parse-driven cases
  * apart limits the bleed.
+ *
+ * The postAction hook polls npm for update notices on a TTY stderr; the
+ * tests/preload.ts fetch guard blocks that call from reaching the network
+ * (see issue #269), so this file does not need the CI=true dodge.
  */
 
 import {
   describe,
   it,
   expect,
-  beforeAll,
   afterAll,
   beforeEach,
   afterEach,
@@ -23,25 +26,11 @@ import type { Command } from 'commander';
 import { cli } from '../src/cli.js';
 import { ErrorCode } from '../src/types/errors.js';
 
-const originalCI = process.env.CI;
-
 let stderr: string[] = [];
 let stdout: string[] = [];
 const originalConsoleError = console.error;
 
-beforeAll(() => {
-  // `maybePrintUpdateNotice` only short-circuits on a NON-TTY stderr, which is
-  // false under an interactive `bun test` — without this the postAction hook
-  // would reach `checkForUpdate()` and hit the npm registry.
-  process.env.CI = 'true';
-});
-
 afterAll(() => {
-  if (originalCI === undefined) {
-    delete process.env.CI;
-  } else {
-    process.env.CI = originalCI;
-  }
   console.error = originalConsoleError;
 });
 

--- a/tests/commands/default-reviewers.test.ts
+++ b/tests/commands/default-reviewers.test.ts
@@ -48,13 +48,16 @@ function createMockService(
     addResult?: DefaultReviewerEntry;
     removeCalls?: string[];
     addCalls?: string[];
+    listCalls?: Array<{ mode: string | undefined }>;
   } = {}
 ): DefaultReviewerService {
   const addCalls = overrides.addCalls ?? [];
   const removeCalls = overrides.removeCalls ?? [];
+  const listCalls = overrides.listCalls ?? [];
 
   const svc = {
-    async list() {
+    async list(_repo: unknown, mode?: string) {
+      listCalls.push({ mode });
       return overrides.entries ?? [];
     },
     async add(_repo: unknown, username: string) {
@@ -111,6 +114,34 @@ describe('ListDefaultReviewersCommand', () => {
     expect(output.logs.some((l) => l.startsWith('info:'))).toBe(true);
   });
 
+  it('requests the effective mode by default (project-inherited included)', async () => {
+    const listCalls: Array<{ mode: string | undefined }> = [];
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({ entries: [], listCalls }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({}, { globalOptions: {} });
+
+    expect(listCalls).toEqual([{ mode: 'effective' }]);
+  });
+
+  it('requests the direct mode with --repo-only (excludes project-inherited)', async () => {
+    const listCalls: Array<{ mode: string | undefined }> = [];
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({ entries: [], listCalls }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({ repoOnly: true }, { globalOptions: {} });
+
+    expect(listCalls).toEqual([{ mode: 'direct' }]);
+  });
+
   it('renders a table with a Source column for effective mode', async () => {
     const output = createMockOutputService();
     const cmd = new ListDefaultReviewersCommand(
@@ -156,7 +187,14 @@ describe('ListDefaultReviewersCommand', () => {
     const output = createMockOutputService();
     const cmd = new ListDefaultReviewersCommand(
       createMockService({
-        entries: [{ uuid: '{a}', displayName: 'Alice' }],
+        entries: [
+          {
+            uuid: '{a}',
+            displayName: 'Alice',
+            nickname: 'alice',
+            reviewerType: 'project',
+          },
+        ],
       }),
       createContextService(),
       output
@@ -164,7 +202,42 @@ describe('ListDefaultReviewersCommand', () => {
 
     await cmd.execute({}, { globalOptions: { json: true } });
 
-    expect(output.logs.some((l) => l.startsWith('json:'))).toBe(true);
+    const jsonLog = output.logs.find((l) => l.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const parsed = JSON.parse(jsonLog!.slice('json:'.length));
+    expect(parsed).toEqual({
+      workspace: 'ws',
+      repoSlug: 'repo',
+      mode: 'effective',
+      count: 1,
+      reviewers: [
+        {
+          uuid: '{a}',
+          displayName: 'Alice',
+          nickname: 'alice',
+          reviewerType: 'project',
+        },
+      ],
+    });
+  });
+
+  it('emits mode=direct and reviewer entries in JSON for --repo-only', async () => {
+    const output = createMockOutputService();
+    const cmd = new ListDefaultReviewersCommand(
+      createMockService({
+        entries: [{ uuid: '{b}', displayName: 'Bob' }],
+      }),
+      createContextService(),
+      output
+    );
+
+    await cmd.execute({ repoOnly: true }, { globalOptions: { json: true } });
+
+    const jsonLog = output.logs.find((l) => l.startsWith('json:'));
+    expect(jsonLog).toBeDefined();
+    const parsed = JSON.parse(jsonLog!.slice('json:'.length));
+    expect(parsed.mode).toBe('direct');
+    expect(parsed.reviewers).toEqual([{ uuid: '{b}', displayName: 'Bob' }]);
   });
 });
 

--- a/tests/core/bootstrap.test.ts
+++ b/tests/core/bootstrap.test.ts
@@ -120,6 +120,92 @@ describe('bootstrap()', () => {
     expect((createPR as unknown as { output: unknown }).output).toBe(output);
   });
 
+  it('wires every command dependency to a container singleton', () => {
+    const container = bootstrap();
+    const commandTokens = Object.entries(ServiceTokens)
+      .filter(([key]) => key.endsWith('Command'))
+      .map(([, token]) => token);
+    const singletonValues = Object.values(ServiceTokens).map((token) =>
+      container.resolve(token)
+    );
+
+    for (const token of commandTokens) {
+      const command = container.resolve<Record<string, unknown>>(token);
+      for (const value of Object.values(command)) {
+        // Internal base-class state (commandPath, suppressNotFoundHint) is
+        // undefined/primitive; skip those. Every object-valued field must be
+        // one of the container's singletons — a missing or re-instantiated
+        // dependency would otherwise pass the resolve-not-throw check above.
+        if (
+          value === undefined ||
+          (typeof value !== 'object' && typeof value !== 'function')
+        ) {
+          continue;
+        }
+        expect(singletonValues.some((sv) => sv === value)).toBe(true);
+      }
+    }
+  });
+
+  it('matches constructor arity to the wired dependency count for every command', () => {
+    const container = bootstrap();
+    const commandTokens = Object.entries(ServiceTokens)
+      .filter(([key]) => key.endsWith('Command'))
+      .map(([, token]) => token);
+
+    for (const token of commandTokens) {
+      const command = container.resolve<Record<string, unknown>>(token);
+      const paramCount = (command.constructor as { length: number }).length;
+      const depCount = Object.values(command).filter(
+        (value) =>
+          (typeof value === 'object' || typeof value === 'function') &&
+          value !== null &&
+          value !== undefined
+      ).length;
+      expect(paramCount, `${token} ctor arity`).toBe(depCount);
+    }
+  });
+
+  it('wires the registerCommand-wired services in constructor order', () => {
+    const container = bootstrap();
+
+    const oauth = container.resolve<{
+      configService: unknown;
+      credentialStore: unknown;
+    }>(ServiceTokens.OAuthService);
+    expect(oauth.configService).toBe(
+      container.resolve(ServiceTokens.ConfigService)
+    );
+    expect(oauth.credentialStore).toBe(
+      container.resolve(ServiceTokens.CredentialStore)
+    );
+
+    const context = container.resolve<{
+      gitService: unknown;
+      configService: unknown;
+    }>(ServiceTokens.ContextService);
+    expect(context.gitService).toBe(
+      container.resolve(ServiceTokens.GitService)
+    );
+    expect(context.configService).toBe(
+      container.resolve(ServiceTokens.ConfigService)
+    );
+
+    const snippetFiles = container.resolve<{ axios: unknown }>(
+      ServiceTokens.SnippetFilesService
+    );
+    expect(snippetFiles.axios).toBe(
+      container.resolve(ServiceTokens.SharedApiAxios)
+    );
+
+    const defaultReviewer = container.resolve<{ pullrequestsApi: unknown }>(
+      ServiceTokens.DefaultReviewerService
+    );
+    expect(defaultReviewer.pullrequestsApi).toBe(
+      container.resolve(ServiceTokens.PullrequestsApi)
+    );
+  });
+
   it('constructs every generated API client on the single shared axios instance', () => {
     Container.reset();
     const container = bootstrap();
@@ -138,6 +224,11 @@ describe('bootstrap()', () => {
       ServiceTokens.UsersApi,
       ServiceTokens.CommitStatusesApi,
       ServiceTokens.SnippetsApi,
+      ServiceTokens.CommitsApi,
+      ServiceTokens.PipelinesApi,
+      ServiceTokens.IssueTrackerApi,
+      ServiceTokens.WorkspacesApi,
+      ServiceTokens.ProjectsApi,
     ];
     for (const token of generatedClientTokens) {
       const client = container.resolve<{ axios: AxiosInstance }>(token);

--- a/tests/core/bootstrap.test.ts
+++ b/tests/core/bootstrap.test.ts
@@ -6,10 +6,17 @@
  * runtime when a user invokes that command. These tests resolve every
  * registered token and verify each command can be instantiated, so a
  * broken wiring fails in CI instead of production.
+ *
+ * Positional dep wiring is pinned against the exported registration table:
+ * `deps.length` must equal the constructor's arity exactly. Note the table
+ * cannot catch a *swapped* pair of same-arity, same-shape deps (tokens are
+ * plain strings) — the named identity checks below close that hole for the
+ * non-trivial registerCommand-wired services, and the shared-axios test
+ * covers every generated client.
  */
 
 import { describe, it, expect } from 'bun:test';
-import { bootstrap } from '../../src/bootstrap.js';
+import { bootstrap, commandRegistrations } from '../../src/bootstrap.js';
 import { Container, ServiceTokens } from '../../src/core/container.js';
 import { BaseCommand } from '../../src/core/base-command.js';
 import { OutputService } from '../../src/services/output.service.js';
@@ -120,65 +127,25 @@ describe('bootstrap()', () => {
     expect((createPR as unknown as { output: unknown }).output).toBe(output);
   });
 
-  it('wires every command dependency to a container singleton', () => {
+  it('matches each registerCommand deps array to its constructor arity', () => {
     const container = bootstrap();
-    const commandTokens = Object.entries(ServiceTokens)
-      .filter(([key]) => key.endsWith('Command'))
-      .map(([, token]) => token);
-    const singletonValues = Object.values(ServiceTokens).map((token) =>
-      container.resolve(token)
-    );
 
-    for (const token of commandTokens) {
-      const command = container.resolve<Record<string, unknown>>(token);
-      for (const value of Object.values(command)) {
-        // Internal base-class state (commandPath, suppressNotFoundHint) is
-        // undefined/primitive; skip those. Every object-valued field must be
-        // one of the container's singletons — a missing or re-instantiated
-        // dependency would otherwise pass the resolve-not-throw check above.
-        if (
-          value === undefined ||
-          (typeof value !== 'object' && typeof value !== 'function')
-        ) {
-          continue;
-        }
-        expect(singletonValues.some((sv) => sv === value)).toBe(true);
+    for (const registration of commandRegistrations) {
+      const paramCount = (registration.ctor as { length: number }).length;
+      expect(
+        paramCount,
+        `${registration.token} deps length must equal constructor arity`
+      ).toBe(registration.deps.length);
+      for (const dep of registration.deps) {
+        expect(container.has(dep), `${registration.token} dep ${dep}`).toBe(
+          true
+        );
       }
-    }
-  });
-
-  it('matches constructor arity to the wired dependency count for every command', () => {
-    const container = bootstrap();
-    const commandTokens = Object.entries(ServiceTokens)
-      .filter(([key]) => key.endsWith('Command'))
-      .map(([, token]) => token);
-
-    for (const token of commandTokens) {
-      const command = container.resolve<Record<string, unknown>>(token);
-      const paramCount = (command.constructor as { length: number }).length;
-      const depCount = Object.values(command).filter(
-        (value) =>
-          (typeof value === 'object' || typeof value === 'function') &&
-          value !== null &&
-          value !== undefined
-      ).length;
-      expect(paramCount, `${token} ctor arity`).toBe(depCount);
     }
   });
 
   it('wires the registerCommand-wired services in constructor order', () => {
     const container = bootstrap();
-
-    const oauth = container.resolve<{
-      configService: unknown;
-      credentialStore: unknown;
-    }>(ServiceTokens.OAuthService);
-    expect(oauth.configService).toBe(
-      container.resolve(ServiceTokens.ConfigService)
-    );
-    expect(oauth.credentialStore).toBe(
-      container.resolve(ServiceTokens.CredentialStore)
-    );
 
     const context = container.resolve<{
       gitService: unknown;

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -6,6 +6,14 @@ for (const key of Object.keys(process.env)) {
   if (key.startsWith('BB_')) delete process.env[key];
 }
 
+// Test output must be terminal-independent (issue #269): chalk colorizes when
+// stdout is a TTY, so an interactive `bun test` would emit ANSI codes and
+// break string-exact assertions (e.g. the control-character sanitization
+// suite). Pin color off before any test file — and therefore before chalk is
+// first imported — loads.
+process.env.FORCE_COLOR = '0';
+process.env.NO_COLOR = '1';
+
 // Tests must never reach the real network (see issue #269): the CLI's
 // postAction hook polls registry.npmjs.org for update notices, and without a
 // guarantee that no test file triggers it, a local `bun test` on a TTY would

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -5,3 +5,32 @@
 for (const key of Object.keys(process.env)) {
   if (key.startsWith('BB_')) delete process.env[key];
 }
+
+// Tests must never reach the real network (see issue #269): the CLI's
+// postAction hook polls registry.npmjs.org for update notices, and without a
+// guarantee that no test file triggers it, a local `bun test` on a TTY would
+// hit the network (CI only avoids it accidentally via GITHUB_ACTIONS). Replace
+// global fetch with a guard that passes through localhost only — the OAuth
+// callback tests legitimately spin up a real loopback server — and fails
+// loudly on anything else. The guard is replaceable: tests that need to stub
+// fetch (version.service.test.ts, oauth.service.test.ts) assign their own
+// globalThis.fetch and restore this one afterwards.
+const realFetch = globalThis.fetch;
+
+globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  if (
+    url.startsWith('http://localhost:') ||
+    url.startsWith('http://127.0.0.1:')
+  ) {
+    return realFetch(input, init);
+  }
+  throw new Error(
+    `Refusing to reach the real network from tests (guarded by tests/preload.ts): ${url}`
+  );
+}) as typeof fetch;

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -17,6 +17,19 @@ for (const key of Object.keys(process.env)) {
 // globalThis.fetch and restore this one afterwards.
 const realFetch = globalThis.fetch;
 
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')
+    );
+  } catch {
+    // Malformed URLs never reach the network anyway — fail loudly instead.
+    return false;
+  }
+}
+
 globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
   const url =
     typeof input === 'string'
@@ -24,10 +37,7 @@ globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
       : input instanceof URL
         ? input.href
         : input.url;
-  if (
-    url.startsWith('http://localhost:') ||
-    url.startsWith('http://127.0.0.1:')
-  ) {
+  if (isLocalhostUrl(url)) {
     return realFetch(input, init);
   }
   throw new Error(

--- a/tests/services/default-reviewer.service.test.ts
+++ b/tests/services/default-reviewer.service.test.ts
@@ -30,14 +30,24 @@ interface MockOptions {
   throwOnDelete?: boolean;
   onPut?: (username: string) => void;
   onDelete?: (username: string) => void;
+  onEffectiveRequest?: (axiosOpts?: {
+    params?: { page?: number; pagelen?: number };
+  }) => void;
+  onDirectRequest?: (axiosOpts?: {
+    params?: { page?: number; pagelen?: number };
+  }) => void;
+  onPutRequest?: (axiosOpts?: { data?: unknown }) => void;
+  valuesAsArrays?: boolean;
 }
 
 function createMockApi(options: MockOptions = {}): PullrequestsApi {
   const paginate = <T>(
     pages: T[][] | undefined,
-    page: number
-  ): { values: Set<T>; next?: string; page: number } => {
-    const values = new Set<T>(pages?.[page - 1] ?? []);
+    page: number,
+    valuesAsArrays: boolean
+  ): { values: Set<T> | T[]; next?: string; page: number } => {
+    const pageValues = pages?.[page - 1] ?? [];
+    const values = valuesAsArrays ? [...pageValues] : new Set<T>(pageValues);
     const hasNext = !!pages && page < pages.length;
     return {
       values,
@@ -52,7 +62,12 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
       axiosOpts?: { params?: { page?: number; pagelen?: number } }
     ) {
       const page = axiosOpts?.params?.page ?? 1;
-      const paginated = paginate(options.effectivePages, page);
+      const paginated = paginate(
+        options.effectivePages,
+        page,
+        options.valuesAsArrays ?? false
+      );
+      options.onEffectiveRequest?.(axiosOpts);
       return axiosOk({
         size: (options.effectivePages ?? []).flat().length,
         page: paginated.page,
@@ -66,7 +81,12 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
       axiosOpts?: { params?: { page?: number; pagelen?: number } }
     ) {
       const page = axiosOpts?.params?.page ?? 1;
-      const paginated = paginate(options.directPages, page);
+      const paginated = paginate(
+        options.directPages,
+        page,
+        options.valuesAsArrays ?? false
+      );
+      options.onDirectRequest?.(axiosOpts);
       return axiosOk({
         size: (options.directPages ?? []).flat().length,
         page: paginated.page,
@@ -75,15 +95,19 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
         values: paginated.values,
       } as PaginatedAccounts);
     },
-    async repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(params: {
-      workspace: string;
-      repoSlug: string;
-      targetUsername: string;
-    }) {
+    async repositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(
+      params: {
+        workspace: string;
+        repoSlug: string;
+        targetUsername: string;
+      },
+      axiosOpts?: { data?: unknown }
+    ) {
       if (options.throwOnPut) {
         throw new Error('forbidden');
       }
       options.onPut?.(params.targetUsername);
+      options.onPutRequest?.(axiosOpts);
       return axiosOk<Account>({
         type: 'user',
         uuid: `{${params.targetUsername}-uuid}`,
@@ -109,6 +133,28 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
 const repo = { workspace: 'ws', repoSlug: 'repo' };
 
 describe('DefaultReviewerService', () => {
+  it('defaults to the effective mode when no mode is passed', async () => {
+    const api = createMockApi({
+      effectivePages: [
+        [
+          {
+            type: 'default_reviewer_and_type',
+            reviewer_type: 'repository',
+            user: {
+              type: 'user',
+              uuid: '{a-uuid}',
+            } as DefaultReviewerAndType['user'],
+          },
+        ],
+      ],
+    });
+    const service = new DefaultReviewerService(api);
+
+    const result = await service.list(repo);
+
+    expect(result).toHaveLength(1);
+  });
+
   describe('list (effective)', () => {
     it('returns entries with reviewer_type and walks pagination', async () => {
       const api = createMockApi({
@@ -152,6 +198,101 @@ describe('DefaultReviewerService', () => {
         reviewerType: 'repository',
       });
       expect(result[1]?.reviewerType).toBe('project');
+    });
+
+    it('surfaces both repository and project reviewer types from a single page', async () => {
+      const api = createMockApi({
+        effectivePages: [
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'repository',
+              user: {
+                type: 'user',
+                uuid: '{a-uuid}',
+              } as DefaultReviewerAndType['user'],
+            },
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'project',
+              user: {
+                type: 'user',
+                uuid: '{b-uuid}',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+        ],
+      });
+      const service = new DefaultReviewerService(api);
+
+      const result = await service.list(repo, 'effective');
+
+      expect(result.map((entry) => entry.reviewerType)).toEqual([
+        'repository',
+        'project',
+      ]);
+    });
+
+    it('normalizes Array-shaped values from the API', async () => {
+      const api = createMockApi({
+        effectivePages: [
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'project',
+              user: {
+                type: 'user',
+                uuid: '{a-uuid}',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+        ],
+        valuesAsArrays: true,
+      });
+      const service = new DefaultReviewerService(api);
+
+      const result = await service.list(repo, 'effective');
+
+      expect(result.map((entry) => entry.uuid)).toEqual(['{a-uuid}']);
+    });
+
+    it('walks pagination with the API-max pagelen (clamped from LIST_LIMIT)', async () => {
+      const requestedPagelens: Array<number | undefined> = [];
+      const api = createMockApi({
+        effectivePages: [
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'repository',
+              user: {
+                type: 'user',
+                uuid: '{a-uuid}',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+          [
+            {
+              type: 'default_reviewer_and_type',
+              reviewer_type: 'repository',
+              user: {
+                type: 'user',
+                uuid: '{b-uuid}',
+              } as DefaultReviewerAndType['user'],
+            },
+          ],
+        ],
+        onEffectiveRequest: (axiosOpts) => {
+          requestedPagelens.push(axiosOpts?.params?.pagelen);
+        },
+      });
+      const service = new DefaultReviewerService(api);
+
+      await service.list(repo, 'effective');
+
+      expect(requestedPagelens.length).toBeGreaterThan(1);
+      for (const pagelen of requestedPagelens) {
+        expect(pagelen).toBe(50);
+      }
     });
 
     it('returns an empty array when the list is empty', async () => {
@@ -219,6 +360,27 @@ describe('DefaultReviewerService', () => {
       expect(entry.uuid).toBe('{alice-uuid}');
       expect(entry.displayName).toBe('Display alice');
     });
+
+    it('sends an empty JSON body ({}) so Bitbucket does not 400', async () => {
+      let putBody: unknown = 'not-called';
+      const api = createMockApi({
+        onPutRequest: (axiosOpts) => {
+          putBody = axiosOpts?.data;
+        },
+      });
+      const service = new DefaultReviewerService(api);
+
+      await service.add(repo, 'alice');
+
+      expect(putBody).toEqual({});
+    });
+
+    it('propagates API errors from PUT', async () => {
+      const api = createMockApi({ throwOnPut: true });
+      const service = new DefaultReviewerService(api);
+
+      await expect(service.add(repo, 'alice')).rejects.toThrow('forbidden');
+    });
   });
 
   describe('remove', () => {
@@ -229,6 +391,13 @@ describe('DefaultReviewerService', () => {
 
       await service.remove(repo, 'alice');
       expect(seen).toBe('alice');
+    });
+
+    it('propagates API errors from DELETE', async () => {
+      const api = createMockApi({ throwOnDelete: true });
+      const service = new DefaultReviewerService(api);
+
+      await expect(service.remove(repo, 'alice')).rejects.toThrow('forbidden');
     });
   });
 });

--- a/tests/services/default-reviewer.service.test.ts
+++ b/tests/services/default-reviewer.service.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'bun:test';
 import type { AxiosResponse } from 'axios';
 import { DefaultReviewerService } from '../../src/services/default-reviewer.service.js';
+import { MAX_PAGE_LENGTH } from '../../src/services/pagination.js';
 import type {
   Account,
   DefaultReviewerAndType,
@@ -23,6 +24,19 @@ function axiosOk<T>(data: T): AxiosResponse<T> {
   };
 }
 
+/** One effective-default-reviewer entry with a full-typed user. */
+function makeEntry(
+  uuid: string | undefined,
+  reviewerType: 'repository' | 'project',
+  user: Partial<DefaultReviewerAndType['user']> = {}
+): DefaultReviewerAndType {
+  return {
+    type: 'default_reviewer_and_type',
+    reviewer_type: reviewerType,
+    user: { type: 'user', uuid, ...user },
+  };
+}
+
 interface MockOptions {
   effectivePages?: DefaultReviewerAndType[][];
   directPages?: Account[][];
@@ -37,17 +51,14 @@ interface MockOptions {
     params?: { page?: number; pagelen?: number };
   }) => void;
   onPutRequest?: (axiosOpts?: { data?: unknown }) => void;
-  valuesAsArrays?: boolean;
 }
 
 function createMockApi(options: MockOptions = {}): PullrequestsApi {
   const paginate = <T>(
     pages: T[][] | undefined,
-    page: number,
-    valuesAsArrays: boolean
-  ): { values: Set<T> | T[]; next?: string; page: number } => {
-    const pageValues = pages?.[page - 1] ?? [];
-    const values = valuesAsArrays ? [...pageValues] : new Set<T>(pageValues);
+    page: number
+  ): { values: Set<T>; next?: string; page: number } => {
+    const values = new Set<T>(pages?.[page - 1] ?? []);
     const hasNext = !!pages && page < pages.length;
     return {
       values,
@@ -62,11 +73,7 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
       axiosOpts?: { params?: { page?: number; pagelen?: number } }
     ) {
       const page = axiosOpts?.params?.page ?? 1;
-      const paginated = paginate(
-        options.effectivePages,
-        page,
-        options.valuesAsArrays ?? false
-      );
+      const paginated = paginate(options.effectivePages, page);
       options.onEffectiveRequest?.(axiosOpts);
       return axiosOk({
         size: (options.effectivePages ?? []).flat().length,
@@ -81,11 +88,7 @@ function createMockApi(options: MockOptions = {}): PullrequestsApi {
       axiosOpts?: { params?: { page?: number; pagelen?: number } }
     ) {
       const page = axiosOpts?.params?.page ?? 1;
-      const paginated = paginate(
-        options.directPages,
-        page,
-        options.valuesAsArrays ?? false
-      );
+      const paginated = paginate(options.directPages, page);
       options.onDirectRequest?.(axiosOpts);
       return axiosOk({
         size: (options.directPages ?? []).flat().length,
@@ -135,18 +138,7 @@ const repo = { workspace: 'ws', repoSlug: 'repo' };
 describe('DefaultReviewerService', () => {
   it('defaults to the effective mode when no mode is passed', async () => {
     const api = createMockApi({
-      effectivePages: [
-        [
-          {
-            type: 'default_reviewer_and_type',
-            reviewer_type: 'repository',
-            user: {
-              type: 'user',
-              uuid: '{a-uuid}',
-            } as DefaultReviewerAndType['user'],
-          },
-        ],
-      ],
+      effectivePages: [[makeEntry('{a-uuid}', 'repository')]],
     });
     const service = new DefaultReviewerService(api);
 
@@ -160,29 +152,13 @@ describe('DefaultReviewerService', () => {
       const api = createMockApi({
         effectivePages: [
           [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'repository',
-              user: {
-                type: 'user',
-                uuid: '{a-uuid}',
-                display_name: 'Alice',
-                account_id: 'alice-id',
-                nickname: 'alice',
-              } as DefaultReviewerAndType['user'],
-            },
+            makeEntry('{a-uuid}', 'repository', {
+              display_name: 'Alice',
+              account_id: 'alice-id',
+              nickname: 'alice',
+            }),
           ],
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'project',
-              user: {
-                type: 'user',
-                uuid: '{b-uuid}',
-                display_name: 'Bob',
-              } as DefaultReviewerAndType['user'],
-            },
-          ],
+          [makeEntry('{b-uuid}', 'project', { display_name: 'Bob' })],
         ],
       });
 
@@ -200,86 +176,12 @@ describe('DefaultReviewerService', () => {
       expect(result[1]?.reviewerType).toBe('project');
     });
 
-    it('surfaces both repository and project reviewer types from a single page', async () => {
-      const api = createMockApi({
-        effectivePages: [
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'repository',
-              user: {
-                type: 'user',
-                uuid: '{a-uuid}',
-              } as DefaultReviewerAndType['user'],
-            },
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'project',
-              user: {
-                type: 'user',
-                uuid: '{b-uuid}',
-              } as DefaultReviewerAndType['user'],
-            },
-          ],
-        ],
-      });
-      const service = new DefaultReviewerService(api);
-
-      const result = await service.list(repo, 'effective');
-
-      expect(result.map((entry) => entry.reviewerType)).toEqual([
-        'repository',
-        'project',
-      ]);
-    });
-
-    it('normalizes Array-shaped values from the API', async () => {
-      const api = createMockApi({
-        effectivePages: [
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'project',
-              user: {
-                type: 'user',
-                uuid: '{a-uuid}',
-              } as DefaultReviewerAndType['user'],
-            },
-          ],
-        ],
-        valuesAsArrays: true,
-      });
-      const service = new DefaultReviewerService(api);
-
-      const result = await service.list(repo, 'effective');
-
-      expect(result.map((entry) => entry.uuid)).toEqual(['{a-uuid}']);
-    });
-
-    it('walks pagination with the API-max pagelen (clamped from LIST_LIMIT)', async () => {
+    it('uses the API-max pagelen on every page', async () => {
       const requestedPagelens: Array<number | undefined> = [];
       const api = createMockApi({
         effectivePages: [
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'repository',
-              user: {
-                type: 'user',
-                uuid: '{a-uuid}',
-              } as DefaultReviewerAndType['user'],
-            },
-          ],
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'repository',
-              user: {
-                type: 'user',
-                uuid: '{b-uuid}',
-              } as DefaultReviewerAndType['user'],
-            },
-          ],
+          [makeEntry('{a-uuid}', 'repository')],
+          [makeEntry('{b-uuid}', 'repository')],
         ],
         onEffectiveRequest: (axiosOpts) => {
           requestedPagelens.push(axiosOpts?.params?.pagelen);
@@ -289,10 +191,7 @@ describe('DefaultReviewerService', () => {
 
       await service.list(repo, 'effective');
 
-      expect(requestedPagelens.length).toBeGreaterThan(1);
-      for (const pagelen of requestedPagelens) {
-        expect(pagelen).toBe(50);
-      }
+      expect(requestedPagelens).toEqual([MAX_PAGE_LENGTH, MAX_PAGE_LENGTH]);
     });
 
     it('returns an empty array when the list is empty', async () => {
@@ -304,15 +203,7 @@ describe('DefaultReviewerService', () => {
 
     it('skips entries without a user uuid', async () => {
       const api = createMockApi({
-        effectivePages: [
-          [
-            {
-              type: 'default_reviewer_and_type',
-              reviewer_type: 'repository',
-              user: { type: 'user' } as DefaultReviewerAndType['user'],
-            },
-          ],
-        ],
+        effectivePages: [[makeEntry(undefined, 'repository')]],
       });
       const service = new DefaultReviewerService(api);
       const result = await service.list(repo, 'effective');
@@ -345,6 +236,21 @@ describe('DefaultReviewerService', () => {
           nickname: undefined,
         },
       ]);
+    });
+
+    it('uses the API-max pagelen on every page', async () => {
+      const requestedPagelens: Array<number | undefined> = [];
+      const api = createMockApi({
+        directPages: [[{ type: 'user', uuid: '{c-uuid}' } as Account]],
+        onDirectRequest: (axiosOpts) => {
+          requestedPagelens.push(axiosOpts?.params?.pagelen);
+        },
+      });
+      const service = new DefaultReviewerService(api);
+
+      await service.list(repo, 'direct');
+
+      expect(requestedPagelens).toEqual([MAX_PAGE_LENGTH]);
     });
   });
 

--- a/tests/services/git.service.test.ts
+++ b/tests/services/git.service.test.ts
@@ -8,6 +8,11 @@
  * - GIT_CONFIG_NOSYSTEM + system/global config pointed at an isolated file
  *   that pins `init.defaultBranch = main`,
  * - an isolated HOME, and fixed author/committer identities.
+ *
+ * The environment is injected explicitly everywhere: Bun.spawn does not
+ * inherit `process.env` mutations made at runtime on this Bun version, so
+ * the production GitService gets it via its constructor options and the
+ * setup spawns pass it directly. Setting process.env would be inert.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -17,23 +22,6 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const GIT_ENV_KEYS = [
-  'HOME',
-  'GIT_CONFIG_NOSYSTEM',
-  'GIT_CONFIG_GLOBAL',
-  'GIT_CONFIG_SYSTEM',
-  'GIT_AUTHOR_NAME',
-  'GIT_AUTHOR_EMAIL',
-  'GIT_COMMITTER_NAME',
-  'GIT_COMMITTER_EMAIL',
-  'GIT_TERMINAL_PROMPT',
-] as const;
-
-const originalEnv: Record<string, string | undefined> = {};
-for (const key of GIT_ENV_KEYS) {
-  originalEnv[key] = process.env[key];
-}
-
 const HERMETIC_GLOBAL_CONFIG = `[init]
     defaultBranch = main
 [user]
@@ -41,79 +29,85 @@ const HERMETIC_GLOBAL_CONFIG = `[init]
     email = test@test.com
 `;
 
-/**
- * Spawn git with the hermetic environment, asserting a clean exit. `env` is
- * passed explicitly because Bun.spawn does not inherit `process.env`
- * mutations made at runtime on this Bun version.
- */
+function hermeticEnv(home: string): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? '',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: join(home, '.gitconfig'),
+    GIT_CONFIG_SYSTEM: join(home, 'system-gitconfig'),
+    HOME: home,
+    GIT_AUTHOR_NAME: 'Test Author',
+    GIT_AUTHOR_EMAIL: 'test@test.com',
+    GIT_COMMITTER_NAME: 'Test Committer',
+    GIT_COMMITTER_EMAIL: 'test@test.com',
+    GIT_TERMINAL_PROMPT: '0',
+  };
+}
+
+/** Spawn git with the hermetic environment, asserting a clean exit. */
+async function git(
+  args: string[],
+  cwd: string,
+  env: Record<string, string>
+): Promise<void> {
+  const proc = Bun.spawn(['git', ...args], {
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const exited = await proc.exited;
+  if (exited !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`git ${args.join(' ')} failed (${exited}): ${stderr}`);
+  }
+}
+
+/** Spawn git and return its trimmed stdout, asserting a clean exit. */
+async function gitOut(
+  args: string[],
+  cwd: string,
+  env: Record<string, string>
+): Promise<string> {
+  const proc = Bun.spawn(['git', ...args], {
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const exited = await proc.exited;
+  if (exited !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`git ${args.join(' ')} failed (${exited}): ${stderr}`);
+  }
+  return stdout.trim();
+}
+
 describe('GitService', () => {
   let testDir: string;
   let hermeticHome: string;
+  let env: Record<string, string>;
   let gitService: GitService;
-
-  function hermeticEnv(): Record<string, string> {
-    return {
-      GIT_CONFIG_NOSYSTEM: '1',
-      GIT_CONFIG_GLOBAL: join(hermeticHome, '.gitconfig'),
-      GIT_CONFIG_SYSTEM: join(hermeticHome, 'system-gitconfig'),
-      HOME: hermeticHome,
-      GIT_AUTHOR_NAME: 'Test Author',
-      GIT_AUTHOR_EMAIL: 'test@test.com',
-      GIT_COMMITTER_NAME: 'Test Committer',
-      GIT_COMMITTER_EMAIL: 'test@test.com',
-      GIT_TERMINAL_PROMPT: '0',
-    };
-  }
-
-  async function git(args: string[], cwd: string): Promise<void> {
-    const proc = Bun.spawn(['git', ...args], {
-      cwd,
-      env: hermeticEnv(),
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const exited = await proc.exited;
-    if (exited !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`git ${args.join(' ')} failed (${exited}): ${stderr}`);
-    }
-  }
 
   /** Init a repo in `cwd` with a first commit, using the hermetic identity. */
   async function initRepoWithCommit(cwd: string): Promise<void> {
-    await git(['init'], cwd);
+    await git(['init'], cwd, env);
     await writeFile(join(cwd, 'test.txt'), 'test');
-    await git(['add', '.'], cwd);
-    await git(['commit', '-m', 'Initial'], cwd);
+    await git(['add', '.'], cwd, env);
+    await git(['commit', '-m', 'Initial'], cwd, env);
   }
 
   beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'bb-git-test-'));
     hermeticHome = await mkdtemp(join(tmpdir(), 'bb-git-home-'));
+    env = hermeticEnv(hermeticHome);
+    await writeFile(env.GIT_CONFIG_GLOBAL, HERMETIC_GLOBAL_CONFIG);
 
-    process.env.GIT_CONFIG_NOSYSTEM = '1';
-    process.env.GIT_CONFIG_GLOBAL = join(hermeticHome, '.gitconfig');
-    process.env.GIT_CONFIG_SYSTEM = join(hermeticHome, 'system-gitconfig');
-    process.env.HOME = hermeticHome;
-    process.env.GIT_AUTHOR_NAME = 'Test Author';
-    process.env.GIT_AUTHOR_EMAIL = 'test@test.com';
-    process.env.GIT_COMMITTER_NAME = 'Test Committer';
-    process.env.GIT_COMMITTER_EMAIL = 'test@test.com';
-    process.env.GIT_TERMINAL_PROMPT = '0';
-    await writeFile(process.env.GIT_CONFIG_GLOBAL, HERMETIC_GLOBAL_CONFIG);
-
-    gitService = new GitService(testDir);
+    gitService = new GitService(testDir, { env });
   });
 
   afterEach(async () => {
-    for (const key of GIT_ENV_KEYS) {
-      const original = originalEnv[key];
-      if (original === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = original;
-      }
-    }
     try {
       await rm(testDir, { recursive: true, force: true });
       await rm(hermeticHome, { recursive: true, force: true });
@@ -130,7 +124,7 @@ describe('GitService', () => {
     });
 
     it('should return true for git directory', async () => {
-      await git(['init'], testDir);
+      await git(['init'], testDir, env);
 
       const result = await gitService.isRepository();
 
@@ -173,7 +167,7 @@ describe('GitService', () => {
 
   describe('getRemoteUrl', () => {
     it('should throw error when no remote exists', async () => {
-      await git(['init'], testDir);
+      await git(['init'], testDir, env);
 
       await expect(gitService.getRemoteUrl('origin')).rejects.toMatchObject({
         code: ErrorCode.GIT_REMOTE_NOT_FOUND,
@@ -181,10 +175,11 @@ describe('GitService', () => {
     });
 
     it('should return remote URL when exists', async () => {
-      await git(['init'], testDir);
+      await git(['init'], testDir, env);
       await git(
         ['remote', 'add', 'origin', 'git@bitbucket.org:workspace/repo.git'],
-        testDir
+        testDir,
+        env
       );
 
       const url = await gitService.getRemoteUrl('origin');
@@ -193,10 +188,11 @@ describe('GitService', () => {
     });
 
     it('should support different remote names', async () => {
-      await git(['init'], testDir);
+      await git(['init'], testDir, env);
       await git(
         ['remote', 'add', 'upstream', 'https://bitbucket.org/other/repo.git'],
-        testDir
+        testDir,
+        env
       );
 
       const url = await gitService.getRemoteUrl('upstream');
@@ -208,7 +204,7 @@ describe('GitService', () => {
   describe('checkout', () => {
     it('should checkout existing branch', async () => {
       await initRepoWithCommit(testDir);
-      await git(['branch', 'feature'], testDir);
+      await git(['branch', 'feature'], testDir, env);
 
       await gitService.checkout('feature');
 
@@ -236,13 +232,7 @@ describe('GitService', () => {
     it('should create branch from specific start point', async () => {
       await initRepoWithCommit(testDir);
 
-      // Get current commit hash
-      const proc = Bun.spawn(['git', 'rev-parse', 'HEAD'], {
-        cwd: testDir,
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-      const commitHash = (await new Response(proc.stdout).text()).trim();
+      const commitHash = await gitOut(['rev-parse', 'HEAD'], testDir, env);
 
       await gitService.checkoutNewBranch('from-commit', commitHash);
 
@@ -252,7 +242,7 @@ describe('GitService', () => {
 
     it('should fail if branch already exists', async () => {
       await initRepoWithCommit(testDir);
-      await git(['branch', 'existing'], testDir);
+      await git(['branch', 'existing'], testDir, env);
 
       await expect(
         gitService.checkoutNewBranch('existing')
@@ -262,7 +252,7 @@ describe('GitService', () => {
 
   describe('fetch', () => {
     it('should throw error when no remote exists', async () => {
-      await git(['init'], testDir);
+      await git(['init'], testDir, env);
 
       await expect(gitService.fetch('origin')).rejects.toBeDefined();
     });
@@ -272,26 +262,26 @@ describe('GitService', () => {
     it('should clone repository', async () => {
       // Create a bare repo to clone from
       const bareDir = join(testDir, 'bare.git');
-      await git(['init', '--bare', bareDir], testDir);
+      await git(['init', '--bare', bareDir], testDir, env);
 
       const cloneDir = join(testDir, 'cloned');
       await gitService.clone(bareDir, cloneDir);
 
       // Verify the clone worked by checking if it's a git repo
-      const clonedGitService = new GitService(cloneDir);
+      const clonedGitService = new GitService(cloneDir, { env });
       const isRepo = await clonedGitService.isRepository();
       expect(isRepo).toBe(true);
     });
 
     it('should handle clone with destination directory', async () => {
       const bareDir = join(testDir, 'bare2.git');
-      await git(['init', '--bare', bareDir], testDir);
+      await git(['init', '--bare', bareDir], testDir, env);
 
       const cloneDir = join(testDir, 'cloned-with-dest');
       await gitService.clone(bareDir, cloneDir);
 
       // Verify the clone worked
-      const clonedGitService = new GitService(cloneDir);
+      const clonedGitService = new GitService(cloneDir, { env });
       const isRepo = await clonedGitService.isRepository();
       expect(isRepo).toBe(true);
     });
@@ -301,7 +291,7 @@ describe('GitService', () => {
     it('should create new instance with different cwd', async () => {
       const otherDir = join(testDir, 'other');
       await mkdir(otherDir, { recursive: true });
-      await git(['init'], otherDir);
+      await git(['init'], otherDir, env);
 
       const otherService = gitService.withCwd(otherDir);
       const result = await otherService.isRepository();
@@ -312,7 +302,7 @@ describe('GitService', () => {
     it('should not affect original instance', async () => {
       const otherDir = join(testDir, 'other');
       await mkdir(otherDir, { recursive: true });
-      await git(['init'], otherDir);
+      await git(['init'], otherDir, env);
 
       gitService.withCwd(otherDir);
 

--- a/tests/services/git.service.test.ts
+++ b/tests/services/git.service.test.ts
@@ -1,26 +1,122 @@
 /**
  * GitService tests
+ *
+ * These tests spawn real `git` subprocesses. To stay hermetic and
+ * deterministic regardless of the developer's machine (issue #269), every
+ * spawn runs with:
+ * - a fresh temp directory (mkdtemp) as the working tree,
+ * - GIT_CONFIG_NOSYSTEM + system/global config pointed at an isolated file
+ *   that pins `init.defaultBranch = main`,
+ * - an isolated HOME, and fixed author/committer identities.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { GitService } from '../../src/services/git.service.js';
 import { ErrorCode } from '../../src/types/errors.js';
-import { mkdir, rm, writeFile } from 'fs/promises';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
+const GIT_ENV_KEYS = [
+  'HOME',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_SYSTEM',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+  'GIT_TERMINAL_PROMPT',
+] as const;
+
+const originalEnv: Record<string, string | undefined> = {};
+for (const key of GIT_ENV_KEYS) {
+  originalEnv[key] = process.env[key];
+}
+
+const HERMETIC_GLOBAL_CONFIG = `[init]
+    defaultBranch = main
+[user]
+    name = Test Author
+    email = test@test.com
+`;
+
+/**
+ * Spawn git with the hermetic environment, asserting a clean exit. `env` is
+ * passed explicitly because Bun.spawn does not inherit `process.env`
+ * mutations made at runtime on this Bun version.
+ */
 describe('GitService', () => {
-  const testDir = join(tmpdir(), `bb-git-test-${Date.now()}`);
+  let testDir: string;
+  let hermeticHome: string;
   let gitService: GitService;
 
+  function hermeticEnv(): Record<string, string> {
+    return {
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: join(hermeticHome, '.gitconfig'),
+      GIT_CONFIG_SYSTEM: join(hermeticHome, 'system-gitconfig'),
+      HOME: hermeticHome,
+      GIT_AUTHOR_NAME: 'Test Author',
+      GIT_AUTHOR_EMAIL: 'test@test.com',
+      GIT_COMMITTER_NAME: 'Test Committer',
+      GIT_COMMITTER_EMAIL: 'test@test.com',
+      GIT_TERMINAL_PROMPT: '0',
+    };
+  }
+
+  async function git(args: string[], cwd: string): Promise<void> {
+    const proc = Bun.spawn(['git', ...args], {
+      cwd,
+      env: hermeticEnv(),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const exited = await proc.exited;
+    if (exited !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`git ${args.join(' ')} failed (${exited}): ${stderr}`);
+    }
+  }
+
+  /** Init a repo in `cwd` with a first commit, using the hermetic identity. */
+  async function initRepoWithCommit(cwd: string): Promise<void> {
+    await git(['init'], cwd);
+    await writeFile(join(cwd, 'test.txt'), 'test');
+    await git(['add', '.'], cwd);
+    await git(['commit', '-m', 'Initial'], cwd);
+  }
+
   beforeEach(async () => {
-    await mkdir(testDir, { recursive: true });
+    testDir = await mkdtemp(join(tmpdir(), 'bb-git-test-'));
+    hermeticHome = await mkdtemp(join(tmpdir(), 'bb-git-home-'));
+
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
+    process.env.GIT_CONFIG_GLOBAL = join(hermeticHome, '.gitconfig');
+    process.env.GIT_CONFIG_SYSTEM = join(hermeticHome, 'system-gitconfig');
+    process.env.HOME = hermeticHome;
+    process.env.GIT_AUTHOR_NAME = 'Test Author';
+    process.env.GIT_AUTHOR_EMAIL = 'test@test.com';
+    process.env.GIT_COMMITTER_NAME = 'Test Committer';
+    process.env.GIT_COMMITTER_EMAIL = 'test@test.com';
+    process.env.GIT_TERMINAL_PROMPT = '0';
+    await writeFile(process.env.GIT_CONFIG_GLOBAL, HERMETIC_GLOBAL_CONFIG);
+
     gitService = new GitService(testDir);
   });
 
   afterEach(async () => {
+    for (const key of GIT_ENV_KEYS) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
     try {
       await rm(testDir, { recursive: true, force: true });
+      await rm(hermeticHome, { recursive: true, force: true });
     } catch {
       // Ignore cleanup errors
     }
@@ -34,9 +130,7 @@ describe('GitService', () => {
     });
 
     it('should return true for git directory', async () => {
-      // Initialize a git repo
-      const proc = Bun.spawn(['git', 'init'], { cwd: testDir });
-      await proc.exited;
+      await git(['init'], testDir);
 
       const result = await gitService.isRepository();
 
@@ -46,22 +140,12 @@ describe('GitService', () => {
 
   describe('getCurrentBranch', () => {
     it('should return current branch name', async () => {
-      // Initialize git repo with a commit
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
+      await initRepoWithCommit(testDir);
 
       const branch = await gitService.getCurrentBranch();
 
-      // Could be 'main' or 'master' depending on git config
-      expect(['main', 'master']).toContain(branch);
+      // Pinned via the hermetic global config — deterministic on all machines.
+      expect(branch).toBe('main');
     });
 
     it('should throw error for non-git directory', async () => {
@@ -73,16 +157,7 @@ describe('GitService', () => {
 
   describe('getCurrentCommit', () => {
     it('should return the current commit SHA', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
+      await initRepoWithCommit(testDir);
 
       const sha = await gitService.getCurrentCommit();
 
@@ -98,7 +173,7 @@ describe('GitService', () => {
 
   describe('getRemoteUrl', () => {
     it('should throw error when no remote exists', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
+      await git(['init'], testDir);
 
       await expect(gitService.getRemoteUrl('origin')).rejects.toMatchObject({
         code: ErrorCode.GIT_REMOTE_NOT_FOUND,
@@ -106,17 +181,11 @@ describe('GitService', () => {
     });
 
     it('should return remote URL when exists', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(
-        [
-          'git',
-          'remote',
-          'add',
-          'origin',
-          'git@bitbucket.org:workspace/repo.git',
-        ],
-        { cwd: testDir }
-      ).exited;
+      await git(['init'], testDir);
+      await git(
+        ['remote', 'add', 'origin', 'git@bitbucket.org:workspace/repo.git'],
+        testDir
+      );
 
       const url = await gitService.getRemoteUrl('origin');
 
@@ -124,17 +193,11 @@ describe('GitService', () => {
     });
 
     it('should support different remote names', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(
-        [
-          'git',
-          'remote',
-          'add',
-          'upstream',
-          'https://bitbucket.org/other/repo.git',
-        ],
-        { cwd: testDir }
-      ).exited;
+      await git(['init'], testDir);
+      await git(
+        ['remote', 'add', 'upstream', 'https://bitbucket.org/other/repo.git'],
+        testDir
+      );
 
       const url = await gitService.getRemoteUrl('upstream');
 
@@ -144,17 +207,8 @@ describe('GitService', () => {
 
   describe('checkout', () => {
     it('should checkout existing branch', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
-      await Bun.spawn(['git', 'branch', 'feature'], { cwd: testDir }).exited;
+      await initRepoWithCommit(testDir);
+      await git(['branch', 'feature'], testDir);
 
       await gitService.checkout('feature');
 
@@ -163,16 +217,7 @@ describe('GitService', () => {
     });
 
     it('should throw error for non-existent branch', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
+      await initRepoWithCommit(testDir);
 
       await expect(gitService.checkout('nonexistent')).rejects.toBeDefined();
     });
@@ -180,16 +225,7 @@ describe('GitService', () => {
 
   describe('checkoutNewBranch', () => {
     it('should create and checkout new branch', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
+      await initRepoWithCommit(testDir);
 
       await gitService.checkoutNewBranch('new-feature');
 
@@ -198,21 +234,13 @@ describe('GitService', () => {
     });
 
     it('should create branch from specific start point', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
+      await initRepoWithCommit(testDir);
 
       // Get current commit hash
       const proc = Bun.spawn(['git', 'rev-parse', 'HEAD'], {
         cwd: testDir,
         stdout: 'pipe',
+        stderr: 'pipe',
       });
       const commitHash = (await new Response(proc.stdout).text()).trim();
 
@@ -223,17 +251,8 @@ describe('GitService', () => {
     });
 
     it('should fail if branch already exists', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'config', 'user.email', 'test@test.com'], {
-        cwd: testDir,
-      }).exited;
-      await Bun.spawn(['git', 'config', 'user.name', 'Test'], { cwd: testDir })
-        .exited;
-      await writeFile(join(testDir, 'test.txt'), 'test');
-      await Bun.spawn(['git', 'add', '.'], { cwd: testDir }).exited;
-      await Bun.spawn(['git', 'commit', '-m', 'Initial'], { cwd: testDir })
-        .exited;
-      await Bun.spawn(['git', 'branch', 'existing'], { cwd: testDir }).exited;
+      await initRepoWithCommit(testDir);
+      await git(['branch', 'existing'], testDir);
 
       await expect(
         gitService.checkoutNewBranch('existing')
@@ -243,7 +262,7 @@ describe('GitService', () => {
 
   describe('fetch', () => {
     it('should throw error when no remote exists', async () => {
-      await Bun.spawn(['git', 'init'], { cwd: testDir }).exited;
+      await git(['init'], testDir);
 
       await expect(gitService.fetch('origin')).rejects.toBeDefined();
     });
@@ -253,7 +272,7 @@ describe('GitService', () => {
     it('should clone repository', async () => {
       // Create a bare repo to clone from
       const bareDir = join(testDir, 'bare.git');
-      await Bun.spawn(['git', 'init', '--bare', bareDir]).exited;
+      await git(['init', '--bare', bareDir], testDir);
 
       const cloneDir = join(testDir, 'cloned');
       await gitService.clone(bareDir, cloneDir);
@@ -266,7 +285,7 @@ describe('GitService', () => {
 
     it('should handle clone with destination directory', async () => {
       const bareDir = join(testDir, 'bare2.git');
-      await Bun.spawn(['git', 'init', '--bare', bareDir]).exited;
+      await git(['init', '--bare', bareDir], testDir);
 
       const cloneDir = join(testDir, 'cloned-with-dest');
       await gitService.clone(bareDir, cloneDir);
@@ -282,7 +301,7 @@ describe('GitService', () => {
     it('should create new instance with different cwd', async () => {
       const otherDir = join(testDir, 'other');
       await mkdir(otherDir, { recursive: true });
-      await Bun.spawn(['git', 'init'], { cwd: otherDir }).exited;
+      await git(['init'], otherDir);
 
       const otherService = gitService.withCwd(otherDir);
       const result = await otherService.isRepository();
@@ -293,7 +312,7 @@ describe('GitService', () => {
     it('should not affect original instance', async () => {
       const otherDir = join(testDir, 'other');
       await mkdir(otherDir, { recursive: true });
-      await Bun.spawn(['git', 'init'], { cwd: otherDir }).exited;
+      await git(['init'], otherDir);
 
       gitService.withCwd(otherDir);
 

--- a/tests/services/output.project.test.ts
+++ b/tests/services/output.project.test.ts
@@ -50,4 +50,45 @@ describe('projectFields', () => {
     );
     expect(result).toEqual({ tags: ['x', 'y'], meta: { ok: true } });
   });
+
+  it('traverses into arrays via numeric segments', () => {
+    const result = projectFields({ tags: ['x', 'y'] }, [
+      'tags.0',
+      'tags.length',
+    ]);
+    expect(result).toEqual({ 'tags.0': 'x', 'tags.length': 2 });
+  });
+
+  it('returns null when a numeric segment misses', () => {
+    const result = projectFields({ tags: ['x'] }, ['tags.1']);
+    expect(result).toEqual({ 'tags.1': null });
+  });
+
+  it('returns null for empty or duplicated dotted segments', () => {
+    const result = projectFields({ a: { b: 1 } }, ['a..b', '.a', 'a.', '']);
+    expect(result).toEqual({ 'a..b': null, '.a': null, 'a.': null, '': null });
+  });
+
+  it('maps an undefined leaf to null', () => {
+    const result = projectFields({ a: { b: undefined } }, ['a.b']);
+    expect(result).toEqual({ 'a.b': null });
+  });
+
+  it('keeps the last occurrence of a duplicated field', () => {
+    const result = projectFields({ a: 1 }, ['a', 'a']) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('treats a top-level array as a record of indexed segments', () => {
+    const result = projectFields(['x', 'y'], ['0', '1', '2']);
+    expect(result).toEqual({ 0: 'x', 1: 'y', 2: null });
+  });
+
+  it('returns booleans and undefined unchanged as non-object inputs', () => {
+    expect(projectFields(true, ['x'])).toBe(true);
+    expect(projectFields(undefined, ['x'])).toBeUndefined();
+  });
 });

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -137,6 +137,11 @@ describe('OutputService', () => {
       ['activities', 'pr activity'],
       ['statuses', 'pr checks'],
       ['files', 'pr diff --stat / --name-only'],
+      ['pipelines', 'pipeline list'],
+      ['commits', 'commit list'],
+      ['issues', 'issue list'],
+      ['workspaces', 'workspace list'],
+      ['projects', 'project list'],
       ['values', 'generic paginated payloads'],
     ])('drops the wrapper for the %s key (used by %s)', async (key) => {
       output.setJsonFormatOptions({ fields: ['id'] });
@@ -148,6 +153,26 @@ describe('OutputService', () => {
 
       const parsed = JSON.parse(consoleLogs[0]!);
       expect(parsed).toEqual([{ id: 99 }]);
+    });
+
+    it('returns an empty array for a known wrapper key holding an empty array', async () => {
+      output.setJsonFormatOptions({ fields: ['id'] });
+      await output.json({ workspace: 'ws', count: 0, pullRequests: [] });
+
+      const parsed = JSON.parse(consoleLogs[0]!);
+      expect(parsed).toEqual([]);
+    });
+
+    it('skips a known wrapper key that holds a non-array', async () => {
+      output.setJsonFormatOptions({ fields: ['workspace', 'count'] });
+      await output.json({
+        workspace: 'ws',
+        count: 1,
+        comments: { nested: 'object' },
+      });
+
+      const parsed = JSON.parse(consoleLogs[0]!);
+      expect(parsed).toEqual({ workspace: 'ws', count: 1 });
     });
   });
 

--- a/tests/services/output.service.test.ts
+++ b/tests/services/output.service.test.ts
@@ -163,16 +163,19 @@ describe('OutputService', () => {
       expect(parsed).toEqual([]);
     });
 
-    it('skips a known wrapper key that holds a non-array', async () => {
-      output.setJsonFormatOptions({ fields: ['workspace', 'count'] });
+    it('skips a known wrapper key that holds a non-array and keeps scanning', async () => {
+      output.setJsonFormatOptions({ fields: ['id'] });
       await output.json({
         workspace: 'ws',
         count: 1,
         comments: { nested: 'object' },
+        pullRequests: [{ id: 1, other: 'x' }],
       });
 
+      // A buggy implementation that stopped at the first non-array wrapper
+      // key would project the envelope instead; the later array key wins.
       const parsed = JSON.parse(consoleLogs[0]!);
-      expect(parsed).toEqual({ workspace: 'ws', count: 1 });
+      expect(parsed).toEqual([{ id: 1 }]);
     });
   });
 

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -96,6 +96,31 @@ describe('collectPages', () => {
     expect(result).toEqual([]);
   });
 
+  it('normalizes Set-valued pages (Bitbucket may return a Set)', async () => {
+    const result = await collectPages<number>({
+      limit: 10,
+      fetchPage: async () => ({ values: new Set([1, 2, 3]) }),
+    });
+
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('walks pagination across mixed Set/Array pages', async () => {
+    const pages: Array<PaginatedCollection<number>> = [
+      { values: new Set([1, 2]), next: 'page2' },
+      { values: [3, 4], next: 'page3' },
+      { values: new Set([5]) },
+    ];
+
+    const result = await collectPages<number>({
+      limit: 10,
+      pageSize: 2,
+      fetchPage: async (page) => pages[page - 1] ?? { values: [] },
+    });
+
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
   it('stops when next is a malformed URL without crashing', async () => {
     const pages: Array<PaginatedCollection<number>> = [
       { values: [1, 2], next: 'not-a-valid-url://???' },

--- a/tests/services/snippet-files.service.test.ts
+++ b/tests/services/snippet-files.service.test.ts
@@ -22,6 +22,12 @@ afterEach(() => {
   }
 });
 
+interface StubResponse {
+  status?: number;
+  statusText?: string;
+  data?: unknown;
+}
+
 interface CapturedRequest {
   url?: string;
   method?: string;
@@ -44,9 +50,27 @@ function createStubAxios(
       headers: (config.headers ?? {}) as Record<string, string>,
       responseType: config.responseType,
     });
-    const data = responses.shift() ?? { ok: true };
+    const entry = responses.shift();
+    const status = errorStatus(entry);
+    if (status !== undefined) {
+      throw new axios.AxiosError(
+        errorStatusText(entry) ?? `Request failed with status code ${status}`,
+        undefined,
+        config,
+        undefined,
+        {
+          data: (entry as StubResponse).data ?? {},
+          status,
+          statusText: errorStatusText(entry) ?? '',
+          headers: {},
+          config,
+        }
+      );
+    }
     return {
-      data,
+      data: isDataEntry(entry)
+        ? (entry as StubResponse).data
+        : (entry ?? { ok: true }),
       status: 200,
       statusText: 'OK',
       headers: {},
@@ -54,6 +78,32 @@ function createStubAxios(
     };
   };
   return instance;
+}
+
+function isErrorEntry(entry: unknown): entry is StubResponse {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    typeof (entry as StubResponse).status === 'number' &&
+    (entry as StubResponse).status >= 400
+  );
+}
+
+function errorStatus(entry: unknown): number | undefined {
+  return isErrorEntry(entry) ? (entry as StubResponse).status : undefined;
+}
+
+function errorStatusText(entry: unknown): string | undefined {
+  return isErrorEntry(entry) ? (entry as StubResponse).statusText : undefined;
+}
+
+function isDataEntry(entry: unknown): boolean {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    !isErrorEntry(entry) &&
+    'data' in (entry as Record<string, unknown>)
+  );
 }
 
 function writeTempFile(name: string, contents: string): string {
@@ -163,6 +213,95 @@ describe('SnippetFilesService', () => {
       const contents = await Promise.all(files.map((v) => (v as Blob).text()));
       expect(contents.sort()).toEqual(['AAA', 'BBB']);
     });
+
+    it('uses the filename override as the multipart part name', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('a.txt', 'contents');
+
+      await svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: true,
+        files: [{ path: filePath, filename: 'renamed.txt' }],
+      });
+
+      const form = captured[0].data as FormData;
+      const parts = form.getAll('file');
+      expect(parts).toHaveLength(1);
+      expect((parts[0] as File).name).toBe('renamed.txt');
+    });
+
+    it('defaults the part name to the file basename', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('base-name.txt', 'contents');
+
+      await svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: true,
+        files: [{ path: filePath }],
+      });
+
+      const form = captured[0].data as FormData;
+      const parts = form.getAll('file');
+      expect((parts[0] as File).name).toBe('base-name.txt');
+    });
+
+    it('sends a form without file parts when files is empty', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+
+      await svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: true,
+        files: [],
+      });
+
+      const flat = await formDataToString(captured[0].data);
+      expect(flat).toContain('title:t');
+      expect(flat).not.toContain('file:');
+    });
+
+    it('propagates API errors from the multipart POST', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [
+        { status: 500, statusText: 'Server Error' },
+      ]);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('a.txt', 'a');
+
+      await expect(
+        svc.createWithFiles({
+          workspace: 'ws',
+          title: 't',
+          isPrivate: true,
+          files: [{ path: filePath }],
+        })
+      ).rejects.toMatchObject({ response: { status: 500 } });
+    });
+
+    it('propagates a missing-file error from readFileSync', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const missingPath = path.join(os.tmpdir(), 'bb-missing', 'nope.txt');
+
+      await expect(
+        svc.createWithFiles({
+          workspace: 'ws',
+          title: 't',
+          isPrivate: true,
+          files: [{ path: missingPath }],
+        })
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(captured).toHaveLength(0);
+    });
   });
 
   describe('editMetadata', () => {
@@ -231,6 +370,41 @@ describe('SnippetFilesService', () => {
       expect(flat).toContain('title:T');
       expect(flat).toContain('file:blob(updated)');
     });
+
+    it('omits title and is_private parts when not provided', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('up.txt', 'updated');
+
+      await svc.editWithFiles({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        files: [{ path: filePath }],
+      });
+
+      const flat = await formDataToString(captured[0].data);
+      expect(flat).toContain('file:blob(updated)');
+      expect(flat).not.toContain('title:');
+      expect(flat).not.toContain('is_private:');
+    });
+
+    it('propagates API errors from the multipart PUT', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [
+        { status: 403, statusText: 'Forbidden' },
+      ]);
+      const svc = new SnippetFilesService(instance);
+      const filePath = writeTempFile('up.txt', 'updated');
+
+      await expect(
+        svc.editWithFiles({
+          workspace: 'ws',
+          encodedId: 'kypj',
+          files: [{ path: filePath }],
+        })
+      ).rejects.toMatchObject({ response: { status: 403 } });
+    });
   });
 
   describe('getFileContent', () => {
@@ -255,6 +429,28 @@ describe('SnippetFilesService', () => {
       expect(captured[0].url).toBe(
         '/snippets/ws/kypj/files/dir%20name/sub/f%20oo.txt'
       );
+    });
+
+    it('coerces non-string raw responses to strings', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [{ data: 12345 }]);
+      const svc = new SnippetFilesService(instance);
+
+      const result = await svc.getFileContent('ws', 'kypj', 'a.txt');
+
+      expect(result).toBe('12345');
+    });
+
+    it('propagates 404 errors from the raw-file fetch', async () => {
+      const captured: CapturedRequest[] = [];
+      const instance = createStubAxios(captured, [
+        { status: 404, statusText: 'Not Found' },
+      ]);
+      const svc = new SnippetFilesService(instance);
+
+      await expect(
+        svc.getFileContent('ws', 'kypj', 'missing.txt')
+      ).rejects.toMatchObject({ response: { status: 404 } });
     });
   });
 });

--- a/tests/services/snippet-files.service.test.ts
+++ b/tests/services/snippet-files.service.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
   }
 });
 
+/** A queued adapter response: either a raw payload or a {status, ...} error. */
 interface StubResponse {
   status?: number;
   statusText?: string;
@@ -34,6 +35,22 @@ interface CapturedRequest {
   data?: unknown;
   headers?: Record<string, string>;
   responseType?: string;
+}
+
+/** Normalize one queued entry into a {data, status, statusText} result. */
+function toResponse(entry: unknown): {
+  data: unknown;
+  status: number;
+  statusText: string;
+} {
+  if (typeof entry === 'object' && entry !== null) {
+    const { status, statusText, data } = entry as StubResponse;
+    if (status !== undefined) {
+      return { data: data ?? {}, status, statusText: statusText ?? '' };
+    }
+    return { data: data ?? entry, status: 200, statusText: 'OK' };
+  }
+  return { data: entry ?? { ok: true }, status: 200, statusText: 'OK' };
 }
 
 function createStubAxios(
@@ -50,60 +67,40 @@ function createStubAxios(
       headers: (config.headers ?? {}) as Record<string, string>,
       responseType: config.responseType,
     });
-    const entry = responses.shift();
-    const status = errorStatus(entry);
-    if (status !== undefined) {
+    const { data, status, statusText } = toResponse(responses.shift());
+    if (status >= 400) {
       throw new axios.AxiosError(
-        errorStatusText(entry) ?? `Request failed with status code ${status}`,
+        statusText || `Request failed with status code ${status}`,
         undefined,
         config,
         undefined,
-        {
-          data: (entry as StubResponse).data ?? {},
-          status,
-          statusText: errorStatusText(entry) ?? '',
-          headers: {},
-          config,
-        }
+        { data, status, statusText, headers: {}, config }
       );
     }
-    return {
-      data: isDataEntry(entry)
-        ? (entry as StubResponse).data
-        : (entry ?? { ok: true }),
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config,
-    };
+    return { data, status, statusText, headers: {}, config };
   };
   return instance;
 }
 
-function isErrorEntry(entry: unknown): entry is StubResponse {
-  return (
-    typeof entry === 'object' &&
-    entry !== null &&
-    typeof (entry as StubResponse).status === 'number' &&
-    (entry as StubResponse).status >= 400
-  );
+/** Service wired to a stub adapter, with the captured request log. */
+function makeService(responses: unknown[] = []): {
+  svc: SnippetFilesService;
+  captured: CapturedRequest[];
+} {
+  const captured: CapturedRequest[] = [];
+  return {
+    svc: new SnippetFilesService(createStubAxios(captured, responses)),
+    captured,
+  };
 }
 
-function errorStatus(entry: unknown): number | undefined {
-  return isErrorEntry(entry) ? (entry as StubResponse).status : undefined;
-}
-
-function errorStatusText(entry: unknown): string | undefined {
-  return isErrorEntry(entry) ? (entry as StubResponse).statusText : undefined;
-}
-
-function isDataEntry(entry: unknown): boolean {
-  return (
-    typeof entry === 'object' &&
-    entry !== null &&
-    !isErrorEntry(entry) &&
-    'data' in (entry as Record<string, unknown>)
-  );
+/** The first 'file' part of a multipart form, as a real File. */
+function filePart(form: FormData, index = 0): File {
+  const part = form.getAll('file')[index];
+  if (typeof part === 'string') {
+    throw new Error('expected a binary file part');
+  }
+  return part;
 }
 
 function writeTempFile(name: string, contents: string): string {
@@ -133,10 +130,7 @@ async function formDataToString(data: unknown): Promise<string> {
 describe('SnippetFilesService', () => {
   describe('createWithFiles', () => {
     it('POSTs multipart/form-data with title, is_private and file parts', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [{ id: 'abc' }]);
-      const svc = new SnippetFilesService(instance);
-
+      const { svc, captured } = makeService([{ id: 'abc' }]);
       const filePath = writeTempFile('hello.txt', 'hello world');
 
       const result = await svc.createWithFiles({
@@ -161,9 +155,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('URL-encodes workspace slug', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('a.txt', 'a');
 
       await svc.createWithFiles({
@@ -177,9 +169,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('sends is_private=false for public snippets', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('a.txt', 'a');
 
       await svc.createWithFiles({
@@ -194,9 +184,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('includes multiple files as separate parts', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const f1 = writeTempFile('one.txt', 'AAA');
       const f2 = writeTempFile('two.txt', 'BBB');
 
@@ -215,9 +203,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('uses the filename override as the multipart part name', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('a.txt', 'contents');
 
       await svc.createWithFiles({
@@ -228,15 +214,11 @@ describe('SnippetFilesService', () => {
       });
 
       const form = captured[0].data as FormData;
-      const parts = form.getAll('file');
-      expect(parts).toHaveLength(1);
-      expect((parts[0] as File).name).toBe('renamed.txt');
+      expect(filePart(form).name).toBe('renamed.txt');
     });
 
     it('defaults the part name to the file basename', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('base-name.txt', 'contents');
 
       await svc.createWithFiles({
@@ -247,14 +229,11 @@ describe('SnippetFilesService', () => {
       });
 
       const form = captured[0].data as FormData;
-      const parts = form.getAll('file');
-      expect((parts[0] as File).name).toBe('base-name.txt');
+      expect(filePart(form).name).toBe('base-name.txt');
     });
 
     it('sends a form without file parts when files is empty', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
 
       await svc.createWithFiles({
         workspace: 'ws',
@@ -269,27 +248,25 @@ describe('SnippetFilesService', () => {
     });
 
     it('propagates API errors from the multipart POST', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [
+      const { svc } = makeService([
         { status: 500, statusText: 'Server Error' },
       ]);
-      const svc = new SnippetFilesService(instance);
       const filePath = writeTempFile('a.txt', 'a');
 
-      await expect(
-        svc.createWithFiles({
-          workspace: 'ws',
-          title: 't',
-          isPrivate: true,
-          files: [{ path: filePath }],
-        })
-      ).rejects.toMatchObject({ response: { status: 500 } });
+      const rejection = svc.createWithFiles({
+        workspace: 'ws',
+        title: 't',
+        isPrivate: true,
+        files: [{ path: filePath }],
+      });
+      await expect(rejection).rejects.toBeInstanceOf(axios.AxiosError);
+      await expect(rejection).rejects.toMatchObject({
+        response: { status: 500 },
+      });
     });
 
     it('propagates a missing-file error from readFileSync', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const missingPath = path.join(os.tmpdir(), 'bb-missing', 'nope.txt');
 
       await expect(
@@ -306,9 +283,7 @@ describe('SnippetFilesService', () => {
 
   describe('editMetadata', () => {
     it('PUTs JSON body with only provided fields', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [{ id: 'kypj' }]);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService([{ id: 'kypj' }]);
 
       await svc.editMetadata({
         workspace: 'ws',
@@ -329,9 +304,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('includes is_private when provided', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
 
       await svc.editMetadata({
         workspace: 'ws',
@@ -346,13 +319,25 @@ describe('SnippetFilesService', () => {
           : (req.data as Record<string, unknown>);
       expect(parsed).toEqual({ is_private: false });
     });
+
+    it('propagates API errors from the JSON PUT', async () => {
+      const { svc } = makeService([{ status: 400, statusText: 'Bad Request' }]);
+
+      const rejection = svc.editMetadata({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        title: 'New',
+      });
+      await expect(rejection).rejects.toBeInstanceOf(axios.AxiosError);
+      await expect(rejection).rejects.toMatchObject({
+        response: { status: 400 },
+      });
+    });
   });
 
   describe('editWithFiles', () => {
     it('PUTs multipart/form-data when files are supplied', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('up.txt', 'updated');
 
       await svc.editWithFiles({
@@ -372,9 +357,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('omits title and is_private parts when not provided', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService();
       const filePath = writeTempFile('up.txt', 'updated');
 
       await svc.editWithFiles({
@@ -390,28 +373,24 @@ describe('SnippetFilesService', () => {
     });
 
     it('propagates API errors from the multipart PUT', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [
-        { status: 403, statusText: 'Forbidden' },
-      ]);
-      const svc = new SnippetFilesService(instance);
+      const { svc } = makeService([{ status: 403, statusText: 'Forbidden' }]);
       const filePath = writeTempFile('up.txt', 'updated');
 
-      await expect(
-        svc.editWithFiles({
-          workspace: 'ws',
-          encodedId: 'kypj',
-          files: [{ path: filePath }],
-        })
-      ).rejects.toMatchObject({ response: { status: 403 } });
+      const rejection = svc.editWithFiles({
+        workspace: 'ws',
+        encodedId: 'kypj',
+        files: [{ path: filePath }],
+      });
+      await expect(rejection).rejects.toBeInstanceOf(axios.AxiosError);
+      await expect(rejection).rejects.toMatchObject({
+        response: { status: 403 },
+      });
     });
   });
 
   describe('getFileContent', () => {
     it('GETs raw file content with text response type', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, ['hello file']);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService(['hello file']);
 
       const result = await svc.getFileContent('ws', 'kypj', 'path/to/file.txt');
 
@@ -421,9 +400,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('URL-encodes path segments while preserving slashes', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, ['x']);
-      const svc = new SnippetFilesService(instance);
+      const { svc, captured } = makeService(['x']);
 
       await svc.getFileContent('ws', 'kypj', 'dir name/sub/f oo.txt');
       expect(captured[0].url).toBe(
@@ -432,9 +409,7 @@ describe('SnippetFilesService', () => {
     });
 
     it('coerces non-string raw responses to strings', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [{ data: 12345 }]);
-      const svc = new SnippetFilesService(instance);
+      const { svc } = makeService([{ data: 12345 }]);
 
       const result = await svc.getFileContent('ws', 'kypj', 'a.txt');
 
@@ -442,15 +417,13 @@ describe('SnippetFilesService', () => {
     });
 
     it('propagates 404 errors from the raw-file fetch', async () => {
-      const captured: CapturedRequest[] = [];
-      const instance = createStubAxios(captured, [
-        { status: 404, statusText: 'Not Found' },
-      ]);
-      const svc = new SnippetFilesService(instance);
+      const { svc } = makeService([{ status: 404, statusText: 'Not Found' }]);
 
-      await expect(
-        svc.getFileContent('ws', 'kypj', 'missing.txt')
-      ).rejects.toMatchObject({ response: { status: 404 } });
+      const rejection = svc.getFileContent('ws', 'kypj', 'missing.txt');
+      await expect(rejection).rejects.toBeInstanceOf(axios.AxiosError);
+      await expect(rejection).rejects.toMatchObject({
+        response: { status: 404 },
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #269 — strengthens the thinnest test suites and makes the test job hermetic. No runtime behavior changes (one small, justified production change: `GitService` accepts an injected `env`).

## Test-suite depth

- **default-reviewers** (`default-reviewer.service.test.ts`, `default-reviewers.test.ts`)
  - Set/Array shape normalization covered directly in `pagination.test.ts` (`collectPages` is the normalizer)
  - Mode dispatch pinned at both layers: `--repo-only` → `direct`, default → `effective` (mock now captures the mode arg; previously it ignored args)
  - `reviewerType` (`repository`/`project`) propagation into table + full JSON shape (replaces `startsWith('json:')` smoke check)
  - `pagelen` = `MAX_PAGE_LENGTH` per page, both modes; PUT body `{ data: {} }`; PUT/DELETE error propagation (previously dead mock options now exercised)
- **output.project** — dotted-path/nested-array edge cases (numeric segments, empty/duplicated dots, `''`, undefined leaf, duplicate fields, top-level array); wrapper-key drift guard extended from 9 → all 14 `WRAPPER_ARRAY_KEYS`; empty-array wrapper and skip-and-continue branches pinned
- **snippet-files.service** — stub adapter now simulates non-2xx; error paths for create/edit/getFileContent assert `AxiosError` instance + status; `filename` override, basename default, ENOENT, non-string coercion, empty `files`, missing editMetadata error test
- **bootstrap** — `commandRegistrations` table exported from `bootstrap.ts`; every row asserts `deps.length === constructor arity` exactly (both directions) and every dep token is registered; named identity checks for the registerCommand-wired services; shared-axios identity extended to all 10 generated clients

## Hermeticity

- **git.service.test.ts** — every spawn (setup + production service) runs with `GIT_CONFIG_NOSYSTEM`, isolated `HOME`, isolated global/system config pinning `init.defaultBranch = main` (the `'main' | 'master'` tolerance is gone), fixed author/committer identity, `mkdtemp` dirs. `GitService` gained a constructor `env` option because Bun.spawn does not inherit runtime `process.env` mutations — without it the hermetic env never reached production spawns (and a developer's `GIT_DIR`/`GIT_SSH_COMMAND` etc. could leak into tests)
- **tests/preload.ts** — global fetch guard: only `http://localhost` / `127.0.0.1` pass through (OAuth callback tests), anything else fails loudly; URL is parsed so the `http://localhost:8080@evil.com/` userinfo bypass is closed; `cli-unknown-command.test.ts` no longer dodges the npm update poll with `CI=true`

## Verification

- `bun test` — 1541 pass / 0 fail across 49 files
- `bun run lint` (tsc --noEmit) and `bun run format:check` clean
- CI matrix (3 OS) unchanged — `bun install` is the only network step and is legitimate

## Review

Changes passed a clean-room thermo-nuclear review (4 independent reviewers); all findings addressed in the second commit.
