### PR TITLE
chore: add contract test pinning the generated client to the spec (#266)

### DIFF
--- a/.changeset/api-contract-test.md
+++ b/.changeset/api-contract-test.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+chore(ci): add a contract test pinning the generated API client to the pinned spec (#266)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,53 @@ jobs:
       - name: Check formatting
         run: bun run format:check
 
+  api-contract:
+    name: API client contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # The pinned generator version and its output are byte-stable, but the
+      # JDK must be hermetic too: runner-image Java can drift between
+      # ubuntu-latest image updates (issue #266).
+      - name: Setup Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock*') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      # The generator jar (~95 MB) is fetched from Maven Central on first
+      # generate, not by bun install; cache it in its storageDir
+      # (openapitools.json) so every PR does not pay the download.
+      - name: Cache OpenAPI generator jar
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .cache/openapi-generator
+          key: ${{ runner.os }}-openapi-generator-${{ hashFiles('openapitools.json', 'bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Regenerates src/generated/ from the pinned spec and fails when the
+      # committed client differs (issue #266).
+      - name: Check generated client matches the pinned spec
+        run: bun run check:api-contract
+
   test:
     name: Test & build (${{ matrix.os }})
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ node_modules/
 dist/
 docs/.astro/
 
-# Generated API client - we commit this to avoid requiring Java/generator in CI
+# Generated API client - we commit this so consumers never need Java or the
+# generator; the api-contract CI job proves it matches the pinned spec
 # src/generated/
 
 # Environment files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ bun run format:check # Prettier check
 
 # Generated API
 bun run generate:api # Regenerate src/generated/ from the pinned spec
+bun run check:api-contract # Regenerate and fail if src/generated/ drifts (CI gate)
 bun run check:api-updates # Check if the pinned spec has an upstream update (0=current, 1=update, 2=unverifiable)
 bun run update:api # Download the latest spec, regenerate src/generated/, restore the old spec if generation fails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Before pushing:
 bun test
 bun run lint
 bun run format:check
+bun run check:api-contract   # regenerates src/generated/ and fails on drift
 ```
 
 ### 3. Add a Changeset

--- a/openapitools.json
+++ b/openapitools.json
@@ -3,6 +3,7 @@
   "spaces": 2,
   "generator-cli": {
     "version": "7.19.0",
+    "storageDir": ".cache/openapi-generator",
     "generators": {
       "bitbucket": {
         "generatorName": "typescript-axios",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:api": "bun scripts/normalize-spec.ts && openapi-generator-cli generate && bun scripts/patch-generated.ts",
+    "check:api-contract": "bun scripts/check-api-contract.ts",
     "check:api-updates": "bun scripts/check-api-updates.ts check",
     "update:api": "bun scripts/check-api-updates.ts update",
     "docs:dev": "cd docs && bun run dev",

--- a/scripts/check-api-contract.ts
+++ b/scripts/check-api-contract.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+// Contract test for the generated API client (issue #266).
+//
+// Regenerates src/generated/ from the pinned spec with `bun run generate:api`
+// and fails when the committed client differs. Drift between the spec, the
+// normalize/patch scripts, and the committed output (or a missed
+// regeneration) would otherwise go undetected — only regeneration can prove
+// the committed client still matches its inputs.
+//
+// Exit codes:
+//   0 - the regenerated client matches the committed one
+//   1 - drift detected, generation failed, or src/generated/ was dirty
+//   2 - the check could not be verified (not a git repository)
+
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const GENERATED_PATH = 'src/generated';
+const repoRoot = resolve(import.meta.dir, '..');
+
+const EXIT_CLEAN = 0;
+const EXIT_DRIFT = 1;
+const EXIT_UNVERIFIABLE = 2;
+
+function gitStatusPorcelain(): { ok: boolean; output: string } {
+  const result = spawnSync(
+    'git',
+    ['status', '--porcelain', '--', GENERATED_PATH],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  return { ok: result.status === 0, output: result.stdout ?? '' };
+}
+
+// Refuse to run over uncommitted work: regeneration would overwrite it, and
+// the resulting comparison could not be trusted anyway.
+const before = gitStatusPorcelain();
+if (!before.ok) {
+  console.error(
+    'api-contract: could not inspect the git working tree; run inside the bitbucket-cli repository'
+  );
+  process.exit(EXIT_UNVERIFIABLE);
+}
+if (before.output.trim() !== '') {
+  console.error(
+    'api-contract: src/generated/ has uncommitted changes; commit or stash them before running'
+  );
+  process.exit(EXIT_DRIFT);
+}
+
+const generate = spawnSync('bun', ['run', 'generate:api'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+});
+if (generate.status !== 0) {
+  console.error('api-contract: generation failed (see output above)');
+  process.exit(EXIT_DRIFT);
+}
+
+const after = gitStatusPorcelain();
+if (!after.ok) {
+  console.error(
+    'api-contract: could not inspect the git working tree after generation'
+  );
+  process.exit(EXIT_UNVERIFIABLE);
+}
+const changes = after.output.trim();
+if (changes !== '') {
+  console.error(
+    'api-contract: the regenerated client differs from the committed one:'
+  );
+  console.error(changes);
+  console.error(
+    'Run `bun run generate:api`, review the diff, and commit it; if the spec changed upstream, use `bun run update:api`.'
+  );
+  process.exit(EXIT_DRIFT);
+}
+
+console.log('api-contract: generated client matches the pinned spec');
+process.exit(EXIT_CLEAN);

--- a/tests/generated-client.smoke.test.ts
+++ b/tests/generated-client.smoke.test.ts
@@ -41,9 +41,13 @@ describe('generated API client', () => {
 
   it('re-exports every *Api class from the barrel index', () => {
     for (const name of apiClassNames()) {
-      expect(name in barrel, `${name} missing from the barrel index`).toBe(
-        true
-      );
+      const barrelBinding = barrel[name as keyof typeof barrel];
+      expect(
+        barrelBinding,
+        `${name} missing from the barrel index`
+      ).toBeDefined();
+      const apiBinding = api[name as keyof typeof api];
+      expect(barrelBinding).toBe(apiBinding);
     }
   });
 });

--- a/tests/generated-client.smoke.test.ts
+++ b/tests/generated-client.smoke.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Smoke test for the generated API client (issue #266).
+ *
+ * Only a subset of the generated *Api classes is wired into commands, so the
+ * rest are never imported at runtime — a broken class (missing export, import
+ * cycle, runtime error at module load) would go unnoticed by command tests.
+ * This suite imports every class and asserts each one is constructible.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import * as api from '../src/generated/api.js';
+import * as barrel from '../src/generated/index.js';
+
+// Floor below the 23 classes generated today; guards against a spec update
+// silently gutting the client without a hardcoded list that would then rot.
+const MIN_API_CLASSES = 20;
+
+function apiClassNames(): string[] {
+  return Object.keys(api).filter((name) => name.endsWith('Api'));
+}
+
+describe('generated API client', () => {
+  it('exports every *Api class as a constructible class', () => {
+    const apiClasses = Object.entries(api).filter(([name]) =>
+      name.endsWith('Api')
+    ) as Array<[string, unknown]>;
+
+    expect(apiClasses.length).toBeGreaterThanOrEqual(MIN_API_CLASSES);
+
+    for (const [name, exported] of apiClasses) {
+      const isClass = Function.prototype.toString
+        .call(exported)
+        .startsWith('class ');
+      expect(isClass, `${name} should be a class`).toBe(true);
+      expect(
+        () => new (exported as new () => unknown)(),
+        `${name} should construct with no arguments`
+      ).not.toThrow();
+    }
+  });
+
+  it('re-exports every *Api class from the barrel index', () => {
+    for (const name of apiClassNames()) {
+      expect(name in barrel, `${name} missing from the barrel index`).toBe(
+        true
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a contract test that regenerates `src/generated/` from the pinned Bitbucket spec and fails when the committed client differs (issue #266). `src/generated/` is hand-committed and never regenerated in CI, and `patch-generated.ts` rewrites it post-generation — drift between the spec, the scripts, and the committed output would otherwise go undetected.

## Changes

- **`scripts/check-api-contract.ts`** (+ `bun run check:api-contract`): runs `generate:api`, then fails if `git status --porcelain -- src/generated` is non-empty (covers both modified and untracked files). Aborts early if `src/generated/` is dirty so regeneration never clobbers uncommitted work. Exit codes mirror `check-api-updates` (0 clean / 1 drift / 2 unverifiable).
- **`.github/workflows/ci.yml`** — new `api-contract` job (ubuntu-latest, every PR): hermetic temurin 21 via SHA-pinned `setup-java` v5.7.0, caches the ~95 MB generator jar in its new `storageDir`, runs the contract check.
- **`openapitools.json`** — `storageDir: .cache/openapi-generator` (gitignored) so the jar survives across installs and is CI-cacheable.
- **`tests/generated-client.smoke.test.ts`** — imports all 23 generated `*Api` classes and asserts each is constructible and re-exported from the barrel; most are never wired into commands so a broken class would otherwise go unnoticed. No hardcoded class list (floor of 20), so spec updates don't rot it.
- Docs: `CONTRIBUTING.md` pre-push checklist, `AGENTS.md` commands, stale `.gitignore` comment, changeset.

## Verification

Empirically confirmed regeneration is byte-deterministic (clean `git status` after a full regenerate), then exercised every failure mode:

- ✅ green path → exit 0
- ✅ dirty pre-check (modified + untracked files) → exit 1, "commit or stash"
- ✅ post-generation drift (spec tweak) → exit 1, porcelain + actionable hint
- ✅ generation failure → exit 1

`bun run lint`, `bun run format:check`, and the full test suite (1591 tests incl. the new smoke suite) all pass.

Closes #266