### PR TITLE
feat(alias): user-defined command aliases (bb alias set/list/delete)

### DIFF
--- a/.changeset/alias-commands.md
+++ b/.changeset/alias-commands.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+New `bb alias` command group for user-defined command aliases, mirroring `gh alias` (#275). `bb alias set <name> <expansion>` persists an alias in `config.json`; the alias then expands in place of the first argument (`bb co 42` → `bb pr checkout 42`). Expansions support `$1`–`$9` argument placeholders, and a `!` prefix runs the expansion through `sh -c` with the remaining arguments as shell positional parameters. `bb alias list` and `bb alias delete <name>` complete the surface; all three support `--json`. Aliases can never shadow built-in commands.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -125,6 +125,7 @@ export default defineConfig({
               label: "API",
               slug: "commands/api",
             },
+            { label: "Alias Commands", slug: "commands/alias" },
             { label: "Config Commands", slug: "commands/config" },
             { label: "Completion", slug: "commands/completion" },
           ],

--- a/docs/src/content/docs/commands/alias.mdx
+++ b/docs/src/content/docs/commands/alias.mdx
@@ -1,0 +1,92 @@
+---
+title: Alias Commands
+description: Create shortcuts for bb commands
+---
+
+Create your own shortcuts for `bb` commands, mirroring `gh alias`. An alias
+expands in place of the first argument: after `bb alias set co "pr checkout $1"`,
+running `bb co 42` runs `bb pr checkout 42`.
+
+Aliases are stored in the `aliases` map of the [configuration file](/reference/configuration/)
+and are managed with the commands below (not with `bb config set`).
+
+## How expansion works
+
+- The first argument after `bb` is looked up in your alias map. Built-in
+  command names always win: an alias can never shadow a real `bb` command.
+- `$1`–`$9` placeholders in the expansion are filled from the arguments that
+  follow the alias. Missing arguments are an error.
+- Arguments not consumed by a placeholder are appended to the expanded command.
+- Expansion is a single level deep — an alias cannot reference another alias.
+
+## `bb alias set`
+
+Create or update an alias.
+
+```bash
+bb alias set <name> <expansion>
+```
+
+### Examples
+
+```bash
+# Shortcut with a placeholder
+bb alias set co "pr checkout $1"
+bb co 42                      # → bb pr checkout 42
+
+# Shortcut for a flag-heavy invocation
+bb alias set prd "pr create --draft"
+bb prd -t "My PR"             # → bb pr create --draft -t "My PR"
+
+# JSON output
+bb alias set co "pr checkout $1" --json
+```
+
+### Shell passthrough (`!` prefix)
+
+An expansion starting with `!` is run through `sh -c` instead of being parsed
+as a `bb` command. The arguments after the alias are available as shell
+positional parameters (`$1`, `$@`), so pipes, `xargs`, and other shell
+constructs work:
+
+```bash
+bb alias set igrep '!bb issue list --all --json | grep "$1"'
+bb igrep login                # → sh -c 'bb issue list --all --json | grep "$1"' bb-alias login
+```
+
+:::caution
+Shell aliases execute arbitrary shell commands you define. They run with your
+permissions, exactly like a shell function or an entry in your shell rc file —
+only define shell aliases you understand. The config file is created with
+`0600` permissions so other local users cannot inject aliases.
+:::
+
+## `bb alias list`
+
+List configured aliases.
+
+```bash
+bb alias list
+```
+
+### Examples
+
+```bash
+bb alias list
+bb alias list --json
+```
+
+## `bb alias delete`
+
+Delete an alias.
+
+```bash
+bb alias delete <name>
+```
+
+### Examples
+
+```bash
+bb alias delete co
+bb alias delete co --json
+```

--- a/docs/src/content/docs/commands/alias.mdx
+++ b/docs/src/content/docs/commands/alias.mdx
@@ -30,8 +30,8 @@ bb alias set <name> <expansion>
 ### Examples
 
 ```bash
-# Shortcut with a placeholder
-bb alias set co "pr checkout $1"
+# Shortcut with a placeholder (single quotes keep $1 literal for bb)
+bb alias set co 'pr checkout $1'
 bb co 42                      # → bb pr checkout 42
 
 # Shortcut for a flag-heavy invocation
@@ -39,7 +39,7 @@ bb alias set prd "pr create --draft"
 bb prd -t "My PR"             # → bb pr create --draft -t "My PR"
 
 # JSON output
-bb alias set co "pr checkout $1" --json
+bb alias set co 'pr checkout $1' --json
 ```
 
 ### Shell passthrough (`!` prefix)

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -26,6 +26,7 @@ On Linux and macOS the CLI creates the directory `0700` and the file `0600`, and
 | `prCreateIncludeDefaultReviewers` | yes | yes | Auto-add the repository's default reviewers on `bb pr create` (default: false) |
 | `username` | yes | no — use `bb auth login` | Bitbucket username |
 | `apiToken` | no — use `bb auth token` | no — use `bb auth login` | Bitbucket API token (masked in `bb config list`) |
+| `aliases` | no — use [`bb alias`](/commands/alias/) | no — use [`bb alias`](/commands/alias/) | User-defined command aliases |
 | `lastVersionCheck` | no | no | Timestamp of the last update check. Auto-managed; `bb config get lastVersionCheck` fails with `Unknown config key` |
 
 `bb auth login` also writes `authMethod` — `basic` for API tokens, `oauth` for OAuth — and, after an OAuth login, the `oauth*` keys (`oauthAccessToken`, `oauthRefreshToken`, `oauthExpiresAt`, and custom consumer credentials). Only `bb auth login` and `bb auth logout` touch those keys; see [Configuration file](/reference/configuration/) for the full schema.

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -45,7 +45,7 @@ On Linux and macOS the CLI creates the directory `0700` and the file `0600`, and
 }
 ```
 
-Don't edit this file by hand. Use `bb config set` for settings and `bb auth login` for credentials.
+Don't edit this file by hand. Use `bb config set` for settings, `bb auth login` for credentials, and [`bb alias`](/commands/alias/) for command aliases.
 
 ## `bb config get`
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -44,6 +44,7 @@ and write it, see the [Config command reference](/commands/config/).
 | `skipVersionCheck` | boolean | Disable update notifications | `bb config set` |
 | `versionCheckInterval` | number | Days between update checks (default: 1) | `bb config set` |
 | `prCreateIncludeDefaultReviewers` | boolean | Auto-add the repository's default reviewers on `bb pr create` (default: false) | `bb config set` |
+| `aliases` | object | User-defined command aliases | `bb alias set` |
 | `lastVersionCheck` | string | Timestamp of last update check | Automatic |
 
 ### Example configuration (OAuth)

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -5,9 +5,9 @@ description: Complete reference for the bb configuration file
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-All persistent settings live in one JSON file, written by `bb auth login` and
-`bb config set`. This page documents the file itself; for the commands that read
-and write it, see the [Config command reference](/commands/config/).
+All persistent settings live in one JSON file, written by `bb auth login`,
+`bb config set`, and `bb alias set`. This page documents the file itself; for
+the commands that read and write it, see the [Config command reference](/commands/config/).
 
 ## File location
 

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -160,15 +160,17 @@ const PLACEHOLDER_PATTERN = /\$([1-9])/g;
 
 /**
  * Fill `$1`–`$9` placeholders in the expansion words from `args` and append
- * any arguments no placeholder consumed. Throws when the expansion references
- * a placeholder the caller didn't supply, naming the alias for a clear error.
+ * every argument no placeholder consumed (in their original order), so sparse
+ * placeholders like `$2` don't drop the first argument. Throws when the
+ * expansion references a placeholder the caller didn't supply, naming the
+ * alias for a clear error.
  */
 export function substitutePlaceholders(
   words: string[],
   args: string[],
   aliasName: string
 ): string[] {
-  let highestUsed = 0;
+  const consumed = new Set<number>();
 
   const substituted = words.map((word) =>
     word.replace(PLACEHOLDER_PATTERN, (_match, digit: string) => {
@@ -181,12 +183,13 @@ export function substitutePlaceholders(
           context: { alias: aliasName, placeholder: index },
         });
       }
-      highestUsed = Math.max(highestUsed, index);
+      consumed.add(index);
       return value;
     })
   );
 
-  return [...substituted, ...args.slice(highestUsed)];
+  const leftover = args.filter((_arg, position) => !consumed.has(position + 1));
+  return [...substituted, ...leftover];
 }
 
 /**
@@ -209,7 +212,11 @@ export function expandAliasArgv(
     return { kind: 'none' };
   }
 
-  const expansion = aliases[candidate];
+  // Own properties only: reading `aliases[candidate]` directly would fall
+  // through to Object.prototype members such as 'toString' or 'constructor'.
+  const expansion = Object.prototype.hasOwnProperty.call(aliases, candidate)
+    ? aliases[candidate]
+    : undefined;
   if (expansion === undefined) {
     return { kind: 'none' };
   }

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,0 +1,229 @@
+/**
+ * User-defined command aliases (issue #275), mirroring `gh alias`.
+ *
+ * Aliases live in the existing `config.json` under an `aliases` map and are
+ * expanded by rewriting argv BEFORE `cli.js` is imported — the CLI module
+ * reads `process.argv` at load time (color/locale/completion resolution), so
+ * expansion cannot happen later. `src/index.ts` owns that ordering.
+ *
+ * Two alias forms, matching `gh`:
+ *  - Command alias: `co` → `pr checkout $1`. The expansion is split into
+ *    shell-style words; `$1`–`$9` placeholders are filled from the arguments
+ *    following the alias, and any leftover arguments are appended.
+ *  - Shell alias: a `!` prefix (`igrep` → `!bb issue list --json | grep $1`)
+ *    runs the body via `sh -c` with the remaining argv as shell positional
+ *    parameters, so `$1`/`$@` behave exactly as in a shell script.
+ *
+ * Expansion is a single level deep: an alias body is never re-expanded, so
+ * aliases cannot reference each other or recurse.
+ */
+
+import { ConfigService } from './services/config.service.js';
+import { BBError, ErrorCode } from './types/errors.js';
+
+/**
+ * Built-in top-level command names that an alias may never shadow. Expansion
+ * also skips these, so a stale alias from an older config can never hijack a
+ * command added in a newer release. Kept in sync with the live Commander tree
+ * by a drift test (tests/alias.test.ts) — add the command here when adding a
+ * top-level command.
+ */
+export const RESERVED_COMMAND_NAMES = [
+  'auth',
+  'repo',
+  'pr',
+  'snippet',
+  'pipeline',
+  'commit',
+  'status',
+  'issue',
+  'workspace',
+  'project',
+  'browse',
+  'api',
+  'config',
+  'completion',
+  'alias',
+  'help',
+] as const;
+
+const ALIAS_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/i;
+
+export function isValidAliasName(name: string): boolean {
+  return ALIAS_NAME_PATTERN.test(name);
+}
+
+export function isReservedCommandName(name: string): boolean {
+  return (RESERVED_COMMAND_NAMES as readonly string[]).includes(name);
+}
+
+/** A shell alias delegates its body to `sh -c` instead of expanding argv. */
+export function isShellAlias(expansion: string): boolean {
+  return expansion.startsWith('!');
+}
+
+export type AliasExpansion =
+  | { kind: 'none' }
+  | { kind: 'argv'; argv: string[] }
+  | { kind: 'shell'; command: string; args: string[] };
+
+/**
+ * Split an alias expansion into words the way a POSIX shell tokenizes a
+ * command line: whitespace separates words; single quotes preserve everything
+ * literally; double quotes preserve everything except `\"` and `\\` escapes;
+ * an unquoted backslash escapes the next character. Throws on an unclosed
+ * quote so a broken alias fails loudly at definition/expansion time instead
+ * of silently mangling arguments.
+ */
+export function splitShellWords(input: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let hasWord = false;
+  let quote: "'" | '"' | null = null;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i] as string;
+
+    if (quote === "'") {
+      if (ch === "'") {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (quote === '"') {
+      if (ch === '"') {
+        quote = null;
+      } else if (
+        ch === '\\' &&
+        (input[i + 1] === '"' || input[i + 1] === '\\')
+      ) {
+        current += input[++i];
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      hasWord = true;
+    } else if (ch === '\\' && i + 1 < input.length) {
+      current += input[++i];
+      hasWord = true;
+    } else if (/\s/.test(ch)) {
+      if (hasWord) {
+        words.push(current);
+        current = '';
+        hasWord = false;
+      }
+    } else {
+      current += ch;
+      hasWord = true;
+    }
+  }
+
+  if (quote) {
+    throw new BBError({
+      code: ErrorCode.VALIDATION_INVALID,
+      message: `Alias expansion has an unclosed ${quote === "'" ? 'single' : 'double'} quote.`,
+      context: { expansion: input },
+    });
+  }
+
+  if (hasWord) {
+    words.push(current);
+  }
+  return words;
+}
+
+/**
+ * Read the alias map from the user's config. Expansion runs before bootstrap,
+ * so this constructs its own (read-only) ConfigService rather than resolving
+ * the DI singleton. Best-effort: an unreadable or invalid config yields an
+ * empty map so alias expansion can never break the CLI — the actual command
+ * will surface the config error through the normal error path if it needs
+ * the config itself.
+ */
+export async function loadAliases(): Promise<Record<string, string>> {
+  try {
+    const config = await new ConfigService().getConfig();
+    return config.aliases ?? {};
+  } catch {
+    return {};
+  }
+}
+
+const PLACEHOLDER_PATTERN = /\$([1-9])/g;
+
+/**
+ * Fill `$1`–`$9` placeholders in the expansion words from `args` and append
+ * any arguments no placeholder consumed. Throws when the expansion references
+ * a placeholder the caller didn't supply, naming the alias for a clear error.
+ */
+export function substitutePlaceholders(
+  words: string[],
+  args: string[],
+  aliasName: string
+): string[] {
+  let highestUsed = 0;
+
+  const substituted = words.map((word) =>
+    word.replace(PLACEHOLDER_PATTERN, (_match, digit: string) => {
+      const index = Number.parseInt(digit, 10);
+      const value = args[index - 1];
+      if (value === undefined) {
+        throw new BBError({
+          code: ErrorCode.VALIDATION_REQUIRED,
+          message: `Alias '${aliasName}' requires argument $${index}.`,
+          context: { alias: aliasName, placeholder: index },
+        });
+      }
+      highestUsed = Math.max(highestUsed, index);
+      return value;
+    })
+  );
+
+  return [...substituted, ...args.slice(highestUsed)];
+}
+
+/**
+ * Expand a user alias in `argv` (the raw `process.argv`, binary and script
+ * tokens included). Returns what the entrypoint should do next:
+ *  - `none`  — argv untouched (no alias present, or the token is reserved)
+ *  - `argv`  — parse the rewritten argv with Commander
+ *  - `shell` — run `command` via `sh -c` with `args` as positional parameters
+ */
+export function expandAliasArgv(
+  argv: string[],
+  aliases: Record<string, string>
+): AliasExpansion {
+  const candidate = argv[2];
+  if (
+    candidate === undefined ||
+    candidate.startsWith('-') ||
+    isReservedCommandName(candidate)
+  ) {
+    return { kind: 'none' };
+  }
+
+  const expansion = aliases[candidate];
+  if (expansion === undefined) {
+    return { kind: 'none' };
+  }
+
+  const args = argv.slice(3);
+
+  if (isShellAlias(expansion)) {
+    return { kind: 'shell', command: expansion.slice(1), args };
+  }
+
+  const words = substitutePlaceholders(
+    splitShellWords(expansion),
+    args,
+    candidate
+  );
+  return { kind: 'argv', argv: [...argv.slice(0, 2), ...words] };
+}

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -122,6 +122,9 @@ import { ViewProjectCommand } from './commands/project/view.command.js';
 import { CreateProjectCommand } from './commands/project/create.command.js';
 
 // Config commands
+import { SetAliasCommand } from './commands/alias/set.command.js';
+import { ListAliasesCommand } from './commands/alias/list.command.js';
+import { DeleteAliasCommand } from './commands/alias/delete.command.js';
 import { GetConfigCommand } from './commands/config/get.command.js';
 import { SetConfigCommand } from './commands/config/set.command.js';
 import { ListConfigCommand } from './commands/config/list.command.js';
@@ -894,6 +897,23 @@ export function bootstrap(options: BootstrapOptions = {}): Container {
     container,
     ServiceTokens.ListConfigCommand,
     ListConfigCommand,
+    [ServiceTokens.ConfigService, ServiceTokens.OutputService]
+  );
+
+  registerCommand(container, ServiceTokens.SetAliasCommand, SetAliasCommand, [
+    ServiceTokens.ConfigService,
+    ServiceTokens.OutputService,
+  ]);
+  registerCommand(
+    container,
+    ServiceTokens.ListAliasesCommand,
+    ListAliasesCommand,
+    [ServiceTokens.ConfigService, ServiceTokens.OutputService]
+  );
+  registerCommand(
+    container,
+    ServiceTokens.DeleteAliasCommand,
+    DeleteAliasCommand,
     [ServiceTokens.ConfigService, ServiceTokens.OutputService]
   );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2547,6 +2547,72 @@ cli
     );
   });
 
+// Alias commands
+const aliasCmd = new Command('alias').description(
+  'Create shortcuts for bb commands'
+);
+
+aliasCmd
+  .command('set <name> <expansion>')
+  .description(
+    'Create or update an alias; supports $1-$9 placeholders and a ! prefix for shell passthrough'
+  )
+  .addHelpText(
+    'before',
+    '\nAn alias expands in place of the first bb argument: `bb co 42` runs\n' +
+      '`bb pr checkout 42` after `bb alias set co "pr checkout $1"`. Extra\n' +
+      'arguments are appended unless consumed by $1-$9 placeholders. A `!`\n' +
+      'prefix runs the expansion through `sh -c` instead, with the remaining\n' +
+      'arguments available as shell positional parameters ($1, $@).\n'
+  )
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: [
+        'bb alias set co "pr checkout $1"',
+        'bb alias set prd "pr create --draft"',
+        'bb alias set openpr \'!bb pr list --json --jq ".pullRequests[0].id" | xargs bb browse --pr\'',
+      ],
+      seeAlso: [
+        {
+          label: 'Configuration File',
+          url: 'https://bitbucket-cli.paulvanderlei.com/reference/configuration/',
+        },
+      ],
+    })
+  )
+  .action(async (name, expansion) => {
+    await runCommand(ServiceTokens.SetAliasCommand, { name, expansion }, cli);
+  });
+
+aliasCmd
+  .command('list')
+  .description('List configured aliases')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb alias list', 'bb alias list --json'],
+    })
+  )
+  .action(async () => {
+    await runCommand(ServiceTokens.ListAliasesCommand, undefined, cli);
+  });
+
+aliasCmd
+  .command('delete <name>')
+  .description('Delete an alias')
+  .addHelpText(
+    'after',
+    buildHelpText({
+      examples: ['bb alias delete co', 'bb alias delete co --json'],
+    })
+  )
+  .action(async (name) => {
+    await runCommand(ServiceTokens.DeleteAliasCommand, { name }, cli);
+  });
+
+cli.addCommand(aliasCmd);
+
 // Config commands
 const configCmd = new Command('config').description('Manage configuration');
 

--- a/src/commands/alias/delete.command.ts
+++ b/src/commands/alias/delete.command.ts
@@ -1,0 +1,49 @@
+/**
+ * Delete alias command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export class DeleteAliasCommand extends BaseCommand<{ name: string }, void> {
+  public readonly name = 'delete';
+  public readonly description = 'Delete a command alias';
+
+  constructor(
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { name: string },
+    context: CommandContext
+  ): Promise<void> {
+    const { name } = options;
+    const aliases = (await this.configService.getValue('aliases')) ?? {};
+
+    if (aliases[name] === undefined) {
+      throw new BBError({
+        code: ErrorCode.CONFIG_INVALID_KEY,
+        message: `No alias named '${name}'. Run 'bb alias list' to see configured aliases.`,
+        context: { name },
+      });
+    }
+
+    const { [name]: expansion, ...rest } = aliases;
+    await this.configService.setValue('aliases', rest);
+
+    if (context.globalOptions.json) {
+      await this.output.json({ success: true, name, expansion });
+      return;
+    }
+
+    this.output.success(`Deleted alias '${name}' (was: ${expansion})`);
+  }
+}

--- a/src/commands/alias/delete.command.ts
+++ b/src/commands/alias/delete.command.ts
@@ -28,7 +28,9 @@ export class DeleteAliasCommand extends BaseCommand<{ name: string }, void> {
     const { name } = options;
     const aliases = (await this.configService.getValue('aliases')) ?? {};
 
-    if (aliases[name] === undefined) {
+    // Own properties only: a name like 'toString' must never match through
+    // the prototype chain, and deleting it would be a no-op anyway.
+    if (!Object.prototype.hasOwnProperty.call(aliases, name)) {
       throw new BBError({
         code: ErrorCode.CONFIG_INVALID_KEY,
         message: `No alias named '${name}'. Run 'bb alias list' to see configured aliases.`,

--- a/src/commands/alias/list.command.ts
+++ b/src/commands/alias/list.command.ts
@@ -1,0 +1,52 @@
+/**
+ * List aliases command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+
+export class ListAliasesCommand extends BaseCommand<undefined, void> {
+  public readonly name = 'list';
+  public readonly description = 'List command aliases';
+
+  constructor(
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    _options: undefined,
+    context: CommandContext
+  ): Promise<void> {
+    const aliases = (await this.configService.getValue('aliases')) ?? {};
+    const entries = Object.entries(aliases).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        count: entries.length,
+        aliases: Object.fromEntries(entries),
+      });
+      return;
+    }
+
+    if (entries.length === 0) {
+      this.output.info(
+        "No aliases configured. Add one with 'bb alias set <name> <expansion>'."
+      );
+      return;
+    }
+
+    this.output.table(
+      ['Alias', 'Expansion'],
+      entries.map(([name, expansion]) => [name, expansion])
+    );
+  }
+}

--- a/src/commands/alias/set.command.ts
+++ b/src/commands/alias/set.command.ts
@@ -67,7 +67,12 @@ export class SetAliasCommand extends BaseCommand<
     }
 
     const aliases = (await this.configService.getValue('aliases')) ?? {};
-    const previous = aliases[name];
+
+    // Own properties only: a name like 'toString' must never read a value
+    // through the prototype chain.
+    const previous = Object.prototype.hasOwnProperty.call(aliases, name)
+      ? aliases[name]
+      : undefined;
     await this.configService.setValue('aliases', {
       ...aliases,
       [name]: expansion,

--- a/src/commands/alias/set.command.ts
+++ b/src/commands/alias/set.command.ts
@@ -1,0 +1,94 @@
+/**
+ * Set alias command implementation
+ */
+
+import { BaseCommand } from '../../core/base-command.js';
+import type { CommandContext } from '../../core/interfaces/commands.js';
+import type {
+  IConfigService,
+  IOutputService,
+} from '../../core/interfaces/services.js';
+import {
+  isReservedCommandName,
+  isShellAlias,
+  isValidAliasName,
+  splitShellWords,
+} from '../../alias.js';
+import { BBError, ErrorCode } from '../../types/errors.js';
+
+export class SetAliasCommand extends BaseCommand<
+  { name: string; expansion: string },
+  void
+> {
+  public readonly name = 'set';
+  public readonly description = 'Create or update a command alias';
+
+  constructor(
+    private readonly configService: IConfigService,
+    output: IOutputService
+  ) {
+    super(output);
+  }
+
+  public async execute(
+    options: { name: string; expansion: string },
+    context: CommandContext
+  ): Promise<void> {
+    const { name, expansion } = options;
+
+    if (!isValidAliasName(name)) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `Invalid alias name '${name}'. Use a letter followed by letters, digits, '-' or '_'.`,
+        context: { name },
+      });
+    }
+
+    if (isReservedCommandName(name)) {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_INVALID,
+        message: `Cannot use '${name}' as an alias name: it is a built-in bb command.`,
+        context: { name },
+      });
+    }
+
+    if (expansion.trim() === '') {
+      throw new BBError({
+        code: ErrorCode.VALIDATION_REQUIRED,
+        message: 'Alias expansion cannot be empty.',
+        context: { name },
+      });
+    }
+
+    // Surface unclosed quotes at definition time; shell aliases are passed to
+    // `sh -c` verbatim, so only command aliases are pre-tokenized here.
+    if (!isShellAlias(expansion)) {
+      splitShellWords(expansion);
+    }
+
+    const aliases = (await this.configService.getValue('aliases')) ?? {};
+    const previous = aliases[name];
+    await this.configService.setValue('aliases', {
+      ...aliases,
+      [name]: expansion,
+    });
+
+    if (context.globalOptions.json) {
+      await this.output.json({
+        success: true,
+        name,
+        expansion,
+        ...(previous !== undefined && { previous }),
+      });
+      return;
+    }
+
+    if (previous !== undefined) {
+      this.output.success(
+        `Changed alias '${name}' = ${expansion} (was: ${previous})`
+      );
+    } else {
+      this.output.success(`Added alias '${name}' = ${expansion}`);
+    }
+  }
+}

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -249,6 +249,11 @@ export const ServiceTokens = {
   SetConfigCommand: 'SetConfigCommand',
   ListConfigCommand: 'ListConfigCommand',
 
+  // Commands - Alias
+  SetAliasCommand: 'SetAliasCommand',
+  ListAliasesCommand: 'ListAliasesCommand',
+  DeleteAliasCommand: 'DeleteAliasCommand',
+
   // Commands - Completion
   InstallCompletionCommand: 'InstallCompletionCommand',
   UninstallCompletionCommand: 'UninstallCompletionCommand',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env bun
 
+// Top-level await below requires module context; this file has no static
+// imports (cli.js must load only after argv is rewritten), so mark it a
+// module explicitly.
+export {};
+
 // Runtime check: Ensure Bun runtime is being used
 if (typeof Bun === 'undefined') {
   console.error('Error: This CLI requires the Bun runtime.');
@@ -9,7 +14,41 @@ if (typeof Bun === 'undefined') {
   process.exit(1);
 }
 
-import { cli } from './cli.js';
+// User-alias expansion must rewrite process.argv BEFORE cli.js is imported:
+// that module resolves --no-color/--locale/completion from argv at load time.
+// Shell completion (tabtab) is driven by COMP_LINE, not argv, and must stay
+// fast — skip expansion entirely there.
+const isCompleting =
+  process.env.COMP_LINE !== undefined ||
+  process.argv.includes('--get-yargs-completions');
+
+if (!isCompleting) {
+  const { expandAliasArgv, loadAliases } = await import('./alias.js');
+  try {
+    const expansion = expandAliasArgv(process.argv, await loadAliases());
+    if (expansion.kind === 'shell') {
+      // `!`-prefixed alias: hand the body to sh with the remaining argv as
+      // shell positional parameters ($0 is the conventional command label),
+      // then exit with the child's status — Commander never runs.
+      const result = Bun.spawnSync(
+        ['sh', '-c', expansion.command, 'bb-alias', ...expansion.args],
+        { stdio: ['inherit', 'inherit', 'inherit'] }
+      );
+      process.exit(result.exitCode);
+    }
+    if (expansion.kind === 'argv') {
+      process.argv = expansion.argv;
+    }
+  } catch (error) {
+    // No OutputService exists this early; mirror the Bun-guard style above.
+    console.error(
+      error instanceof Error ? `Error: ${error.message}` : String(error)
+    );
+    process.exit(1);
+  }
+}
+
+const { cli } = await import('./cli.js');
 
 // parseAsync (not parse) so Commander awaits async action handlers and the
 // postAction update-check hook before the process exits.

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,11 @@ if (!isCompleting) {
       process.argv = expansion.argv;
     }
   } catch (error) {
-    // No OutputService exists this early; mirror the Bun-guard style above.
-    console.error(
+    // Route through IOutputService per the output contract. The module is
+    // imported lazily: this file must not import cli.js (or anything that
+    // pulls it in) before argv is rewritten.
+    const { OutputService } = await import('./services/output.service.js');
+    new OutputService().error(
       error instanceof Error ? `Error: ${error.message}` : String(error)
     );
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
 
+// Type-only: erased at runtime, so nothing is loaded before argv is rewritten.
+import type { IOutputService } from './core/interfaces/services.js';
+
 // Top-level await below requires module context; this file has no static
 // imports (cli.js must load only after argv is rewritten), so mark it a
 // module explicitly.
@@ -44,7 +47,8 @@ if (!isCompleting) {
     // imported lazily: this file must not import cli.js (or anything that
     // pulls it in) before argv is rewritten.
     const { OutputService } = await import('./services/output.service.js');
-    new OutputService().error(
+    const output: IOutputService = new OutputService();
+    output.error(
       error instanceof Error ? `Error: ${error.message}` : String(error)
     );
     process.exit(1);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,6 +20,7 @@ export interface BBConfig {
   skipVersionCheck?: boolean;
   versionCheckInterval?: number;
   prCreateIncludeDefaultReviewers?: boolean;
+  aliases?: Record<string, string>;
 }
 
 export interface AuthCredentials {
@@ -65,6 +66,7 @@ export const CONFIG_KEYS = [
   'skipVersionCheck',
   'versionCheckInterval',
   'prCreateIncludeDefaultReviewers',
+  'aliases',
 ] as const;
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
 

--- a/tests/alias.test.ts
+++ b/tests/alias.test.ts
@@ -68,6 +68,18 @@ describe('substitutePlaceholders', () => {
     ).toEqual(['pr', 'view', '42', '--json']);
   });
 
+  it('keeps arguments skipped by a sparse placeholder', () => {
+    expect(
+      substitutePlaceholders(['pr', 'checkout', '$2'], ['A', 'B', 'C'], 'co')
+    ).toEqual(['pr', 'checkout', 'B', 'A', 'C']);
+  });
+
+  it('appends only unconsumed args when placeholders skip around', () => {
+    expect(
+      substitutePlaceholders(['diff', '$1', '$3'], ['A', 'B', 'C'], 'd13')
+    ).toEqual(['diff', 'A', 'C', 'B']);
+  });
+
   it('appends all args when no placeholder is used', () => {
     expect(
       substitutePlaceholders(['pr', 'list'], ['--all', '--json'], 'prs')
@@ -132,6 +144,15 @@ describe('expandAliasArgv', () => {
     expect(
       expandAliasArgv([...BIN, 'pr', 'list'], { pr: 'repo list' })
     ).toEqual({ kind: 'none' });
+  });
+
+  it('never expands inherited Object members as aliases', () => {
+    expect(expandAliasArgv([...BIN, 'toString'], aliases)).toEqual({
+      kind: 'none',
+    });
+    expect(expandAliasArgv([...BIN, '__proto__'], aliases)).toEqual({
+      kind: 'none',
+    });
   });
 
   it('expands one level only (no recursion into other aliases)', () => {

--- a/tests/alias.test.ts
+++ b/tests/alias.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Alias expansion tests (issue #275): word splitting, placeholder
+ * substitution, argv rewriting, shell-alias detection, and the drift guard
+ * keeping RESERVED_COMMAND_NAMES in sync with the live Commander tree.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  RESERVED_COMMAND_NAMES,
+  expandAliasArgv,
+  isReservedCommandName,
+  isShellAlias,
+  isValidAliasName,
+  splitShellWords,
+  substitutePlaceholders,
+} from '../src/alias.js';
+import { cli } from '../src/cli.js';
+import { BBError, ErrorCode } from '../src/types/errors.js';
+
+const BIN = ['/usr/local/bin/bun', '/app/src/index.ts'];
+
+describe('splitShellWords', () => {
+  it('splits on whitespace', () => {
+    expect(splitShellWords('pr view --web')).toEqual(['pr', 'view', '--web']);
+  });
+
+  it('keeps single-quoted segments intact', () => {
+    expect(splitShellWords("pr create -t 'My title'")).toEqual([
+      'pr',
+      'create',
+      '-t',
+      'My title',
+    ]);
+  });
+
+  it('keeps double-quoted segments intact and honors escapes', () => {
+    expect(splitShellWords('api "/user" -f name="a \\"b\\""')).toEqual([
+      'api',
+      '/user',
+      '-f',
+      'name=a "b"',
+    ]);
+  });
+
+  it('treats a quoted empty string as a word', () => {
+    expect(splitShellWords("pr view ''")).toEqual(['pr', 'view', '']);
+  });
+
+  it('supports unquoted backslash escapes', () => {
+    expect(splitShellWords('echo a\\ b')).toEqual(['echo', 'a b']);
+  });
+
+  it('throws on an unclosed quote', () => {
+    expect(() => splitShellWords("pr view 'oops")).toThrow(BBError);
+  });
+});
+
+describe('substitutePlaceholders', () => {
+  it('fills $1-$9 from args', () => {
+    expect(
+      substitutePlaceholders(['pr', 'checkout', '$1'], ['42'], 'co')
+    ).toEqual(['pr', 'checkout', '42']);
+  });
+
+  it('appends args beyond the highest placeholder', () => {
+    expect(
+      substitutePlaceholders(['pr', 'view', '$1'], ['42', '--json'], 'v')
+    ).toEqual(['pr', 'view', '42', '--json']);
+  });
+
+  it('appends all args when no placeholder is used', () => {
+    expect(
+      substitutePlaceholders(['pr', 'list'], ['--all', '--json'], 'prs')
+    ).toEqual(['pr', 'list', '--all', '--json']);
+  });
+
+  it('substitutes a placeholder embedded in a word', () => {
+    expect(substitutePlaceholders(['browse', '--pr=$1'], ['7'], 'bpr')).toEqual(
+      ['browse', '--pr=7']
+    );
+  });
+
+  it('throws VALIDATION_REQUIRED when a placeholder argument is missing', () => {
+    expect(() => substitutePlaceholders(['pr', 'view', '$1'], [], 'v')).toThrow(
+      expect.objectContaining({ code: ErrorCode.VALIDATION_REQUIRED })
+    );
+  });
+});
+
+describe('expandAliasArgv', () => {
+  const aliases = {
+    co: 'pr checkout $1',
+    prs: 'pr list --all',
+    sh: '!echo "$1"',
+    loop: 'loop again',
+    again: 'pr list',
+  };
+
+  it('expands a simple alias and appends extra args', () => {
+    expect(expandAliasArgv([...BIN, 'prs', '--json'], aliases)).toEqual({
+      kind: 'argv',
+      argv: [...BIN, 'pr', 'list', '--all', '--json'],
+    });
+  });
+
+  it('expands placeholders', () => {
+    expect(expandAliasArgv([...BIN, 'co', '42'], aliases)).toEqual({
+      kind: 'argv',
+      argv: [...BIN, 'pr', 'checkout', '42'],
+    });
+  });
+
+  it('returns shell expansion for !-prefixed aliases without substituting', () => {
+    expect(expandAliasArgv([...BIN, 'sh', 'hello'], aliases)).toEqual({
+      kind: 'shell',
+      command: 'echo "$1"',
+      args: ['hello'],
+    });
+  });
+
+  it('leaves unknown commands, flags, and empty argv untouched', () => {
+    expect(expandAliasArgv([...BIN, 'nosuch'], aliases)).toEqual({
+      kind: 'none',
+    });
+    expect(expandAliasArgv([...BIN, '--help'], aliases)).toEqual({
+      kind: 'none',
+    });
+    expect(expandAliasArgv([...BIN], aliases)).toEqual({ kind: 'none' });
+  });
+
+  it('never expands a built-in command name, even if aliased in config', () => {
+    expect(
+      expandAliasArgv([...BIN, 'pr', 'list'], { pr: 'repo list' })
+    ).toEqual({ kind: 'none' });
+  });
+
+  it('expands one level only (no recursion into other aliases)', () => {
+    expect(expandAliasArgv([...BIN, 'loop'], aliases)).toEqual({
+      kind: 'argv',
+      argv: [...BIN, 'loop', 'again'],
+    });
+  });
+});
+
+describe('alias name validation', () => {
+  it('accepts letters, digits, dash, underscore', () => {
+    expect(isValidAliasName('co')).toBe(true);
+    expect(isValidAliasName('my-alias_2')).toBe(true);
+  });
+
+  it('rejects names that cannot be a command word', () => {
+    expect(isValidAliasName('')).toBe(false);
+    expect(isValidAliasName('2fast')).toBe(false);
+    expect(isValidAliasName('has space')).toBe(false);
+    expect(isValidAliasName('--flag')).toBe(false);
+    expect(isValidAliasName('!bang')).toBe(false);
+  });
+
+  it('flags reserved built-in names', () => {
+    expect(isReservedCommandName('pr')).toBe(true);
+    expect(isReservedCommandName('co')).toBe(false);
+  });
+
+  it('detects shell aliases by the ! prefix', () => {
+    expect(isShellAlias('!echo hi')).toBe(true);
+    expect(isShellAlias('pr list')).toBe(false);
+  });
+});
+
+describe('RESERVED_COMMAND_NAMES drift guard', () => {
+  it('matches the live top-level Commander tree (plus implicit help)', () => {
+    const liveNames = cli.commands.map((cmd) => cmd.name());
+    expect([...RESERVED_COMMAND_NAMES].sort()).toEqual(
+      [...new Set([...liveNames, 'help'])].sort()
+    );
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -478,6 +478,7 @@ describe('CLI command registration', () => {
   it('should register all top-level commands', () => {
     const names = cli.commands.map((command) => command.name()).sort();
     expect(names).toEqual([
+      'alias',
       'api',
       'auth',
       'browse',

--- a/tests/commands/alias.test.ts
+++ b/tests/commands/alias.test.ts
@@ -92,6 +92,24 @@ describe('SetAliasCommand', () => {
     ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
   });
 
+  it('does not treat inherited members as previous aliases', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new SetAliasCommand(configService, output);
+    await command.execute(
+      { name: 'constructor', expansion: 'repo list' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs).toContain(
+      "success:Added alias 'constructor' = repo list"
+    );
+    expect(await configService.getValue('aliases')).toEqual({
+      constructor: 'repo list',
+    });
+  });
+
   it('rejects an empty expansion', async () => {
     const command = new SetAliasCommand(
       createMockConfigService(),
@@ -201,6 +219,17 @@ describe('DeleteAliasCommand', () => {
 
     await expect(
       command.execute({ name: 'nosuch' }, { globalOptions: {} })
+    ).rejects.toMatchObject({ code: ErrorCode.CONFIG_INVALID_KEY });
+  });
+
+  it('errors on an inherited Object member name with no such alias', async () => {
+    const command = new DeleteAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute({ name: 'toString' }, { globalOptions: {} })
     ).rejects.toMatchObject({ code: ErrorCode.CONFIG_INVALID_KEY });
   });
 

--- a/tests/commands/alias.test.ts
+++ b/tests/commands/alias.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Alias command tests (bb alias set/list/delete)
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { SetAliasCommand } from '../../src/commands/alias/set.command.js';
+import { ListAliasesCommand } from '../../src/commands/alias/list.command.js';
+import { DeleteAliasCommand } from '../../src/commands/alias/delete.command.js';
+import { ErrorCode } from '../../src/types/errors.js';
+import { createMockConfigService, createMockOutputService } from '../setup.js';
+
+describe('SetAliasCommand', () => {
+  it('adds a new alias', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new SetAliasCommand(configService, output);
+    await command.execute(
+      { name: 'co', expansion: 'pr checkout $1' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs).toContain("success:Added alias 'co' = pr checkout $1");
+    expect(await configService.getValue('aliases')).toEqual({
+      co: 'pr checkout $1',
+    });
+  });
+
+  it('notes the previous expansion when redefining', async () => {
+    const configService = createMockConfigService({
+      aliases: { co: 'pr checkout $1' },
+    });
+    const output = createMockOutputService();
+
+    const command = new SetAliasCommand(configService, output);
+    await command.execute(
+      { name: 'co', expansion: 'pr view $1' },
+      { globalOptions: {} }
+    );
+
+    expect(output.logs).toContain(
+      "success:Changed alias 'co' = pr view $1 (was: pr checkout $1)"
+    );
+    expect(
+      output.logs.filter((log) => log.startsWith('success:'))
+    ).toHaveLength(1);
+    expect(await configService.getValue('aliases')).toEqual({
+      co: 'pr view $1',
+    });
+  });
+
+  it('emits a JSON envelope with --json', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new SetAliasCommand(configService, output);
+    await command.execute(
+      { name: 'prs', expansion: 'pr list --all' },
+      { globalOptions: { json: true } }
+    );
+
+    expect(output.logs).toContain(
+      'json:{"success":true,"name":"prs","expansion":"pr list --all"}'
+    );
+  });
+
+  it('rejects invalid alias names', async () => {
+    const command = new SetAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute(
+        { name: '--flag', expansion: 'pr list' },
+        { globalOptions: {} }
+      )
+    ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+  });
+
+  it('rejects reserved built-in command names', async () => {
+    const command = new SetAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute(
+        { name: 'pr', expansion: 'repo list' },
+        { globalOptions: {} }
+      )
+    ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+  });
+
+  it('rejects an empty expansion', async () => {
+    const command = new SetAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute({ name: 'co', expansion: '   ' }, { globalOptions: {} })
+    ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_REQUIRED });
+  });
+
+  it('rejects a command alias with an unclosed quote', async () => {
+    const command = new SetAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute(
+        { name: 'bad', expansion: "pr view 'oops" },
+        { globalOptions: {} }
+      )
+    ).rejects.toMatchObject({ code: ErrorCode.VALIDATION_INVALID });
+  });
+
+  it('accepts shell aliases verbatim (no tokenization)', async () => {
+    const configService = createMockConfigService();
+    const output = createMockOutputService();
+
+    const command = new SetAliasCommand(configService, output);
+    await command.execute(
+      { name: 'greet', expansion: '!echo "unbalanced is fine: \'" ' },
+      { globalOptions: {} }
+    );
+
+    expect(await configService.getValue('aliases')).toEqual({
+      greet: '!echo "unbalanced is fine: \'" ',
+    });
+  });
+});
+
+describe('ListAliasesCommand', () => {
+  it('renders a sorted table', async () => {
+    const configService = createMockConfigService({
+      aliases: { prs: 'pr list --all', co: 'pr checkout $1' },
+    });
+    const output = createMockOutputService();
+
+    const command = new ListAliasesCommand(configService, output);
+    await command.execute(undefined, { globalOptions: {} });
+
+    expect(output.logs).toContain('table:Alias,Expansion');
+    expect(output.logs).toContain(
+      'table-rows:[["co","pr checkout $1"],["prs","pr list --all"]]'
+    );
+  });
+
+  it('prints a hint when no aliases exist', async () => {
+    const output = createMockOutputService();
+
+    const command = new ListAliasesCommand(createMockConfigService(), output);
+    await command.execute(undefined, { globalOptions: {} });
+
+    expect(
+      output.logs.some((log) => log.startsWith('info:No aliases configured'))
+    ).toBe(true);
+  });
+
+  it('emits a JSON envelope with --json', async () => {
+    const configService = createMockConfigService({
+      aliases: { co: 'pr checkout $1' },
+    });
+    const output = createMockOutputService();
+
+    const command = new ListAliasesCommand(configService, output);
+    await command.execute(undefined, { globalOptions: { json: true } });
+
+    expect(output.logs).toContain(
+      'json:{"count":1,"aliases":{"co":"pr checkout $1"}}'
+    );
+  });
+});
+
+describe('DeleteAliasCommand', () => {
+  it('deletes an existing alias', async () => {
+    const configService = createMockConfigService({
+      aliases: { co: 'pr checkout $1', prs: 'pr list --all' },
+    });
+    const output = createMockOutputService();
+
+    const command = new DeleteAliasCommand(configService, output);
+    await command.execute({ name: 'co' }, { globalOptions: {} });
+
+    expect(output.logs).toContain(
+      "success:Deleted alias 'co' (was: pr checkout $1)"
+    );
+    expect(await configService.getValue('aliases')).toEqual({
+      prs: 'pr list --all',
+    });
+  });
+
+  it('errors on an unknown alias', async () => {
+    const command = new DeleteAliasCommand(
+      createMockConfigService(),
+      createMockOutputService()
+    );
+
+    await expect(
+      command.execute({ name: 'nosuch' }, { globalOptions: {} })
+    ).rejects.toMatchObject({ code: ErrorCode.CONFIG_INVALID_KEY });
+  });
+
+  it('emits a JSON envelope with --json', async () => {
+    const configService = createMockConfigService({
+      aliases: { co: 'pr checkout $1' },
+    });
+    const output = createMockOutputService();
+
+    const command = new DeleteAliasCommand(configService, output);
+    await command.execute({ name: 'co' }, { globalOptions: { json: true } });
+
+    expect(output.logs).toContain(
+      'json:{"success":true,"name":"co","expansion":"pr checkout $1"}'
+    );
+  });
+});


### PR DESCRIPTION
Closes #275

## What

gh-style user-defined command aliases:

- `bb alias set <name> <expansion>` — persists an alias in the existing `config.json` (`aliases` map, same 0600-hardened storage). Validates the name, rejects built-in command names, and pre-tokenizes command aliases so unclosed quotes fail at definition time.
- `bb alias list` / `bb alias delete <name>` — with `--json` support across all three.
- Expansion rewrites `process.argv` in `src/index.ts` **before** `cli.js` is imported (that module resolves `--no-color`/`--locale`/completion from argv at load time), then hands off to Commander as usual.
- `$1`–`$9` placeholders are filled from the trailing arguments (missing ones error); unconsumed arguments are appended.
- `!`-prefixed shell aliases run via `sh -c` with the remaining argv as shell positional parameters (`$1`, `$@` work natively), propagating the child's exit code.

## Design notes

- **Reserved names**: expansion refuses to expand any built-in top-level command, so a stale alias can never hijack a command added in a newer release. The list is drift-guarded by a test against the live Commander tree (same idiom as the existing completion drift guards).
- **One-level expansion**: alias bodies are never re-expanded — no recursion, no alias-to-alias chains.
- **Completion untouched**: the tabtab path (`COMP_LINE`) skips alias loading entirely, so completion stays fast.
- **Security posture** (issue's open question): shell aliases execute user-authored strings from the user's own 0600 config — the same trust model as `gh alias --shell` and shell rc files. Documented with a caution block in the docs page.

## Consciously skipped (possible follow-ups)

- Alias names in shell completion candidates (the completer is sync; the alias map is an async config read).
- Showing aliases in `bb config list` (they have their own `bb alias list`).
- Alias names in the new did-you-mean suggestions (from the rebase onto main): a defined alias never reaches the unknown-command path (it expands before Commander parses), so suggestions currently draw from built-in commands only.

## Testing

- 36 new tests: word splitting, placeholder substitution, argv rewriting, shell detection, reserved-name guard, and full command coverage (set/list/delete incl. JSON envelopes and error paths).
- Manual end-to-end smoke against an isolated HOME: set/list/delete, placeholder expansion, missing-placeholder error, shell alias with `$1`/`$@`, reserved-name rejection.
- `bun test` (1431 pass), `bun run lint`, `bun run format:check`, `bun run lint:docs` all green.

Docs: new `commands/alias.mdx` page + sidebar entry, `aliases` key added to the configuration reference. Changeset: minor.
