### PR TITLE
test: cover createApiClient interceptor behavior directly (#265)

### DIFF
--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -141,10 +141,11 @@ interface RetryableConfig extends InternalAxiosRequestConfig {
 }
 
 /**
- * Backoff delay for one retry attempt (1-based). A numeric `Retry-After`
- * header on a 429 wins; anything else — missing/garbage header, HTTP-date
- * format, or a non-429 status — falls back to exponential backoff
- * `1000 * 2^(attempt-1)`. Exported for direct unit tests.
+ * Backoff delay for one retry attempt (1-based). A `Retry-After` header with
+ * an integer-prefixed value (e.g. `5`, `5abc` parses as 5) on a 429 wins;
+ * anything else — missing header, non-numeric start, HTTP-date format, or a
+ * non-429 status — falls back to exponential backoff `1000 * 2^(attempt-1)`.
+ * Exported for direct unit tests.
  */
 export function getRetryDelay(error: AxiosError, attempt: number): number {
   if (error.response?.status === 429) {
@@ -166,8 +167,10 @@ function sleep(ms: number): Promise<void> {
 /**
  * Strip a request URL down to `origin + pathname`, replacing any query
  * string with `?[redacted]` so tokens in query params never reach DEBUG
- * output. Falls back to a manual query split when URL parsing fails.
- * Exported for direct unit tests.
+ * output. Root-relative URLs (a leading `/`) are resolved against the base
+ * so the base path survives and the log matches the actual wire URL. Falls
+ * back to a manual query split when URL parsing fails. Exported for direct
+ * unit tests.
  */
 export function redactRequestUrl(
   requestUrl: string | undefined,
@@ -175,7 +178,14 @@ export function redactRequestUrl(
 ): string {
   const raw = requestUrl ?? '';
   try {
-    const parsed = new URL(raw, baseUrl);
+    // axios concatenates baseURL + url for relative paths; mirror that so
+    // the logged URL matches the actual wire request (base path preserved).
+    // Absolute and protocol-relative URLs are used as-is.
+    const full =
+      raw.startsWith('//') || /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)
+        ? raw
+        : `${(baseUrl ?? '').replace(/\/+$/, '')}/${raw.replace(/^\/+/, '')}`;
+    const parsed = new URL(full);
     const query = parsed.search ? '?[redacted]' : '';
     return `${parsed.origin}${parsed.pathname}${query}`;
   } catch {

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -102,7 +102,13 @@ const SENSITIVE_KEYS = new Set([
 
 const REDACTED = '[REDACTED]';
 
-function redactSensitive(
+/**
+ * Recursively replace values under case-insensitive sensitive keys
+ * (tokens, passwords, authorization headers) with `[REDACTED]` and break
+ * circular references. Exported for direct unit tests; used by the DEBUG
+ * response/error body logging.
+ */
+export function redactSensitive(
   value: unknown,
   seen = new WeakSet<object>()
 ): unknown {
@@ -134,7 +140,13 @@ interface RetryableConfig extends InternalAxiosRequestConfig {
   __tokenRefreshed?: boolean;
 }
 
-function getRetryDelay(error: AxiosError, attempt: number): number {
+/**
+ * Backoff delay for one retry attempt (1-based). A numeric `Retry-After`
+ * header on a 429 wins; anything else — missing/garbage header, HTTP-date
+ * format, or a non-429 status — falls back to exponential backoff
+ * `1000 * 2^(attempt-1)`. Exported for direct unit tests.
+ */
+export function getRetryDelay(error: AxiosError, attempt: number): number {
   if (error.response?.status === 429) {
     const retryAfter = error.response.headers['retry-after'];
     if (retryAfter) {
@@ -151,7 +163,13 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function redactRequestUrl(
+/**
+ * Strip a request URL down to `origin + pathname`, replacing any query
+ * string with `?[redacted]` so tokens in query params never reach DEBUG
+ * output. Falls back to a manual query split when URL parsing fails.
+ * Exported for direct unit tests.
+ */
+export function redactRequestUrl(
   requestUrl: string | undefined,
   baseUrl: string | undefined
 ): string {
@@ -356,9 +374,9 @@ export function createApiClient(
 /**
  * Flatten Bitbucket's `error.fields` map into `key: reason` pairs. Bitbucket
  * pairs a terse message like "Bad request" with this map, and it is the only
- * part that says which key was rejected.
+ * part that says which key was rejected. Exported for direct unit tests.
  */
-function formatErrorFields(fields: unknown): string | undefined {
+export function formatErrorFields(fields: unknown): string | undefined {
   if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
     return undefined;
   }
@@ -377,7 +395,13 @@ function formatErrorFields(fields: unknown): string | undefined {
   return parts.length > 0 ? parts.join('; ') : undefined;
 }
 
-function extractErrorMessage(data: unknown): string | undefined {
+/**
+ * Extract a human-readable message from a Bitbucket error response body:
+ * the nested `error.message` (with formatted `error.fields` appended when
+ * present), else a top-level string `message`. Exported for direct unit
+ * tests.
+ */
+export function extractErrorMessage(data: unknown): string | undefined {
   if (typeof data === 'object' && data !== null) {
     const errorObj = data as Record<string, unknown>;
     if (typeof errorObj.error === 'object' && errorObj.error !== null) {

--- a/tests/services/api-client.helpers.test.ts
+++ b/tests/services/api-client.helpers.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Direct unit tests for the api-client helper functions exported for the
+ * interceptor suite (issue #265): redaction, URL scrubbing, retry delay, and
+ * error-message extraction. Testing the pure functions directly is more
+ * precise than observing them through the DEBUG console seam.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  extractErrorMessage,
+  formatErrorFields,
+  getRetryDelay,
+  redactRequestUrl,
+  redactSensitive,
+} from '../../src/services/api-client.service.js';
+import { AxiosError } from 'axios';
+
+describe('redactSensitive', () => {
+  it('replaces values under sensitive keys with [REDACTED] case-insensitively', () => {
+    const result = redactSensitive({
+      Access_Token: 'a',
+      refresh_token: 'b',
+      Authorization: 'c',
+      client_secret: 'd',
+      id: 1,
+      name: 'keep',
+    });
+    expect(result).toEqual({
+      Access_Token: '[REDACTED]',
+      refresh_token: '[REDACTED]',
+      Authorization: '[REDACTED]',
+      client_secret: '[REDACTED]',
+      id: 1,
+      name: 'keep',
+    });
+  });
+
+  it('redacts sensitive keys nested inside arrays and objects', () => {
+    const result = redactSensitive({
+      items: [
+        { id: 1, token: 'nested' },
+        { id: 2, password: 'also' },
+      ],
+      meta: { token: 'deep' },
+    });
+    expect(result).toEqual({
+      items: [
+        { id: 1, token: '[REDACTED]' },
+        { id: 2, password: '[REDACTED]' },
+      ],
+      meta: { token: '[REDACTED]' },
+    });
+  });
+
+  it('passes primitives and null through unchanged', () => {
+    expect(redactSensitive(null)).toBeNull();
+    expect(redactSensitive('plain')).toBe('plain');
+    expect(redactSensitive(42)).toBe(42);
+    expect(redactSensitive(undefined)).toBeUndefined();
+  });
+
+  it('breaks circular references with [Circular]', () => {
+    const circular: Record<string, unknown> = { name: 'self' };
+    circular.self = circular;
+    const result = redactSensitive(circular) as Record<string, unknown>;
+    expect(result.name).toBe('self');
+    expect(result.self).toBe('[Circular]');
+  });
+
+  it('redacts circular references nested inside arrays', () => {
+    const inner: Record<string, unknown> = { token: 'x' };
+    const arr = [inner, inner];
+    const result = redactSensitive(arr) as Array<Record<string, unknown>>;
+    expect(result[0]).toEqual({ token: '[REDACTED]' });
+    expect(result[1]).toBe('[Circular]');
+  });
+});
+
+describe('redactRequestUrl', () => {
+  it('keeps path and origin but scrubs the query string', () => {
+    expect(
+      redactRequestUrl(
+        '/repositories/ws/r?token=abc&other=xyz',
+        'https://api.bitbucket.org/2.0'
+      )
+    ).toBe('https://api.bitbucket.org/repositories/ws/r?[redacted]');
+  });
+
+  it('keeps a URL without a query string unchanged', () => {
+    expect(
+      redactRequestUrl('/repositories/ws/r', 'https://api.bitbucket.org/2.0')
+    ).toBe('https://api.bitbucket.org/repositories/ws/r');
+  });
+
+  it('resolves root-relative URLs against the origin (base path is dropped)', () => {
+    // `new URL('/x', 'https://host/2.0')` is root-relative, so the base path
+    // does not survive — the DEBUG log URL omits the /2.0 prefix. Cosmetic
+    // inaccuracy in an opt-in log; pinned here so a future fix is deliberate.
+    expect(redactRequestUrl('/a/b', 'https://api.bitbucket.org/2.0')).toBe(
+      'https://api.bitbucket.org/a/b'
+    );
+  });
+
+  it('handles absolute request URLs', () => {
+    expect(redactRequestUrl('https://example.com/x?a=1', undefined)).toBe(
+      'https://example.com/x?[redacted]'
+    );
+  });
+
+  it('falls back to a manual query split when URL parsing fails', () => {
+    expect(redactRequestUrl('https://[invalid?a=1', undefined)).toBe(
+      'https://[invalid?[redacted]'
+    );
+    expect(redactRequestUrl('https://[invalid', undefined)).toBe(
+      'https://[invalid'
+    );
+  });
+});
+
+function retryError(
+  status: number,
+  headers: Record<string, string>
+): AxiosError {
+  return new AxiosError('Request failed', undefined, undefined, undefined, {
+    data: {},
+    status,
+    statusText: String(status),
+    headers,
+    config: {} as never,
+  });
+}
+
+describe('getRetryDelay', () => {
+  it('honors a numeric Retry-After header on 429', () => {
+    const error = retryError(429, { 'retry-after': '5' });
+    expect(getRetryDelay(error, 1)).toBe(5000);
+  });
+
+  it('falls back to exponential backoff for a non-numeric Retry-After', () => {
+    const error = retryError(429, { 'retry-after': 'soon' });
+    expect(getRetryDelay(error, 1)).toBe(1000);
+  });
+
+  it('falls back to exponential backoff for an HTTP-date Retry-After', () => {
+    const error = retryError(429, {
+      'retry-after': 'Tue, 15 Nov 1994 08:12:31 GMT',
+    });
+    expect(getRetryDelay(error, 1)).toBe(1000);
+  });
+
+  it('ignores Retry-After on non-429 statuses', () => {
+    const error = retryError(503, { 'retry-after': '99' });
+    expect(getRetryDelay(error, 1)).toBe(1000);
+  });
+
+  it('escalates exponentially per attempt (1s/2s/4s)', () => {
+    const error = retryError(503, {});
+    expect(getRetryDelay(error, 1)).toBe(1000);
+    expect(getRetryDelay(error, 2)).toBe(2000);
+    expect(getRetryDelay(error, 3)).toBe(4000);
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('extracts the nested error.message', () => {
+    expect(extractErrorMessage({ error: { message: 'Bad request' } })).toBe(
+      'Bad request'
+    );
+  });
+
+  it('appends formatted error.fields to the nested message', () => {
+    expect(
+      extractErrorMessage({
+        error: { message: 'Bad request', fields: { title: ['missing'] } },
+      })
+    ).toBe('Bad request (title: missing)');
+  });
+
+  it('falls back to a top-level string message', () => {
+    expect(extractErrorMessage({ message: 'Something failed' })).toBe(
+      'Something failed'
+    );
+  });
+
+  it('returns undefined for non-string messages and non-object data', () => {
+    expect(extractErrorMessage({ message: 42 })).toBeUndefined();
+    expect(extractErrorMessage('plain text')).toBeUndefined();
+    expect(extractErrorMessage(null)).toBeUndefined();
+  });
+});
+
+describe('formatErrorFields', () => {
+  it('formats string reasons as key: reason pairs', () => {
+    expect(formatErrorFields({ title: 'required' })).toBe('title: required');
+  });
+
+  it('joins array reasons with commas, skipping non-strings', () => {
+    expect(formatErrorFields({ title: ['a', 'b'], name: [1, 'c'] })).toBe(
+      'title: a, b; name: c'
+    );
+  });
+
+  it('returns undefined for empty, non-object, or array input', () => {
+    expect(formatErrorFields({})).toBeUndefined();
+    expect(formatErrorFields('nope')).toBeUndefined();
+    expect(formatErrorFields(null)).toBeUndefined();
+    expect(formatErrorFields(['a', 'b'])).toBeUndefined();
+  });
+});

--- a/tests/services/api-client.helpers.test.ts
+++ b/tests/services/api-client.helpers.test.ts
@@ -13,7 +13,7 @@ import {
   redactRequestUrl,
   redactSensitive,
 } from '../../src/services/api-client.service.js';
-import { AxiosError } from 'axios';
+import { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 
 describe('redactSensitive', () => {
   it('replaces values under sensitive keys with [REDACTED] case-insensitively', () => {
@@ -67,7 +67,11 @@ describe('redactSensitive', () => {
     expect(result.self).toBe('[Circular]');
   });
 
-  it('redacts circular references nested inside arrays', () => {
+  it('flags repeated object references as [Circular] via the seen-set', () => {
+    // Not a cycle: `arr` holds the same object twice. The WeakSet marks it
+    // seen on the first pass, so the second occurrence renders '[Circular]'.
+    // Deliberate seen-set semantics — production bodies come from JSON.parse
+    // and never share references, but the guard must stay bounded anyway.
     const inner: Record<string, unknown> = { token: 'x' };
     const arr = [inner, inner];
     const result = redactSensitive(arr) as Array<Record<string, unknown>>;
@@ -83,21 +87,20 @@ describe('redactRequestUrl', () => {
         '/repositories/ws/r?token=abc&other=xyz',
         'https://api.bitbucket.org/2.0'
       )
-    ).toBe('https://api.bitbucket.org/repositories/ws/r?[redacted]');
+    ).toBe('https://api.bitbucket.org/2.0/repositories/ws/r?[redacted]');
   });
 
   it('keeps a URL without a query string unchanged', () => {
     expect(
       redactRequestUrl('/repositories/ws/r', 'https://api.bitbucket.org/2.0')
-    ).toBe('https://api.bitbucket.org/repositories/ws/r');
+    ).toBe('https://api.bitbucket.org/2.0/repositories/ws/r');
   });
 
-  it('resolves root-relative URLs against the origin (base path is dropped)', () => {
-    // `new URL('/x', 'https://host/2.0')` is root-relative, so the base path
-    // does not survive — the DEBUG log URL omits the /2.0 prefix. Cosmetic
-    // inaccuracy in an opt-in log; pinned here so a future fix is deliberate.
+  it('preserves the base path for root-relative URLs', () => {
+    // axios concatenates baseURL + url, so the logged URL must keep the
+    // base path (e.g. /2.0) to match the actual wire request.
     expect(redactRequestUrl('/a/b', 'https://api.bitbucket.org/2.0')).toBe(
-      'https://api.bitbucket.org/a/b'
+      'https://api.bitbucket.org/2.0/a/b'
     );
   });
 
@@ -126,7 +129,7 @@ function retryError(
     status,
     statusText: String(status),
     headers,
-    config: {} as never,
+    config: {} as InternalAxiosRequestConfig,
   });
 }
 
@@ -182,6 +185,16 @@ describe('extractErrorMessage', () => {
     );
   });
 
+  it('falls through to the top-level message when error.message is not a string', () => {
+    expect(
+      extractErrorMessage({ error: { message: 42 }, message: 'top' })
+    ).toBe('top');
+  });
+
+  it('falls through to the top-level message when error is not an object', () => {
+    expect(extractErrorMessage({ error: 'oops', message: 'top' })).toBe('top');
+  });
+
   it('returns undefined for non-string messages and non-object data', () => {
     expect(extractErrorMessage({ message: 42 })).toBeUndefined();
     expect(extractErrorMessage('plain text')).toBeUndefined();
@@ -205,5 +218,9 @@ describe('formatErrorFields', () => {
     expect(formatErrorFields('nope')).toBeUndefined();
     expect(formatErrorFields(null)).toBeUndefined();
     expect(formatErrorFields(['a', 'b'])).toBeUndefined();
+  });
+
+  it('drops non-string, non-array reasons', () => {
+    expect(formatErrorFields({ title: 42, name: 'keep' })).toBe('name: keep');
   });
 });

--- a/tests/services/api-client.interceptors.test.ts
+++ b/tests/services/api-client.interceptors.test.ts
@@ -2,10 +2,12 @@
  * Direct interceptor coverage for createApiClient (issue #265).
  *
  * Sibling to api-client.test.ts: that file covers the happy paths and the
- * broad retry/redaction matrix; this one pins the seams the behavioral tests
- * cannot see — replay headers, the auth-method re-check on 401, exact
+ * broad retry/timeout/network matrix; this one pins the seams the behavioral
+ * tests cannot see — replay headers, the auth-method re-check on 401, exact
  * APIError shape, the UNKNOWN branch, request-interceptor passthrough, and
- * DEBUG gating on the request/error paths.
+ * DEBUG gating on the request/error paths. It also owns the DEBUG logging
+ * matrix (moved here from api-client.test.ts so redaction coverage has a
+ * single owner).
  */
 
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
@@ -18,32 +20,20 @@ import {
   createMockOutputService,
   mockConfigService,
   mockOAuthConfigService,
+  restoreSetTimeout,
+  stubSetTimeout,
 } from '../setup.js';
 import type { AxiosInstance } from 'axios';
 
-const originalSetTimeout = globalThis.setTimeout;
+beforeEach(() => {
+  stubSetTimeout();
+});
 
-/** Install the synchronous setTimeout stub that neutralizes sleep(). */
-function stubSetTimeout(): void {
-  globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-    fn();
-    return 0 as never;
-  }) as never;
-}
+afterEach(() => {
+  restoreSetTimeout();
+});
 
 describe('createApiClient - 401 refresh replay', () => {
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    stubSetTimeout();
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
-    consoleErrorSpy.mockRestore();
-  });
-
   it('re-sends the replayed request with the refreshed Bearer token', async () => {
     const authHeaders: Array<string | undefined> = [];
     // Stateful mock: the store rotates to the new token on refresh, which is
@@ -63,36 +53,24 @@ describe('createApiClient - 401 refresh replay', () => {
       async revokeToken() {},
     } as never;
 
-    const adapter = (config: { headers: { Authorization?: string } }) => {
-      authHeaders.push(config.headers.Authorization);
-      if (authHeaders.length === 1) {
-        const error = new Error('Request failed with status code 401');
-        (error as any).response = {
-          data: { error: { message: 'Unauthorized' } },
-          status: 401,
-          statusText: 'Unauthorized',
-          headers: {},
-          config,
-        };
-        (error as any).config = config;
-        (error as any).isAxiosError = true;
-        return Promise.reject(error);
+    const mockAdapter = createMockAdapter(
+      [
+        { status: 401, data: { error: { message: 'Unauthorized' } } },
+        { status: 200, data: { ok: true } },
+      ],
+      {
+        onRequest: (config) => {
+          authHeaders.push(config.headers.Authorization);
+        },
       }
-      return Promise.resolve({
-        data: {},
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config,
-      });
-    };
+    );
 
     const client = createApiClient(
       mockOAuthConfigService(),
       createMockOutputService(),
       oauthService
     );
-    client.defaults.adapter = adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     const response = await client.get('/test');
 
@@ -101,6 +79,32 @@ describe('createApiClient - 401 refresh replay', () => {
       'Bearer expired-token',
       'Bearer brand-new-token',
     ]);
+  });
+
+  it('keeps the retry budget across a 401 refresh replay (401 -> 429 -> 200)', async () => {
+    const oauthMock = createMockOAuthService({
+      validToken: 'expired-token',
+      refreshedToken: 'new-token',
+    });
+    const mockAdapter = createMockAdapter([
+      { status: 401, data: { error: { message: 'Unauthorized' } } },
+      { status: 429, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthMock.service
+    );
+    client.defaults.adapter = mockAdapter.adapter;
+
+    const response = await client.get('/test');
+
+    // The 429 after the replay must retry once — the shared __retryCount on
+    // the same config never saw an increment, and no second refresh happens.
+    expect(response.status).toBe(200);
+    expect(mockAdapter.getCallCount()).toBe(3);
+    expect(oauthMock.getRefreshCallCount()).toBe(1);
   });
 
   it('skips the 401 refresh when the auth-method re-check no longer sees oauth', async () => {
@@ -119,11 +123,11 @@ describe('createApiClient - 401 refresh replay', () => {
       { status: 401, data: { error: { message: 'Unauthorized' } } },
     ]);
     const client = createApiClient(
-      store as never,
+      store,
       createMockOutputService(),
       oauthMock.service
     );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     try {
       await client.get('/test');
@@ -139,18 +143,6 @@ describe('createApiClient - 401 refresh replay', () => {
 });
 
 describe('createApiClient - retry matrix completion', () => {
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    stubSetTimeout();
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
-    consoleErrorSpy.mockRestore();
-  });
-
   it('retries a 504 and succeeds', async () => {
     const mockAdapter = createMockAdapter([
       { status: 504, data: {} },
@@ -160,7 +152,7 @@ describe('createApiClient - retry matrix completion', () => {
       mockConfigService(),
       createMockOutputService()
     );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     const response = await client.get('/test');
 
@@ -177,7 +169,7 @@ describe('createApiClient - retry matrix completion', () => {
       mockConfigService(),
       createMockOutputService()
     );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     const response = await client.post('/test', {});
 
@@ -198,7 +190,7 @@ describe('createApiClient - retry matrix completion', () => {
         mockConfigService(),
         createMockOutputService()
       );
-      client.defaults.adapter = mockAdapter.adapter as never;
+      client.defaults.adapter = mockAdapter.adapter;
 
       try {
         await client.get('/test');
@@ -233,7 +225,7 @@ describe('createApiClient - retry matrix completion', () => {
       mockConfigService(),
       createMockOutputService()
     );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     const response = await client.get('/test');
 
@@ -244,18 +236,6 @@ describe('createApiClient - retry matrix completion', () => {
 });
 
 describe('createApiClient - APIError shape', () => {
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    stubSetTimeout();
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
-    consoleErrorSpy.mockRestore();
-  });
-
   it.each([
     [403, ErrorCode.API_FORBIDDEN],
     [500, ErrorCode.API_SERVER_ERROR],
@@ -268,7 +248,7 @@ describe('createApiClient - APIError shape', () => {
         mockConfigService(),
         createMockOutputService()
       );
-      client.defaults.adapter = mockAdapter.adapter as never;
+      client.defaults.adapter = mockAdapter.adapter;
 
       try {
         await client.get('/test');
@@ -288,7 +268,7 @@ describe('createApiClient - APIError shape', () => {
       mockConfigService(),
       createMockOutputService()
     );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client.defaults.adapter = mockAdapter.adapter;
 
     try {
       await client.post('/repos/ws/r', {});
@@ -329,18 +309,6 @@ describe('createApiClient - APIError shape', () => {
 });
 
 describe('createApiClient - interceptor edges', () => {
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    stubSetTimeout();
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
-    consoleErrorSpy.mockRestore();
-  });
-
   it('maps request-interceptor rejections to UNKNOWN with the original as cause', async () => {
     const originalError = new Error('store exploded');
     const store = {
@@ -350,13 +318,12 @@ describe('createApiClient - interceptor edges', () => {
       },
     };
     const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    const client = createApiClient(store as never, createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as never;
+    const client = createApiClient(store, createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
 
     // The request interceptor's rejection lands in the response interceptor's
     // rejected handler, which maps it (no response/request) to UNKNOWN.
-    const rejection = client.get('/test').catch((e: unknown) => e);
-    const error = await rejection;
+    const error = await client.get('/test').catch((e: unknown) => e);
     expect(error).toBeInstanceOf(BBError);
     expect((error as BBError).code).toBe(ErrorCode.UNKNOWN);
     expect((error as BBError).message).toBe('store exploded');
@@ -367,8 +334,8 @@ describe('createApiClient - interceptor edges', () => {
   it('maps getCredentials failures for basic auth to UNKNOWN with cause', async () => {
     const store = createMockConfigService({}); // no credentials configured
     const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    const client = createApiClient(store as never, createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as never;
+    const client = createApiClient(store, createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
 
     const error = await client.get('/test').catch((e: unknown) => e);
     expect(error).toBeInstanceOf(BBError);
@@ -379,22 +346,18 @@ describe('createApiClient - interceptor edges', () => {
   });
 });
 
-describe('createApiClient - DEBUG request/error gating', () => {
+describe('createApiClient - DEBUG logging and redaction', () => {
+  let client: AxiosInstance;
   let consoleDebugSpy: ReturnType<typeof spyOn>;
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
   let originalDebug: string | undefined;
 
   beforeEach(() => {
-    stubSetTimeout();
     originalDebug = process.env.DEBUG;
     consoleDebugSpy = spyOn(console, 'debug').mockImplementation(() => {});
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
     consoleDebugSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
     if (originalDebug === undefined) {
       delete process.env.DEBUG;
     } else {
@@ -402,16 +365,116 @@ describe('createApiClient - DEBUG request/error gating', () => {
     }
   });
 
+  function allDebugOutput(): string {
+    return consoleDebugSpy.mock.calls
+      .map((args) => args.map((a) => String(a)).join(' '))
+      .join('\n');
+  }
+
+  it('redacts access_token and refresh_token from response body logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: {
+          access_token: 'secret-AT',
+          refresh_token: 'secret-RT',
+          expires_in: 7200,
+          scopes: 'repository',
+        },
+      },
+    ]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/test');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] Response Body:');
+    expect(output).not.toContain('secret-AT');
+    expect(output).not.toContain('secret-RT');
+    expect(output).toContain('[REDACTED]');
+    // Non-sensitive fields still logged.
+    expect(output).toContain('expires_in');
+    expect(output).toContain('7200');
+    expect(output).toContain('scopes');
+  });
+
+  it('redacts tokens from error response body logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 400,
+        data: { error: 'invalid_grant', access_token: 'leaked' },
+      },
+    ]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    try {
+      await client.get('/test');
+    } catch {
+      // expected
+    }
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] Error Response Body:');
+    expect(output).not.toContain('leaked');
+    expect(output).toContain('[REDACTED]');
+    expect(output).toContain('invalid_grant');
+  });
+
+  it('redacts sensitive keys nested inside arrays and objects', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: {
+          data: {
+            items: [
+              { id: 1, token: 'nested-secret' },
+              { id: 2, password: 'also-secret' },
+            ],
+          },
+        },
+      },
+    ]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/test');
+
+    const output = allDebugOutput();
+    expect(output).not.toContain('nested-secret');
+    expect(output).not.toContain('also-secret');
+    expect(output).toContain('[REDACTED]');
+    // Non-sensitive surrounding data survives.
+    expect(output).toContain('items');
+  });
+
+  it('does not log response bodies when DEBUG is not set', async () => {
+    delete process.env.DEBUG;
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: { access_token: 'should-not-be-logged' },
+      },
+    ]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/test');
+
+    expect(consoleDebugSpy).not.toHaveBeenCalled();
+  });
+
   it('logs nothing on the request or error path when DEBUG is unset', async () => {
     delete process.env.DEBUG;
     const mockAdapter = createMockAdapter([
       { status: 500, data: { error: { message: 'boom' } } },
     ]);
-    const client = createApiClient(
-      mockConfigService(),
-      createMockOutputService()
-    );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
 
     try {
       await client.get('/test');
@@ -422,32 +485,63 @@ describe('createApiClient - DEBUG request/error gating', () => {
     expect(consoleDebugSpy).not.toHaveBeenCalled();
   });
 
-  it('logs the error line and redacts the error body when DEBUG is set', async () => {
+  it('handles circular references without infinite recursion', async () => {
     process.env.DEBUG = 'true';
+    const circular: Record<string, unknown> = { name: 'self' };
+    circular.self = circular;
+    const mockAdapter = createMockAdapter([{ status: 200, data: circular }]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/test');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[Circular]');
+    expect(output).toContain('self');
+  });
+
+  it('handles circular references nested inside arrays', async () => {
+    process.env.DEBUG = 'true';
+    const inner: Record<string, unknown> = { token: 'secret' };
     const mockAdapter = createMockAdapter([
-      {
-        status: 500,
-        data: { error: { message: 'boom' }, access_token: 'top-secret' },
-      },
+      { status: 200, data: [inner, inner] },
     ]);
-    const client = createApiClient(
-      mockConfigService(),
-      createMockOutputService()
-    );
-    client.defaults.adapter = mockAdapter.adapter as never;
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
 
-    try {
-      await client.get('/test');
-    } catch {
-      // expected
-    }
+    await client.get('/test');
 
-    const output = consoleDebugSpy.mock.calls
-      .map((args) => args.map((a) => String(a)).join(' '))
-      .join('\n');
-    expect(output).toContain('[HTTP] Error:');
-    expect(output).toContain('[HTTP] Error Response Body:');
-    expect(output).toContain('[REDACTED]');
-    expect(output).not.toContain('top-secret');
+    const output = allDebugOutput();
+    expect(output).not.toContain('secret');
+    expect(output).toContain('[Circular]');
+  });
+
+  it('logs request method and URL when DEBUG is set', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/some/resource');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] GET');
+    expect(output).toContain('/some/resource');
+  });
+
+  it('redacts query strings from request URL DEBUG logs', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
+    client = createApiClient(mockConfigService(), createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter;
+
+    await client.get('/test?token=abc&other=xyz');
+
+    const output = allDebugOutput();
+    expect(output).toContain('[HTTP] GET');
+    expect(output).toContain('/test');
+    expect(output).not.toContain('token=abc');
+    expect(output).not.toContain('other=xyz');
+    expect(output).toContain('[redacted]');
   });
 });

--- a/tests/services/api-client.interceptors.test.ts
+++ b/tests/services/api-client.interceptors.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Direct interceptor coverage for createApiClient (issue #265).
+ *
+ * Sibling to api-client.test.ts: that file covers the happy paths and the
+ * broad retry/redaction matrix; this one pins the seams the behavioral tests
+ * cannot see — replay headers, the auth-method re-check on 401, exact
+ * APIError shape, the UNKNOWN branch, request-interceptor passthrough, and
+ * DEBUG gating on the request/error paths.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { createApiClient } from '../../src/services/api-client.service.js';
+import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
+import {
+  createMockAdapter,
+  createMockConfigService,
+  createMockOAuthService,
+  createMockOutputService,
+  mockConfigService,
+  mockOAuthConfigService,
+} from '../setup.js';
+import type { AxiosInstance } from 'axios';
+
+const originalSetTimeout = globalThis.setTimeout;
+
+/** Install the synchronous setTimeout stub that neutralizes sleep(). */
+function stubSetTimeout(): void {
+  globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+    fn();
+    return 0 as never;
+  }) as never;
+}
+
+describe('createApiClient - 401 refresh replay', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    stubSetTimeout();
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('re-sends the replayed request with the refreshed Bearer token', async () => {
+    const authHeaders: Array<string | undefined> = [];
+    // Stateful mock: the store rotates to the new token on refresh, which is
+    // what the request interceptor picks up when the 401 replay re-runs it.
+    let currentToken = 'expired-token';
+    const oauthService = {
+      async getValidAccessToken() {
+        return currentToken;
+      },
+      async refreshAccessToken() {
+        currentToken = 'brand-new-token';
+        return currentToken;
+      },
+      async authorize() {
+        return { username: 'u', displayName: 'U', accountId: '1' };
+      },
+      async revokeToken() {},
+    } as never;
+
+    const adapter = (config: { headers: { Authorization?: string } }) => {
+      authHeaders.push(config.headers.Authorization);
+      if (authHeaders.length === 1) {
+        const error = new Error('Request failed with status code 401');
+        (error as any).response = {
+          data: { error: { message: 'Unauthorized' } },
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: {},
+          config,
+        };
+        (error as any).config = config;
+        (error as any).isAxiosError = true;
+        return Promise.reject(error);
+      }
+      return Promise.resolve({
+        data: {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      });
+    };
+
+    const client = createApiClient(
+      mockOAuthConfigService(),
+      createMockOutputService(),
+      oauthService
+    );
+    client.defaults.adapter = adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(authHeaders).toEqual([
+      'Bearer expired-token',
+      'Bearer brand-new-token',
+    ]);
+  });
+
+  it('skips the 401 refresh when the auth-method re-check no longer sees oauth', async () => {
+    const store = mockOAuthConfigService();
+    let authMethodCalls = 0;
+    const originalGetAuthMethod = store.getAuthMethod.bind(store);
+    store.getAuthMethod = async () => {
+      authMethodCalls++;
+      // First call (request interceptor) sees oauth; the 401 re-check flips
+      // to basic, which must suppress the reactive refresh.
+      return authMethodCalls >= 2 ? 'basic' : originalGetAuthMethod();
+    };
+
+    const oauthMock = createMockOAuthService();
+    const mockAdapter = createMockAdapter([
+      { status: 401, data: { error: { message: 'Unauthorized' } } },
+    ]);
+    const client = createApiClient(
+      store as never,
+      createMockOutputService(),
+      oauthMock.service
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(APIError);
+      expect((err as APIError).code).toBe(ErrorCode.AUTH_INVALID);
+    }
+
+    expect(oauthMock.getRefreshCallCount()).toBe(0);
+    expect(authMethodCalls).toBe(2);
+  });
+});
+
+describe('createApiClient - retry matrix completion', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    stubSetTimeout();
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('retries a 504 and succeeds', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 504, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    expect(mockAdapter.getCallCount()).toBe(2);
+  });
+
+  it('retries POST on 429 (status-code retries apply to all methods)', async () => {
+    const mockAdapter = createMockAdapter([
+      { status: 429, data: {} },
+      { status: 200, data: { ok: true } },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    const response = await client.post('/test', {});
+
+    expect(response.status).toBe(200);
+    expect(mockAdapter.getCallCount()).toBe(2);
+  });
+
+  it.each([502, 503, 504])(
+    'exhausts retries for %s into API_SERVER_ERROR (4 calls)',
+    async (status) => {
+      const mockAdapter = createMockAdapter([
+        { status, data: {} },
+        { status, data: {} },
+        { status, data: {} },
+        { status, data: {} },
+      ]);
+      const client = createApiClient(
+        mockConfigService(),
+        createMockOutputService()
+      );
+      client.defaults.adapter = mockAdapter.adapter as never;
+
+      try {
+        await client.get('/test');
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(APIError);
+        expect((err as APIError).code).toBe(ErrorCode.API_SERVER_ERROR);
+        expect((err as APIError).statusCode).toBe(status);
+      }
+
+      expect(mockAdapter.getCallCount()).toBe(4);
+    }
+  );
+
+  it('falls back to exponential backoff when Retry-After is an HTTP-date', async () => {
+    const setTimeoutCalls: number[] = [];
+    globalThis.setTimeout = ((fn: Function, ms?: number) => {
+      setTimeoutCalls.push(ms ?? 0);
+      fn();
+      return 0 as never;
+    }) as never;
+
+    const mockAdapter = createMockAdapter([
+      {
+        status: 429,
+        data: {},
+        headers: { 'retry-after': 'Tue, 15 Nov 1994 08:12:31 GMT' },
+      },
+      { status: 200, data: { ok: true } },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    const response = await client.get('/test');
+
+    expect(response.status).toBe(200);
+    // HTTP-date is not parsed; the exponential 1000ms (attempt 1) applies.
+    expect(setTimeoutCalls).toEqual([1000]);
+  });
+});
+
+describe('createApiClient - APIError shape', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    stubSetTimeout();
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it.each([
+    [403, ErrorCode.API_FORBIDDEN],
+    [500, ErrorCode.API_SERVER_ERROR],
+    [400, ErrorCode.API_REQUEST_FAILED],
+  ])(
+    'maps status %s to %s at the interceptor boundary',
+    async (status, code) => {
+      const mockAdapter = createMockAdapter([{ status, data: {} }]);
+      const client = createApiClient(
+        mockConfigService(),
+        createMockOutputService()
+      );
+      client.defaults.adapter = mockAdapter.adapter as never;
+
+      try {
+        await client.get('/test');
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(APIError);
+        expect((err as APIError).code).toBe(code);
+        expect((err as APIError).statusCode).toBe(status);
+      }
+    }
+  );
+
+  it('sets context {status, method, url} and preserves the raw response body', async () => {
+    const body = { error: { message: 'Nope', fields: { title: ['missing'] } } };
+    const mockAdapter = createMockAdapter([{ status: 400, data: body }]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    try {
+      await client.post('/repos/ws/r', {});
+      expect(true).toBe(false);
+    } catch (err) {
+      const apiErr = err as APIError;
+      expect(apiErr.context).toEqual({
+        status: 400,
+        method: 'POST',
+        url: '/repos/ws/r',
+      });
+      expect(apiErr.response).toBe(body);
+      expect(apiErr.message).toBe('Nope (title: missing)');
+    }
+  });
+
+  it('maps errors with neither response nor request to UNKNOWN with cause', async () => {
+    const adapter = () => {
+      const error = new Error('mystery failure');
+      (error as any).isAxiosError = true;
+      return Promise.reject(error);
+    };
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = adapter as never;
+
+    try {
+      await client.get('/test');
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BBError);
+      expect((err as BBError).code).toBe(ErrorCode.UNKNOWN);
+      expect((err as BBError).cause).toBeInstanceOf(Error);
+    }
+  });
+});
+
+describe('createApiClient - interceptor edges', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    stubSetTimeout();
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('maps request-interceptor rejections to UNKNOWN with the original as cause', async () => {
+    const originalError = new Error('store exploded');
+    const store = {
+      ...mockConfigService(),
+      getAuthMethod: async () => {
+        throw originalError;
+      },
+    };
+    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
+    const client = createApiClient(store as never, createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    // The request interceptor's rejection lands in the response interceptor's
+    // rejected handler, which maps it (no response/request) to UNKNOWN.
+    const rejection = client.get('/test').catch((e: unknown) => e);
+    const error = await rejection;
+    expect(error).toBeInstanceOf(BBError);
+    expect((error as BBError).code).toBe(ErrorCode.UNKNOWN);
+    expect((error as BBError).message).toBe('store exploded');
+    expect((error as BBError).cause).toBe(originalError);
+    expect(mockAdapter.getCallCount()).toBe(0);
+  });
+
+  it('maps getCredentials failures for basic auth to UNKNOWN with cause', async () => {
+    const store = createMockConfigService({}); // no credentials configured
+    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
+    const client = createApiClient(store as never, createMockOutputService());
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    const error = await client.get('/test').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(BBError);
+    expect((error as BBError).code).toBe(ErrorCode.UNKNOWN);
+    expect((error as BBError).message).toBe('Auth required');
+    expect((error as BBError).cause).toMatchObject({ code: 1001 });
+    expect(mockAdapter.getCallCount()).toBe(0);
+  });
+});
+
+describe('createApiClient - DEBUG request/error gating', () => {
+  let consoleDebugSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let originalDebug: string | undefined;
+
+  beforeEach(() => {
+    stubSetTimeout();
+    originalDebug = process.env.DEBUG;
+    consoleDebugSpy = spyOn(console, 'debug').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+    consoleDebugSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (originalDebug === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = originalDebug;
+    }
+  });
+
+  it('logs nothing on the request or error path when DEBUG is unset', async () => {
+    delete process.env.DEBUG;
+    const mockAdapter = createMockAdapter([
+      { status: 500, data: { error: { message: 'boom' } } },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    try {
+      await client.get('/test');
+    } catch {
+      // expected — we only care about the debug log absence
+    }
+
+    expect(consoleDebugSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs the error line and redacts the error body when DEBUG is set', async () => {
+    process.env.DEBUG = 'true';
+    const mockAdapter = createMockAdapter([
+      {
+        status: 500,
+        data: { error: { message: 'boom' }, access_token: 'top-secret' },
+      },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    try {
+      await client.get('/test');
+    } catch {
+      // expected
+    }
+
+    const output = consoleDebugSpy.mock.calls
+      .map((args) => args.map((a) => String(a)).join(' '))
+      .join('\n');
+    expect(output).toContain('[HTTP] Error:');
+    expect(output).toContain('[HTTP] Error Response Body:');
+    expect(output).toContain('[REDACTED]');
+    expect(output).not.toContain('top-secret');
+  });
+});

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -14,189 +14,20 @@ import {
 import { createApiClient } from '../../src/services/api-client.service.js';
 import { OAuthService } from '../../src/services/oauth.service.js';
 import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
-import { createMockConfigService, createMockOutputService } from '../setup.js';
+import {
+  createMockAdapter,
+  createMockConfigService,
+  createMockOAuthService,
+  createMockOutputService,
+  createNetworkErrorAdapter,
+  createTimeoutErrorAdapter,
+  mockConfigService,
+  mockOAuthConfigService,
+} from '../setup.js';
 import type { AxiosInstance } from 'axios';
-
-function mockConfigService() {
-  return createMockConfigService({
-    username: 'testuser',
-    apiToken: 'testtoken',
-  });
-}
-
-function mockOAuthConfigService() {
-  return createMockConfigService({
-    authMethod: 'oauth',
-    oauthAccessToken: 'oauth-access-token',
-    oauthRefreshToken: 'oauth-refresh-token',
-    oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
-  });
-}
-
-/**
- * Helper: creates an axios adapter that returns responses from a queue.
- * Each entry is either a successful response or an error response.
- * Tracks the number of calls made.
- */
-function createMockAdapter(
-  responses: Array<{
-    status: number;
-    data?: unknown;
-    headers?: Record<string, string>;
-  }>
-) {
-  let callCount = 0;
-  const adapter = (config: unknown) => {
-    const idx = callCount;
-    callCount++;
-    const resp = responses[idx] ?? responses[responses.length - 1];
-    if (resp.status >= 200 && resp.status < 300) {
-      return Promise.resolve({
-        data: resp.data ?? {},
-        status: resp.status,
-        statusText: 'OK',
-        headers: resp.headers ?? {},
-        config,
-      });
-    }
-    // Simulate an axios error for non-2xx
-    const error = new Error(`Request failed with status code ${resp.status}`);
-    (error as any).response = {
-      data: resp.data ?? {},
-      status: resp.status,
-      statusText: resp.status.toString(),
-      headers: resp.headers ?? {},
-      config,
-    };
-    (error as any).config = config;
-    (error as any).isAxiosError = true;
-    // For network errors we handle separately; here we always have a response
-    return Promise.reject(error);
-  };
-
-  return {
-    adapter,
-    getCallCount: () => callCount,
-  };
-}
-
-/**
- * Helper: creates an adapter that simulates an axios request timeout.
- *
- * A real axios timeout rejects with an error that has `code === 'ECONNABORTED'`
- * (or 'ETIMEDOUT'), `request` set, and NO `response` — exactly like a generic
- * network error but with `code` populated. This routes through the same
- * `else if (error.request)` branch a real timeout hits. The presence of
- * `code` is what lets the client emit a timeout-specific message.
- */
-function createTimeoutErrorAdapter(
-  code: 'ECONNABORTED' | 'ETIMEDOUT' = 'ECONNABORTED',
-  options: { succeedAfter?: number } = {}
-) {
-  let callCount = 0;
-  let lastError: unknown;
-  const adapter = (_config: unknown) => {
-    callCount++;
-    if (
-      options.succeedAfter !== undefined &&
-      callCount > options.succeedAfter
-    ) {
-      return Promise.resolve({
-        data: { ok: true },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: _config,
-      });
-    }
-    const error = new Error(`timeout of 30000ms exceeded`);
-    (error as any).code = code;
-    (error as any).request = {}; // request was sent...
-    // ...but no `response` was ever received.
-    (error as any).config = _config;
-    (error as any).isAxiosError = true;
-    lastError = error;
-    return Promise.reject(error);
-  };
-  return {
-    adapter,
-    getCallCount: () => callCount,
-    getLastError: () => lastError,
-  };
-}
-
-/**
- * Helper: creates an adapter that simulates a network error (no response).
- * Optionally tags the error with a `code` (e.g. 'ECONNRESET') and/or starts
- * succeeding after the first `succeedAfter` calls have failed.
- */
-function createNetworkErrorAdapter(
-  options: { code?: string; succeedAfter?: number } = {}
-) {
-  let callCount = 0;
-  const adapter = (_config: unknown) => {
-    callCount++;
-    if (
-      options.succeedAfter !== undefined &&
-      callCount > options.succeedAfter
-    ) {
-      return Promise.resolve({
-        data: { ok: true },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: _config,
-      });
-    }
-    const error = new Error('Network Error');
-    if (options.code !== undefined) {
-      (error as any).code = options.code;
-    }
-    (error as any).request = {}; // has request but no response
-    (error as any).config = _config;
-    (error as any).isAxiosError = true;
-    return Promise.reject(error);
-  };
-  return {
-    adapter,
-    getCallCount: () => callCount,
-  };
-}
 
 // Speed up the sleep() calls by overriding global setTimeout
 const originalSetTimeout = globalThis.setTimeout;
-
-/**
- * Creates a mock OAuthService.
- */
-function createMockOAuthService(
-  options: {
-    validToken?: string;
-    refreshedToken?: string;
-    refreshShouldFail?: boolean;
-  } = {}
-) {
-  let refreshCallCount = 0;
-  return {
-    service: {
-      async getValidAccessToken() {
-        return options.validToken ?? 'valid-oauth-token';
-      },
-      async refreshAccessToken() {
-        refreshCallCount++;
-        if (options.refreshShouldFail) {
-          throw new Error('Refresh failed');
-        }
-        return options.refreshedToken ?? 'refreshed-oauth-token';
-      },
-      async authorize() {
-        return { username: 'user', displayName: 'User', accountId: '123' };
-      },
-      async revokeToken() {},
-    } as any,
-    getRefreshCallCount: () => refreshCallCount,
-  };
-}
 
 describe('createApiClient - OAuth auth', () => {
   let client: AxiosInstance;

--- a/tests/services/api-client.test.ts
+++ b/tests/services/api-client.test.ts
@@ -21,12 +21,15 @@ import {
   createMockOutputService,
   createNetworkErrorAdapter,
   createTimeoutErrorAdapter,
+  createUrlKeyedAdapter,
   mockConfigService,
   mockOAuthConfigService,
+  restoreSetTimeout,
+  stubSetTimeout,
 } from '../setup.js';
 import type { AxiosInstance } from 'axios';
 
-// Speed up the sleep() calls by overriding global setTimeout
+// Kept for the concurrency test that awaits a real timer.
 const originalSetTimeout = globalThis.setTimeout;
 
 describe('createApiClient - OAuth auth', () => {
@@ -34,15 +37,12 @@ describe('createApiClient - OAuth auth', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -231,15 +231,12 @@ describe('createApiClient - shared instance concurrency', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -408,17 +405,14 @@ describe('createApiClient - retry/backoff', () => {
 
   beforeEach(() => {
     // Make setTimeout resolve instantly to avoid real delays
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
 
     // Suppress retry log noise in test output
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -586,211 +580,16 @@ describe('createApiClient - retry/backoff', () => {
   });
 });
 
-describe('createApiClient - DEBUG response logging redaction', () => {
-  let client: AxiosInstance;
-  let consoleDebugSpy: ReturnType<typeof spyOn>;
-  let consoleErrorSpy: ReturnType<typeof spyOn>;
-  let originalDebug: string | undefined;
-
-  beforeEach(() => {
-    originalDebug = process.env.DEBUG;
-    consoleDebugSpy = spyOn(console, 'debug').mockImplementation(() => {});
-    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    consoleDebugSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    if (originalDebug === undefined) {
-      delete process.env.DEBUG;
-    } else {
-      process.env.DEBUG = originalDebug;
-    }
-  });
-
-  function allDebugOutput(): string {
-    return consoleDebugSpy.mock.calls
-      .map((args) => args.map((a) => String(a)).join(' '))
-      .join('\n');
-  }
-
-  it('redacts access_token and refresh_token from response body logs', async () => {
-    process.env.DEBUG = 'true';
-    const mockAdapter = createMockAdapter([
-      {
-        status: 200,
-        data: {
-          access_token: 'secret-AT',
-          refresh_token: 'secret-RT',
-          expires_in: 7200,
-          scopes: 'repository',
-        },
-      },
-    ]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/test');
-
-    const output = allDebugOutput();
-    expect(output).toContain('[HTTP] Response Body:');
-    expect(output).not.toContain('secret-AT');
-    expect(output).not.toContain('secret-RT');
-    expect(output).toContain('[REDACTED]');
-    // Non-sensitive fields still logged.
-    expect(output).toContain('expires_in');
-    expect(output).toContain('7200');
-    expect(output).toContain('scopes');
-  });
-
-  it('redacts tokens from error response body logs', async () => {
-    process.env.DEBUG = 'true';
-    const mockAdapter = createMockAdapter([
-      {
-        status: 400,
-        data: { error: 'invalid_grant', access_token: 'leaked' },
-      },
-    ]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    try {
-      await client.get('/test');
-    } catch {
-      // expected
-    }
-
-    const output = allDebugOutput();
-    expect(output).toContain('[HTTP] Error Response Body:');
-    expect(output).not.toContain('leaked');
-    expect(output).toContain('[REDACTED]');
-    expect(output).toContain('invalid_grant');
-  });
-
-  it('redacts sensitive keys nested inside arrays and objects', async () => {
-    process.env.DEBUG = 'true';
-    const mockAdapter = createMockAdapter([
-      {
-        status: 200,
-        data: {
-          data: {
-            items: [
-              { id: 1, token: 'nested-secret' },
-              { id: 2, password: 'also-secret' },
-            ],
-          },
-        },
-      },
-    ]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/test');
-
-    const output = allDebugOutput();
-    expect(output).not.toContain('nested-secret');
-    expect(output).not.toContain('also-secret');
-    expect(output).toContain('[REDACTED]');
-  });
-
-  it('does not log response bodies when DEBUG is not set', async () => {
-    delete process.env.DEBUG;
-    const mockAdapter = createMockAdapter([
-      {
-        status: 200,
-        data: { access_token: 'should-never-log' },
-      },
-    ]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/test');
-
-    expect(consoleDebugSpy).not.toHaveBeenCalled();
-  });
-
-  it('handles circular references without infinite recursion', async () => {
-    process.env.DEBUG = 'true';
-
-    // Build a circular structure that the client should log without blowing
-    // up. We don't construct the cycle in the adapter response directly
-    // because JSON.stringify in the test harness would fail; instead inject
-    // one through the redact helper via the actual response logging path.
-    const cyclic: Record<string, unknown> = { name: 'root' };
-    cyclic.self = cyclic;
-
-    const mockAdapter = createMockAdapter([{ status: 200, data: cyclic }]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/test');
-
-    const output = allDebugOutput();
-    expect(output).toContain('[HTTP] Response Body:');
-    expect(output).toContain('[Circular]');
-    expect(output).toContain('root');
-  });
-
-  it('handles circular references nested inside arrays', async () => {
-    process.env.DEBUG = 'true';
-
-    const child: Record<string, unknown> = { id: 1 };
-    const parent: Record<string, unknown> = { children: [child] };
-    child.parent = parent;
-
-    const mockAdapter = createMockAdapter([{ status: 200, data: parent }]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/test');
-
-    const output = allDebugOutput();
-    expect(output).toContain('[Circular]');
-  });
-
-  it('logs request method and URL when DEBUG is set', async () => {
-    process.env.DEBUG = 'true';
-    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/some/resource');
-
-    const output = allDebugOutput();
-    expect(output).toContain('[HTTP] GET');
-    expect(output).toContain('/some/resource');
-  });
-
-  it('redacts query strings from request URL DEBUG logs', async () => {
-    process.env.DEBUG = 'true';
-    const mockAdapter = createMockAdapter([{ status: 200, data: {} }]);
-    client = createApiClient(mockConfigService(), createMockOutputService());
-    client.defaults.adapter = mockAdapter.adapter as any;
-
-    await client.get('/some/resource?token=abc&other=xyz');
-
-    const output = allDebugOutput();
-    expect(output).toContain('[HTTP] GET');
-    expect(output).toContain('/some/resource');
-    expect(output).not.toContain('token=abc');
-    expect(output).not.toContain('other=xyz');
-    expect(output).toContain('[redacted]');
-  });
-});
-
 describe('createApiClient - authentication header', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -869,7 +668,7 @@ describe('createApiClient - Retry-After parsing', () => {
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -962,15 +761,12 @@ describe('createApiClient - error message extraction', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 
@@ -1140,16 +936,13 @@ describe('createApiClient - retry messages route through IOutputService', () => 
   let consoleWarnSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
     consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
   });
@@ -1269,7 +1062,7 @@ describe('createApiClient - request timeout (#249)', () => {
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
     if (originalTimeoutEnv === undefined) {
       delete process.env.BB_HTTP_TIMEOUT;
@@ -1401,15 +1194,12 @@ describe('createApiClient - transient network error retry (#267)', () => {
 
   beforeEach(() => {
     // Make sleep() instant so retries don't slow down the suite.
-    globalThis.setTimeout = ((fn: Function, _ms?: number) => {
-      fn();
-      return 0 as any;
-    }) as any;
+    stubSetTimeout();
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    restoreSetTimeout();
     consoleErrorSpy.mockRestore();
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,8 +3,13 @@
  */
 
 import { beforeEach, afterEach } from 'bun:test';
+import axios, {
+  type AxiosAdapter,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 import { Container } from '../src/core/container.js';
 import { ContextService } from '../src/services/context.service.js';
+import type { OAuthService } from '../src/services/oauth.service.js';
 import type {
   IConfigService,
   ICredentialStore,
@@ -24,6 +29,7 @@ import type {
 } from '../src/types/config.js';
 
 const originalNodeEnv = process.env.NODE_ENV;
+const originalSetTimeout = globalThis.setTimeout;
 
 // Reset container before each test
 beforeEach(() => {
@@ -509,6 +515,52 @@ export const mockDiffStat = {
  * api-client.test.ts and api-client.interceptors.test.ts).
  */
 
+type MockResponse = {
+  status: number;
+  data?: unknown;
+  headers?: Record<string, string>;
+};
+
+/** Shared success/error shaping for the queue-based adapters below. */
+function resolveMockResponse(
+  config: InternalAxiosRequestConfig,
+  resp: MockResponse
+) {
+  const response = {
+    data: resp.data ?? {},
+    status: resp.status,
+    statusText:
+      resp.status >= 200 && resp.status < 300 ? 'OK' : resp.status.toString(),
+    headers: resp.headers ?? {},
+    config,
+  };
+  if (resp.status >= 200 && resp.status < 300) {
+    return Promise.resolve(response);
+  }
+  // Simulate an axios error for non-2xx (isAxiosError is set by the ctor)
+  return Promise.reject(
+    new axios.AxiosError(
+      `Request failed with status code ${resp.status}`,
+      undefined,
+      config,
+      undefined,
+      response
+    )
+  );
+}
+
+/** Make the interceptor's setTimeout-based backoff run synchronously. */
+export function stubSetTimeout(): void {
+  globalThis.setTimeout = ((fn: Function, _ms?: number) => {
+    fn();
+    return 0 as never;
+  }) as never;
+}
+
+export function restoreSetTimeout(): void {
+  globalThis.setTimeout = originalSetTimeout;
+}
+
 export function mockConfigService() {
   return createMockConfigService({
     username: 'testuser',
@@ -527,43 +579,22 @@ export function mockOAuthConfigService() {
 
 /**
  * Creates an axios adapter that returns responses from a queue. Each entry
- * is either a successful response or an error response. Tracks the number
- * of calls made.
+ * is either a successful response or an error response; the last entry
+ * repeats indefinitely. Tracks the number of calls made.
  */
 export function createMockAdapter(
-  responses: Array<{
-    status: number;
-    data?: unknown;
-    headers?: Record<string, string>;
-  }>
-) {
+  responses: MockResponse[],
+  options: {
+    onRequest?: (config: InternalAxiosRequestConfig) => void;
+  } = {}
+): { adapter: AxiosAdapter; getCallCount: () => number } {
   let callCount = 0;
-  const adapter = (config: unknown) => {
+  const adapter: AxiosAdapter = (config) => {
     const idx = callCount;
     callCount++;
+    options.onRequest?.(config);
     const resp = responses[idx] ?? responses[responses.length - 1];
-    if (resp.status >= 200 && resp.status < 300) {
-      return Promise.resolve({
-        data: resp.data ?? {},
-        status: resp.status,
-        statusText: 'OK',
-        headers: resp.headers ?? {},
-        config,
-      });
-    }
-    // Simulate an axios error for non-2xx
-    const error = new Error(`Request failed with status code ${resp.status}`);
-    (error as any).response = {
-      data: resp.data ?? {},
-      status: resp.status,
-      statusText: resp.status.toString(),
-      headers: resp.headers ?? {},
-      config,
-    };
-    (error as any).config = config;
-    (error as any).isAxiosError = true;
-    // For network errors we handle separately; here we always have a response
-    return Promise.reject(error);
+    return resolveMockResponse(config, resp);
   };
 
   return {
@@ -583,10 +614,14 @@ export function createMockAdapter(
 export function createTimeoutErrorAdapter(
   code: 'ECONNABORTED' | 'ETIMEDOUT' = 'ECONNABORTED',
   options: { succeedAfter?: number } = {}
-) {
+): {
+  adapter: AxiosAdapter;
+  getCallCount: () => number;
+  getLastError: () => unknown;
+} {
   let callCount = 0;
   let lastError: unknown;
-  const adapter = (_config: unknown) => {
+  const adapter: AxiosAdapter = (config) => {
     callCount++;
     if (
       options.succeedAfter !== undefined &&
@@ -597,15 +632,16 @@ export function createTimeoutErrorAdapter(
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: _config,
+        config,
       });
     }
-    const error = new Error(`timeout of 30000ms exceeded`);
-    (error as any).code = code;
-    (error as any).request = {}; // request was sent...
-    // ...but no `response` was ever received.
-    (error as any).config = _config;
-    (error as any).isAxiosError = true;
+    // request was sent ({}), but no response was ever received
+    const error = new axios.AxiosError(
+      `timeout of 30000ms exceeded`,
+      code,
+      config,
+      {}
+    );
     lastError = error;
     return Promise.reject(error);
   };
@@ -623,9 +659,9 @@ export function createTimeoutErrorAdapter(
  */
 export function createNetworkErrorAdapter(
   options: { code?: string; succeedAfter?: number } = {}
-) {
+): { adapter: AxiosAdapter; getCallCount: () => number } {
   let callCount = 0;
-  const adapter = (_config: unknown) => {
+  const adapter: AxiosAdapter = (config) => {
     callCount++;
     if (
       options.succeedAfter !== undefined &&
@@ -636,21 +672,45 @@ export function createNetworkErrorAdapter(
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: _config,
+        config,
       });
     }
-    const error = new Error('Network Error');
-    if (options.code !== undefined) {
-      (error as any).code = options.code;
-    }
-    (error as any).request = {}; // has request but no response
-    (error as any).config = _config;
-    (error as any).isAxiosError = true;
+    // has request but no response
+    const error = new axios.AxiosError(
+      'Network Error',
+      options.code,
+      config,
+      {}
+    );
     return Promise.reject(error);
   };
   return {
     adapter,
     getCallCount: () => callCount,
+  };
+}
+
+/**
+ * Creates an adapter with a per-URL response queue, so concurrent requests
+ * to different paths each consume their own sequence. Used to prove
+ * interceptor state is per-request, not per-instance.
+ */
+export function createUrlKeyedAdapter(routes: Record<string, MockResponse[]>): {
+  adapter: AxiosAdapter;
+  getCallCount: (url: string) => number;
+} {
+  const callCounts: Record<string, number> = {};
+  const adapter: AxiosAdapter = (config) => {
+    const url = config.url ?? '';
+    const idx = callCounts[url] ?? 0;
+    callCounts[url] = idx + 1;
+    const queue = routes[url] ?? [];
+    const resp = queue[idx] ?? queue[queue.length - 1];
+    return resolveMockResponse(config, resp);
+  };
+  return {
+    adapter,
+    getCallCount: (url: string) => callCounts[url] ?? 0,
   };
 }
 
@@ -681,7 +741,7 @@ export function createMockOAuthService(
         return { username: 'user', displayName: 'User', accountId: '123' };
       },
       async revokeToken() {},
-    } as any,
+    } as unknown as OAuthService,
     getRefreshCallCount: () => refreshCallCount,
   };
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -503,3 +503,185 @@ export const mockDiffStat = {
   lines_added: 1,
   lines_removed: 1,
 };
+
+/**
+ * Axios client mocks shared by the api-client suites (tests/services/
+ * api-client.test.ts and api-client.interceptors.test.ts).
+ */
+
+export function mockConfigService() {
+  return createMockConfigService({
+    username: 'testuser',
+    apiToken: 'testtoken',
+  });
+}
+
+export function mockOAuthConfigService() {
+  return createMockConfigService({
+    authMethod: 'oauth',
+    oauthAccessToken: 'oauth-access-token',
+    oauthRefreshToken: 'oauth-refresh-token',
+    oauthExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+  });
+}
+
+/**
+ * Creates an axios adapter that returns responses from a queue. Each entry
+ * is either a successful response or an error response. Tracks the number
+ * of calls made.
+ */
+export function createMockAdapter(
+  responses: Array<{
+    status: number;
+    data?: unknown;
+    headers?: Record<string, string>;
+  }>
+) {
+  let callCount = 0;
+  const adapter = (config: unknown) => {
+    const idx = callCount;
+    callCount++;
+    const resp = responses[idx] ?? responses[responses.length - 1];
+    if (resp.status >= 200 && resp.status < 300) {
+      return Promise.resolve({
+        data: resp.data ?? {},
+        status: resp.status,
+        statusText: 'OK',
+        headers: resp.headers ?? {},
+        config,
+      });
+    }
+    // Simulate an axios error for non-2xx
+    const error = new Error(`Request failed with status code ${resp.status}`);
+    (error as any).response = {
+      data: resp.data ?? {},
+      status: resp.status,
+      statusText: resp.status.toString(),
+      headers: resp.headers ?? {},
+      config,
+    };
+    (error as any).config = config;
+    (error as any).isAxiosError = true;
+    // For network errors we handle separately; here we always have a response
+    return Promise.reject(error);
+  };
+
+  return {
+    adapter,
+    getCallCount: () => callCount,
+  };
+}
+
+/**
+ * Creates an adapter that simulates an axios request timeout. A real axios
+ * timeout rejects with an error that has `code === 'ECONNABORTED'` (or
+ * 'ETIMEDOUT'), `request` set, and NO `response` — exactly like a generic
+ * network error but with `code` populated. This routes through the same
+ * `else if (error.request)` branch a real timeout hits. The presence of
+ * `code` is what lets the client emit a timeout-specific message.
+ */
+export function createTimeoutErrorAdapter(
+  code: 'ECONNABORTED' | 'ETIMEDOUT' = 'ECONNABORTED',
+  options: { succeedAfter?: number } = {}
+) {
+  let callCount = 0;
+  let lastError: unknown;
+  const adapter = (_config: unknown) => {
+    callCount++;
+    if (
+      options.succeedAfter !== undefined &&
+      callCount > options.succeedAfter
+    ) {
+      return Promise.resolve({
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: _config,
+      });
+    }
+    const error = new Error(`timeout of 30000ms exceeded`);
+    (error as any).code = code;
+    (error as any).request = {}; // request was sent...
+    // ...but no `response` was ever received.
+    (error as any).config = _config;
+    (error as any).isAxiosError = true;
+    lastError = error;
+    return Promise.reject(error);
+  };
+  return {
+    adapter,
+    getCallCount: () => callCount,
+    getLastError: () => lastError,
+  };
+}
+
+/**
+ * Creates an adapter that simulates a network error (no response).
+ * Optionally tags the error with a `code` (e.g. 'ECONNRESET') and/or starts
+ * succeeding after the first `succeedAfter` calls have failed.
+ */
+export function createNetworkErrorAdapter(
+  options: { code?: string; succeedAfter?: number } = {}
+) {
+  let callCount = 0;
+  const adapter = (_config: unknown) => {
+    callCount++;
+    if (
+      options.succeedAfter !== undefined &&
+      callCount > options.succeedAfter
+    ) {
+      return Promise.resolve({
+        data: { ok: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: _config,
+      });
+    }
+    const error = new Error('Network Error');
+    if (options.code !== undefined) {
+      (error as any).code = options.code;
+    }
+    (error as any).request = {}; // has request but no response
+    (error as any).config = _config;
+    (error as any).isAxiosError = true;
+    return Promise.reject(error);
+  };
+  return {
+    adapter,
+    getCallCount: () => callCount,
+  };
+}
+
+/**
+ * Creates a mock OAuthService for driving the api-client interceptor.
+ */
+export function createMockOAuthService(
+  options: {
+    validToken?: string;
+    refreshedToken?: string;
+    refreshShouldFail?: boolean;
+  } = {}
+) {
+  let refreshCallCount = 0;
+  return {
+    service: {
+      async getValidAccessToken() {
+        return options.validToken ?? 'valid-oauth-token';
+      },
+      async refreshAccessToken() {
+        refreshCallCount++;
+        if (options.refreshShouldFail) {
+          throw new Error('Refresh failed');
+        }
+        return options.refreshedToken ?? 'refreshed-oauth-token';
+      },
+      async authorize() {
+        return { username: 'user', displayName: 'User', accountId: '123' };
+      },
+      async revokeToken() {},
+    } as any,
+    getRefreshCallCount: () => refreshCallCount,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #265 — direct coverage of the `createApiClient` interceptor stack (retry/backoff, one-shot 401 refresh, auth selection, error mapping, DEBUG redaction). One behavior-correcting production change: `redactRequestUrl` now mirrors axios's `baseURL + url` concatenation so the opt-in DEBUG log shows the true wire URL (the `/2.0` base path is preserved).

## What's covered

**`tests/services/api-client.interceptors.test.ts`** (25 tests):
- 401 refresh precision: the replayed request carries `Authorization: Bearer <refreshed-token>` (stateful store mock proves the request interceptor picks up the rotated token); the auth-method re-check on 401 suppresses refresh when the method flipped to basic; the shared retry/refresh budget across a 401 → 429 → 200 replay
- Retry matrix: 504 retry-then-success, POST-on-429, 502/503/504 exhaustion → `API_SERVER_ERROR`, HTTP-date `Retry-After` → exponential backoff
- `APIError` shape: context `{status, method, url}` exact, raw body preserved, 403/500/400 mapping, `UNKNOWN` branch with `cause`
- Interceptor edges: request-interceptor rejections map to `UNKNOWN` with the original error as `cause` (pins the actual axios chain behavior)
- DEBUG logging & redaction: full matrix moved here from api-client.test.ts (single owner) — response/error-body redaction, nested keys, circular refs, request-URL logging, query scrubbing, plus request/error-path gating when `DEBUG` is unset

**`tests/services/api-client.helpers.test.ts`** (24 tests): direct unit tests for the exported pure helpers — `redactSensitive` (case-insensitive keys, nested arrays/objects, seen-set semantics), `redactRequestUrl` (query scrubbing, base-path preservation, absolute URLs, parse-failure fallback), `getRetryDelay` matrix, `extractErrorMessage` fall-throughs, `formatErrorFields`.

**Refactor**: shared axios mock helpers moved to `tests/setup.ts` (per AGENTS.md), rebuilt on a typed `AxiosAdapter` core via `new axios.AxiosError(...)` with an `onRequest` hook — the queue adapters no longer hand-shape errors with `as any`. `stubSetTimeout`/`restoreSetTimeout` shared by both suites.

## Review

Clean-room thermo-nuclear review (4 reviewers): no blockers; all structural findings addressed in the follow-up commit — DEBUG matrix consolidated into one owner (giant file 1715 → ~1350 lines), base-path bug fixed, `parseInt` doc lie corrected, scaffolding deduped, 4 uncovered branches added.

## Verification
- `bun test`: 1583 pass / 0 fail (also verified TTY-clean)
- `bun run lint` + `bun run format:check` clean; CI green on all 3 OS legs
