### PR TITLE
feat(pagination): concurrent --all fetching + proactive rate limiting; mock-server integration layer

### DIFF
--- a/.changeset/concurrent-pagination-rate-limit.md
+++ b/.changeset/concurrent-pagination-rate-limit.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': minor
+---
+
+perf: bounded concurrent page fetching for `--all` plus a proactive client-side rate limiter (#277). When the first page reports the collection's total `size`, remaining pages are fetched up to 4 in flight and concatenated in page order, roughly halving wall-clock time for large collections; without a usable `size` the walk stays sequential. The shared axios instance now also paces request starts from `X-RateLimit-Remaining`/`X-RateLimit-Reset` headers once the budget runs low, so bulk runs stay under Bitbucket's limits instead of reacting to 429s after the fact.

--- a/.changeset/integration-test-layer.md
+++ b/.changeset/integration-test-layer.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+test: add an integration test layer driving real commands through the real generated API client against a local mock Bitbucket HTTP server (#264). The fixture (`tests/helpers/mock-bitbucket.ts`) speaks enough of the wire protocol — paginated envelopes with `size`/`next`, Basic-auth enforcement, Bitbucket-shaped error bodies — to validate endpoint paths, query params, auth headers, pagination walking (including concurrent `--all` fetching), 429 retry behavior, and error mapping end-to-end.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "LICENSE"
   ],
   "engines": {
-    "bun": ">=1.0"
+    "bun": ">=1.1.30"
   },
   "scripts": {
     "dev": "bun run src/index.ts",

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -12,6 +12,7 @@ import type {
   IOutputService,
 } from '../core/interfaces/services.js';
 import type { OAuthService } from './oauth.service.js';
+import { RateLimiter } from './rate-limiter.js';
 import { BBError, ErrorCode, APIError } from '../types/errors.js';
 
 const DEFAULT_BASE_URL = 'https://api.bitbucket.org/2.0';
@@ -216,7 +217,8 @@ export function redactRequestUrl(
 export function createApiClient(
   credentialStore: ICredentialStore,
   output: IOutputService,
-  oauthService?: OAuthService
+  oauthService?: OAuthService,
+  rateLimiter: RateLimiter = new RateLimiter()
 ): AxiosInstance {
   const instance = axios.create({
     baseURL: resolveBaseUrl(),
@@ -230,6 +232,10 @@ export function createApiClient(
   // Request interceptor to add auth header (Basic or Bearer)
   instance.interceptors.request.use(
     async (config) => {
+      // Proactive pacing before anything else (issue #277): bulk runs stay
+      // under the rate-limit ceiling instead of reacting to 429s afterwards.
+      await rateLimiter.acquire();
+
       if (process.env.DEBUG === 'true') {
         console.debug(
           `[HTTP] ${config.method?.toUpperCase()} ${redactRequestUrl(config.url, config.baseURL)}`
@@ -258,6 +264,7 @@ export function createApiClient(
   // Response interceptor with retry logic and error transformation
   instance.interceptors.response.use(
     (response) => {
+      rateLimiter.onResponse(response.headers);
       if (process.env.DEBUG === 'true') {
         console.debug(`[HTTP] Response: ${response.status}`);
         console.debug(

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -275,6 +275,11 @@ export function createApiClient(
       return response;
     },
     async (error: AxiosError) => {
+      // Rate-limited responses carry the freshest budget information too:
+      // pace subsequent requests from a 429's headers even though the
+      // response is rejected (the success path handles normal responses).
+      rateLimiter.onResponse(error.response?.headers);
+
       if (process.env.DEBUG === 'true') {
         console.debug(`[HTTP] Error:`, error.message);
         if (error.response) {

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -155,9 +155,14 @@ export async function collectPagesWithMeta<T>(
     }
 
     let cursor = 2;
-    let hasFollowingPage = data.next !== undefined;
+    // Continuation is decided solely by the wire: page 1 must advertise
+    // `next`, then each batch's LAST page decides whether anything follows.
+    // `estimatedPages` only shapes how far each window reaches — a stale or
+    // lying `size` can neither truncate the walk nor extend it past the
+    // server's own end.
+    let keepWalking = data.next !== undefined;
 
-    while (cursor <= estimatedPages || hasFollowingPage) {
+    while (keepWalking) {
       // Inside the estimate: clip to it. Past it (size understated): keep
       // fetching a full window at a time until the wire says otherwise.
       const batchEnd =
@@ -187,9 +192,10 @@ export async function collectPagesWithMeta<T>(
 
       // Continuation follows the LAST page of the batch: an absent `next`
       // ends the walk, an empty page means the server ran out before the
-      // estimate did. Either way, stop trusting `estimatedPages`.
+      // estimate did. Either way, stop immediately — never keep fetching
+      // just because `estimatedPages` says more should exist.
       const lastResult = batchResults[batchResults.length - 1]!;
-      hasFollowingPage = !sawEmptyPage && lastResult.next !== undefined;
+      keepWalking = !sawEmptyPage && lastResult.next !== undefined;
       cursor = batchEnd + 1;
     }
 

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -117,10 +117,17 @@ export async function collectPagesWithMeta<T>(
   let page = 1;
   let data = await fetchPage(page, pagelen);
 
-  // --all fast path: the server told us how many items exist in total, so the
-  // page count is computable up front (`ceil(size / observed page length)`).
-  // Fetch remaining pages in windows of `concurrency` and concatenate in page
-  // order — later pages resolving first never reorder results.
+  // --all fast path: the first page's `size` gives an upfront page-count
+  // estimate (`ceil(size / observed page length)`) so remaining pages can be
+  // fetched in windows of `concurrency` and concatenated in page order —
+  // later pages resolving first never reorder results.
+  //
+  // The estimate shapes the fetch windows but never bounds them: continuation
+  // is governed by wire truth — the last page of each batch advertising
+  // `next`, and empty pages meaning the server ran dry. A stale or lying
+  // `size` therefore cannot silently truncate the collection (underestimate →
+  // extra windows are fetched; overestimate → the walk stops as soon as the
+  // server stops advertising `next`).
   if (
     limit === Number.POSITIVE_INFINITY &&
     concurrency > 1 &&
@@ -134,7 +141,10 @@ export async function collectPagesWithMeta<T>(
     }
 
     const observedPageLength = Math.max(firstValues.length, 1);
-    const totalPages = Math.max(1, Math.ceil(data.size / observedPageLength));
+    const estimatedPages = Math.max(
+      1,
+      Math.ceil(data.size / observedPageLength)
+    );
 
     // Page order is preserved regardless of resolution order: page 1's items
     // go in first, then each batch appends its pages in ascending page order.
@@ -144,26 +154,43 @@ export async function collectPagesWithMeta<T>(
       }
     }
 
-    for (
-      let batchStart = 2;
-      batchStart <= totalPages;
-      batchStart += concurrency
-    ) {
-      const batchEnd = Math.min(batchStart + concurrency - 1, totalPages);
+    let cursor = 2;
+    let hasFollowingPage = data.next !== undefined;
+
+    while (cursor <= estimatedPages || hasFollowingPage) {
+      // Inside the estimate: clip to it. Past it (size understated): keep
+      // fetching a full window at a time until the wire says otherwise.
+      const batchEnd =
+        cursor <= estimatedPages
+          ? Math.min(cursor + concurrency - 1, estimatedPages)
+          : cursor + concurrency - 1;
+
       const pending: Promise<PaginatedCollection<T>>[] = [];
-      for (let p = batchStart; p <= batchEnd; p += 1) {
+      for (let p = cursor; p <= batchEnd; p += 1) {
         pending.push(fetchPage(p, pagelen));
       }
       // A failed page aborts the whole collection via Promise.all rejection.
       const batchResults = await Promise.all(pending);
+
+      let sawEmptyPage = false;
       for (const result of batchResults) {
         const values = result.values ? Array.from(result.values) : [];
+        if (values.length === 0) {
+          sawEmptyPage = true;
+        }
         for (const value of values) {
           if (include(value)) {
             items.push(value);
           }
         }
       }
+
+      // Continuation follows the LAST page of the batch: an absent `next`
+      // ends the walk, an empty page means the server ran out before the
+      // estimate did. Either way, stop trusting `estimatedPages`.
+      const lastResult = batchResults[batchResults.length - 1]!;
+      hasFollowingPage = !sawEmptyPage && lastResult.next !== undefined;
+      cursor = batchEnd + 1;
     }
 
     return { items, hasMore: false };

--- a/src/services/pagination.ts
+++ b/src/services/pagination.ts
@@ -7,6 +7,13 @@ import { BBError, ErrorCode } from '../types/errors.js';
 export interface PaginatedCollection<T> {
   values?: Iterable<T>;
   next?: string;
+  /**
+   * Total number of items in the collection server-side (Bitbucket sends
+   * `size` on paginated list endpoints). Used by the `--all` fast path to
+   * compute the page count up front and fetch pages concurrently; absent or
+   * non-numeric values fall back to the sequential walk.
+   */
+  size?: number;
 }
 
 export interface CollectPagesOptions<T> {
@@ -14,10 +21,24 @@ export interface CollectPagesOptions<T> {
   pageSize?: number;
   fetchPage: (page: number, pagelen: number) => Promise<PaginatedCollection<T>>;
   shouldInclude?: (item: T) => boolean;
+  /**
+   * Max pages fetched in flight on the `--all` fast path. Finite limits never
+   * parallelize (early-stop at the cap must stay exact). Set to 1 to force
+   * sequential fetching.
+   */
+  concurrency?: number;
 }
 
 export const DEFAULT_LIMIT = 25;
 export const MAX_PAGE_LENGTH = 50;
+
+/**
+ * Pages fetched in flight when `--all` can use the size-driven fast path.
+ * Four keeps aggregate throughput well under Bitbucket's rate limits while
+ * cutting wall-clock time for large collections roughly 3-4x versus a
+ * strictly sequential walk.
+ */
+export const PAGE_FETCH_CONCURRENCY = 4;
 
 /**
  * Result of {@link collectPagesWithMeta}: the collected items plus whether the
@@ -65,6 +86,12 @@ export function resolveLimit(options: {
  * Collect items across paginated pages, stopping at `limit`, and report whether
  * more results remain on the server. Pass `limit = Infinity` to fetch every
  * page (`--all`).
+ *
+ * For `--all`, when the first page carries a numeric `size`, pages are fetched
+ * with bounded concurrency ({@link CollectPagesOptions.concurrency}) and
+ * concatenated in page order; without a usable `size` the walk stays strictly
+ * sequential, driven by the server's `next` links. Finite limits always walk
+ * sequentially so early-stop at the cap remains exact.
  */
 export async function collectPagesWithMeta<T>(
   options: CollectPagesOptions<T>
@@ -80,12 +107,69 @@ export async function collectPagesWithMeta<T>(
   // request stays valid while we loop until the server runs out of pages.
   const requestedPageSize = options.pageSize ?? limit;
   const pagelen = Math.max(1, Math.min(requestedPageSize, MAX_PAGE_LENGTH));
+  const concurrency = Math.max(
+    1,
+    options.concurrency ?? PAGE_FETCH_CONCURRENCY
+  );
+  const include = (value: T): boolean => !shouldInclude || shouldInclude(value);
 
   const items: T[] = [];
   let page = 1;
+  let data = await fetchPage(page, pagelen);
+
+  // --all fast path: the server told us how many items exist in total, so the
+  // page count is computable up front (`ceil(size / observed page length)`).
+  // Fetch remaining pages in windows of `concurrency` and concatenate in page
+  // order — later pages resolving first never reorder results.
+  if (
+    limit === Number.POSITIVE_INFINITY &&
+    concurrency > 1 &&
+    typeof data.size === 'number' &&
+    Number.isFinite(data.size)
+  ) {
+    const firstValues = data.values ? Array.from(data.values) : [];
+
+    if (firstValues.length === 0) {
+      return { items: [], hasMore: false };
+    }
+
+    const observedPageLength = Math.max(firstValues.length, 1);
+    const totalPages = Math.max(1, Math.ceil(data.size / observedPageLength));
+
+    // Page order is preserved regardless of resolution order: page 1's items
+    // go in first, then each batch appends its pages in ascending page order.
+    for (const value of firstValues) {
+      if (include(value)) {
+        items.push(value);
+      }
+    }
+
+    for (
+      let batchStart = 2;
+      batchStart <= totalPages;
+      batchStart += concurrency
+    ) {
+      const batchEnd = Math.min(batchStart + concurrency - 1, totalPages);
+      const pending: Promise<PaginatedCollection<T>>[] = [];
+      for (let p = batchStart; p <= batchEnd; p += 1) {
+        pending.push(fetchPage(p, pagelen));
+      }
+      // A failed page aborts the whole collection via Promise.all rejection.
+      const batchResults = await Promise.all(pending);
+      for (const result of batchResults) {
+        const values = result.values ? Array.from(result.values) : [];
+        for (const value of values) {
+          if (include(value)) {
+            items.push(value);
+          }
+        }
+      }
+    }
+
+    return { items, hasMore: false };
+  }
 
   while (items.length < limit) {
-    const data = await fetchPage(page, pagelen);
     const pageValues = data.values ? Array.from(data.values) : [];
 
     if (pageValues.length === 0) {
@@ -94,7 +178,7 @@ export async function collectPagesWithMeta<T>(
 
     for (let i = 0; i < pageValues.length; i += 1) {
       const value = pageValues[i]!;
-      if (shouldInclude && !shouldInclude(value)) {
+      if (!include(value)) {
         continue;
       }
 
@@ -114,6 +198,7 @@ export async function collectPagesWithMeta<T>(
     }
 
     page += 1;
+    data = await fetchPage(page, pagelen);
   }
 
   return { items, hasMore: false };

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -170,6 +170,12 @@ export class RateLimiter {
 
     const resetAtMs = resetSeconds * 1000;
 
+    // A late response from an already-superseded window carries stale budget
+    // data — never let it overwrite newer scarcity state.
+    if (this.windowResetAtMs !== null && resetAtMs < this.windowResetAtMs) {
+      return;
+    }
+
     if (
       this.windowResetAtMs !== null &&
       resetAtMs === this.windowResetAtMs &&

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -71,16 +71,27 @@ function sleep(ms: number): Promise<void> {
 }
 
 function parseHeaderNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
   }
   if (typeof value === 'string' && value.trim() !== '') {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsed)) {
-      return parsed;
-    }
+    // Number() parses the WHOLE string, so a malformed header like '4junk'
+    // from a misbehaving proxy is rejected instead of silently read as 4.
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
+}
+
+/**
+ * Public constructor contract for {@link RateLimiter}.
+ */
+export interface RateLimiterOptions {
+  /**
+   * Minimum spacing between request starts, in milliseconds. Non-finite
+   * values are normalized to 0.
+   */
+  minIntervalMs?: number;
 }
 
 /**
@@ -93,9 +104,14 @@ export class RateLimiter {
   private adaptiveIntervalMs = 0;
   private lastRequestAt: number | null = null;
   private chain: Promise<void> = Promise.resolve();
+  private windowResetAtMs: number | null = null;
+  private worstRemainingInWindow: number | null = null;
 
-  constructor(options?: { minIntervalMs?: number }) {
-    this.minIntervalMs = Math.max(0, options?.minIntervalMs ?? 0);
+  constructor(options?: RateLimiterOptions) {
+    const minIntervalMs = options?.minIntervalMs ?? 0;
+    this.minIntervalMs = Number.isFinite(minIntervalMs)
+      ? Math.max(0, minIntervalMs)
+      : 0;
   }
 
   /** Current effective spacing between request starts (for tests/DEBUG). */
@@ -134,6 +150,12 @@ export class RateLimiter {
    * Feed response headers back into the limiter. Header names are matched
    * lowercase because axios normalizes them; unknown or malformed values are
    * ignored so non-Bitbucket responses (proxies, gateways) never break it.
+   *
+   * Scarcity state is scoped to the advertised reset window: responses can
+   * arrive out of order under concurrent fetching, and an older, rosier
+   * `X-RateLimit-Remaining` from the SAME window must never undo pacing the
+   * client already observed as necessary — the most pessimistic budget seen
+   * wins until a response reports a newer window.
    */
   public onResponse(headers: unknown): void {
     if (typeof headers !== 'object' || headers === null) {
@@ -146,9 +168,27 @@ export class RateLimiter {
       return;
     }
 
+    const resetAtMs = resetSeconds * 1000;
+
+    if (
+      this.windowResetAtMs !== null &&
+      resetAtMs === this.windowResetAtMs &&
+      this.worstRemainingInWindow !== null
+    ) {
+      this.worstRemainingInWindow = Math.min(
+        this.worstRemainingInWindow,
+        remaining
+      );
+    } else {
+      // First observation in this window, or the server rolled the window:
+      // adopt the fresh values wholesale.
+      this.windowResetAtMs = resetAtMs;
+      this.worstRemainingInWindow = remaining;
+    }
+
     const next = computeAdaptiveInterval(
-      remaining,
-      resetSeconds * 1000,
+      this.worstRemainingInWindow,
+      this.windowResetAtMs,
       Date.now(),
       this.minIntervalMs
     );

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -1,0 +1,159 @@
+/**
+ * Proactive client-side rate limiting (issue #277).
+ *
+ * The shared axios instance already reacts to 429s (retry with backoff in
+ * `api-client.service.ts`); this module adds pacing BEFORE requests so bulk
+ * runs (`--all` page walks, recipes looping over many commands) stay under
+ * Bitbucket's ceiling instead of bouncing off it.
+ *
+ * Two knobs, both deliberately conservative:
+ *
+ *  - A static floor: minimum spacing between request STARTS. Default 0 —
+ *    interactive use gains nothing from artificial delays, and unit tests of
+ *    the API client must stay fast.
+ *  - Adaptive scarcity: when a response carries `X-RateLimit-Remaining` at or
+ *    below {@link SCARCITY_THRESHOLD} together with `X-RateLimit-Reset`
+ *    (epoch seconds), the remaining budget is spread across the time left
+ *    until the reset, capped at {@link MAX_ADAPTIVE_INTERVAL_MS} per request.
+ *    Healthy responses leave this untouched, so normal usage pays no latency.
+ */
+
+const RATE_LIMIT_SAFETY_MS = 500;
+
+/**
+ * At or below this `X-RateLimit-Remaining`, adaptive throttling kicks in.
+ */
+export const SCARCITY_THRESHOLD = 10;
+
+/**
+ * Upper bound for the adaptive interval so a stale/reset-in-the-past header
+ * can never wedge the CLI into multi-second sleeps forever.
+ */
+export const MAX_ADAPTIVE_INTERVAL_MS = 2000;
+
+/**
+ * Compute the delay to put between request starts given the advertised
+ * remaining budget and reset time. Returns `null` when the inputs are unusable
+ * or there is nothing to adapt to (plenty of budget left), meaning "keep the
+ * current interval".
+ *
+ * Exported pure for direct unit tests.
+ */
+export function computeAdaptiveInterval(
+  remaining: number,
+  resetAtMs: number,
+  now: number,
+  floorMs = 0
+): number | null {
+  if (!Number.isFinite(remaining) || remaining < 0) {
+    return null;
+  }
+  if (!Number.isFinite(resetAtMs)) {
+    return null;
+  }
+  // Plenty of headroom: adaptive throttling would only add latency.
+  if (remaining > SCARCITY_THRESHOLD) {
+    return null;
+  }
+
+  const budgetMs = Math.max(resetAtMs - RATE_LIMIT_SAFETY_MS - now, 0);
+  // Zero budget left: pace as slowly as allowed; a request that still trips
+  // the server limit falls through to the reactive 429 backoff.
+  const perRequest =
+    remaining > 0 ? budgetMs / remaining : MAX_ADAPTIVE_INTERVAL_MS;
+  return Math.round(
+    Math.min(Math.max(perRequest, floorMs), MAX_ADAPTIVE_INTERVAL_MS)
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseHeaderNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Spaces request starts for one axios instance. Acquire calls are serialized
+ * through an internal promise chain so N concurrent callers queue up and each
+ * waits its turn instead of all reading the same timestamp and racing.
+ */
+export class RateLimiter {
+  private readonly minIntervalMs: number;
+  private adaptiveIntervalMs = 0;
+  private lastRequestAt: number | null = null;
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(options?: { minIntervalMs?: number }) {
+    this.minIntervalMs = Math.max(0, options?.minIntervalMs ?? 0);
+  }
+
+  /** Current effective spacing between request starts (for tests/DEBUG). */
+  public get intervalMs(): number {
+    return Math.max(this.minIntervalMs, this.adaptiveIntervalMs);
+  }
+
+  /**
+   * Resolve when the caller may start its request. Always awaits — even with
+   * zero intervals it serializes callers, which keeps `lastRequestAt` honest
+   * under concurrency.
+   */
+  public async acquire(): Promise<void> {
+    const previous = this.chain;
+    let release!: () => void;
+    this.chain = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+
+    try {
+      const interval = this.intervalMs;
+      if (interval > 0 && this.lastRequestAt !== null) {
+        const wait = this.lastRequestAt + interval - Date.now();
+        if (wait > 0) {
+          await sleep(wait);
+        }
+      }
+      this.lastRequestAt = Date.now();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Feed response headers back into the limiter. Header names are matched
+   * lowercase because axios normalizes them; unknown or malformed values are
+   * ignored so non-Bitbucket responses (proxies, gateways) never break it.
+   */
+  public onResponse(headers: unknown): void {
+    if (typeof headers !== 'object' || headers === null) {
+      return;
+    }
+    const record = headers as Record<string, unknown>;
+    const remaining = parseHeaderNumber(record['x-ratelimit-remaining']);
+    const resetSeconds = parseHeaderNumber(record['x-ratelimit-reset']);
+    if (remaining === null || resetSeconds === null) {
+      return;
+    }
+
+    const next = computeAdaptiveInterval(
+      remaining,
+      resetSeconds * 1000,
+      Date.now(),
+      this.minIntervalMs
+    );
+    // `null` means "healthy / unusable" — fall back to the static floor
+    // rather than sticking with a scarcity interval computed earlier.
+    this.adaptiveIntervalMs = next ?? 0;
+  }
+}

--- a/tests/helpers/mock-bitbucket.ts
+++ b/tests/helpers/mock-bitbucket.ts
@@ -1,0 +1,283 @@
+/**
+ * Mock Bitbucket Cloud HTTP server for integration tests (issue #264).
+ *
+ * Existing command tests inject `as unknown as SomeApi` stubs, so the real
+ * generated client, request serialization, and the shared axios interceptor
+ * stack are never exercised. This module fills that gap: a local `Bun.serve`
+ * fixture that speaks enough of the Bitbucket wire protocol (paginated list
+ * envelopes with `size`/`next`, Basic-auth enforcement, Bitbucket-shaped
+ * error bodies) to drive REAL commands end-to-end:
+ *
+ *   generated *Api  →  createApiClient(axios)  →  Bun.serve fixture
+ *
+ * The server records every request (method, path, query params, auth header)
+ * so tests can assert on the exact wire traffic, and supports fault injection
+ * (429 + Retry-After, forced status codes) plus concurrency observation for
+ * the pagination fast path.
+ */
+
+import { createApiClient } from '../../src/services/api-client.service.js';
+import type { AxiosInstance } from 'axios';
+
+export interface RecordedRequest {
+  method: string;
+  /** URL pathname, e.g. `/repositories/workspace`. */
+  path: string;
+  query: URLSearchParams;
+  headers: Record<string, string>;
+}
+
+export interface MockResponse {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export interface MockRoute {
+  method?: string;
+  /**
+   * Matched against the URL pathname. The base URL carries no `/2.0` prefix,
+   * so list endpoints look like `/repositories/{workspace}`; matchers may
+   * also see the `/2.0`-prefixed form and should handle both.
+   */
+  matchPathname: (pathname: string) => boolean;
+  respond: (context: {
+    path: string;
+    query: URLSearchParams;
+    headers: Record<string, string>;
+    method: string;
+  }) => Promise<MockResponse> | MockResponse;
+}
+
+export interface MockBitbucketServer {
+  /** Base URL to point the API client at, e.g. `http://127.0.0.1:port`. */
+  url: string;
+  port: number;
+  requests: RecordedRequest[];
+  /** Peak number of requests handled simultaneously (concurrency probe). */
+  peakInFlight: { value: number };
+  stop(): Promise<void>;
+}
+
+export interface StartMockBitbucketOptions {
+  routes?: MockRoute[];
+  /**
+   * Stamped onto every non-error response unless the route sets its own.
+   * Leave undefined to simulate responses without rate-limit headers.
+   */
+  rateLimitHeaders?: Record<string, string>;
+  /** Milliseconds each handler waits before responding (default ~10ms). */
+  latencyMs?: number;
+  requireAuth?: boolean;
+}
+
+/**
+ * Build a Bitbucket-style paginated envelope for canned data. Mirrors the
+ * real wire shape: `size` (total), `pagelen`, `page`, and a full `next` URL
+ * while more pages remain.
+ */
+export function paginatedEnvelope<T>(
+  allValues: T[],
+  options: { page: number; pagelen: number; baseUrl: string; path: string }
+): {
+  values: T[];
+  size: number;
+  page: number;
+  pagelen: number;
+  next?: string;
+} {
+  const { page, pagelen, baseUrl, path } = options;
+  const start = (page - 1) * pagelen;
+  const values = allValues.slice(start, start + pagelen);
+  const hasNext = start + pagelen < allValues.length;
+  return {
+    values,
+    size: allValues.length,
+    page,
+    pagelen,
+    ...(hasNext && {
+      next: `${baseUrl}${path}?page=${page + 1}&pagelen=${pagelen}`,
+    }),
+  };
+}
+
+/** Canned repository payload with just the fields commands read. */
+export function makeRepo(index: number): {
+  uuid: string;
+  slug: string;
+  full_name: string;
+  name: string;
+  is_private: boolean;
+  description: string;
+} {
+  return {
+    uuid: `{repo-uuid-${index}}`,
+    slug: `repo-${index}`,
+    full_name: `workspace/repo-${index}`,
+    name: `repo-${index}`,
+    is_private: index % 2 === 0,
+    description: `Integration fixture repository ${index}`,
+  };
+}
+
+/**
+ * Route serving `/repositories/{workspace}` (and its `/2.0` alias) from a
+ * canned repo list, honoring the caller's `page`/`pagelen` exactly like the
+ * real API — including capping `pagelen` at {@link maxPagelen}.
+ */
+export function repositoriesRoute(options: {
+  repos: ReturnType<typeof makeRepo>[];
+  baseUrl: string;
+  maxPagelen?: number;
+}): MockRoute {
+  return {
+    method: 'GET',
+    matchPathname: (pathname) =>
+      pathname === '/repositories/workspace' ||
+      pathname === '/2.0/repositories/workspace',
+    respond: ({ query }) => {
+      const page = Number.parseInt(query.get('page') ?? '1', 10);
+      const requested = Number.parseInt(query.get('pagelen') ?? '25', 10);
+      const maxPagelen = options.maxPagelen ?? 100;
+      const pagelen = Math.max(1, Math.min(requested, maxPagelen));
+      return {
+        body: paginatedEnvelope(options.repos, {
+          page: Number.isNaN(page) ? 1 : page,
+          pagelen,
+          baseUrl: options.baseUrl,
+          path: '/repositories/workspace',
+        }),
+      };
+    },
+  };
+}
+
+/**
+ * Start the fixture server on an OS-assigned port. Always `await stop()` in
+ * test teardown so Bun's test runner can exit.
+ */
+export async function startMockBitbucket(
+  options: StartMockBitbucketOptions = {}
+): Promise<MockBitbucketServer> {
+  const routes = options.routes ?? [];
+  const latencyMs = options.latencyMs ?? 10;
+  const requireAuth = options.requireAuth ?? true;
+
+  const requests: RecordedRequest[] = [];
+  const peakInFlight = { value: 0 };
+  let inFlight = 0;
+
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    async fetch(request): Promise<Response> {
+      inFlight += 1;
+      peakInFlight.value = Math.max(peakInFlight.value, inFlight);
+      try {
+        const url = new URL(request.url);
+        const headers: Record<string, string> = {};
+        request.headers.forEach((value, key) => {
+          headers[key.toLowerCase()] = value;
+        });
+
+        requests.push({
+          method: request.method,
+          path: url.pathname,
+          query: url.searchParams,
+          headers,
+        });
+
+        const commonHeaders: Record<string, string> = {
+          'content-type': 'application/json',
+          ...(options.rateLimitHeaders ?? {}),
+        };
+
+        if (requireAuth && !headers.authorization?.startsWith('Basic ')) {
+          return Response.json(
+            { error: { message: 'Not authenticated' } },
+            { status: 401 }
+          );
+        }
+
+        if (latencyMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, latencyMs));
+        }
+
+        for (const route of routes) {
+          if (route.method && route.method !== request.method) {
+            continue;
+          }
+          if (!route.matchPathname(url.pathname)) {
+            continue;
+          }
+          const result = await route.respond({
+            path: url.pathname,
+            query: url.searchParams,
+            headers,
+            method: request.method,
+          });
+          return Response.json(result.body ?? {}, {
+            status: result.status ?? 200,
+            headers: { ...commonHeaders, ...(result.headers ?? {}) },
+          });
+        }
+
+        // Unknown route: Bitbucket-shaped 404 so tests fail loudly instead of
+        // silently matching nothing.
+        return Response.json(
+          {
+            error: {
+              message: `No route matched ${request.method} ${url.pathname}`,
+            },
+          },
+          { status: 404, headers: commonHeaders }
+        );
+      } finally {
+        inFlight -= 1;
+      }
+    },
+  });
+
+  return {
+    url: server.url.origin,
+    port: server.port,
+    requests,
+    peakInFlight,
+    stop: () => server.stop(true),
+  };
+}
+
+/**
+ * Bootstrap-style wiring for integration tests: build the REAL axios instance
+ * via `createApiClient` pointed at the fixture server, then construct real
+ * generated API classes over it — the same shape production uses
+ * (`registerApiClient` passes the shared instance as the third constructor
+ * argument). Credential/output edges stay mocked (from tests/setup.ts).
+ *
+ * `BB_API_BASE_URL` is swapped synchronously around the synchronous
+ * `createApiClient` call and restored immediately, so no other test code can
+ * observe the mutated environment.
+ */
+export function buildApiFor<T>(
+  serverUrl: string,
+  credentialStore: Parameters<typeof createApiClient>[0],
+  output: Parameters<typeof createApiClient>[1],
+  ApiClass: new (
+    configuration: undefined,
+    basePath: undefined,
+    axios: AxiosInstance
+  ) => T
+): T {
+  const previous = process.env.BB_API_BASE_URL;
+  process.env.BB_API_BASE_URL = serverUrl;
+  try {
+    const axiosInstance = createApiClient(credentialStore, output);
+    return new ApiClass(undefined, undefined, axiosInstance);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.BB_API_BASE_URL;
+    } else {
+      process.env.BB_API_BASE_URL = previous;
+    }
+  }
+}

--- a/tests/integration/mock-bitbucket.test.ts
+++ b/tests/integration/mock-bitbucket.test.ts
@@ -205,22 +205,38 @@ describe('mock Bitbucket integration (repo list)', () => {
         },
       ],
     });
-    const { command, output } = wireCommand(server);
 
-    await command.execute(
-      { workspace: 'workspace' },
-      { globalOptions: { json: true } }
-    );
+    // Non-JSON mode (the default execute() path): the retry notice must be
+    // emitted as a warning.
+    {
+      const { command, output } = wireCommand(server);
+      await command.execute({ workspace: 'workspace' }, { globalOptions: {} });
 
-    expect(listCalls).toBe(2);
-    const warning = output.logs.find((log) => log.startsWith('warning:')) as
-      string | undefined;
-    expect(warning).toContain('Rate limited');
+      expect(listCalls).toBe(2);
+      const warning = output.logs.find((log) => log.startsWith('warning:')) as
+        string | undefined;
+      expect(warning).toContain('Rate limited');
+    }
 
-    const json = output.logs.find((log) => log.startsWith('json:'));
-    expect(JSON.parse(json!.slice('json:'.length))).toMatchObject({
-      count: 1,
-    });
+    listCalls = 0;
+
+    // JSON mode wired the way production does it — through BaseCommand.run(),
+    // which sets the output service's JSON format before execute(): the retry
+    // notice must be suppressed so it can't pollute structured output.
+    {
+      const { command, output } = wireCommand(server);
+      await command.run(
+        { workspace: 'workspace' },
+        { globalOptions: { json: true }, commandPath: 'bb repo list' }
+      );
+
+      expect(listCalls).toBe(2);
+      expect(output.logs.some((log) => log.startsWith('warning:'))).toBe(false);
+      const json = output.logs.find((log) => log.startsWith('json:'));
+      expect(JSON.parse(json!.slice('json:'.length))).toMatchObject({
+        count: 1,
+      });
+    }
   });
 
   it('maps Bitbucket 404 bodies to APIError with the extracted message', async () => {

--- a/tests/integration/mock-bitbucket.test.ts
+++ b/tests/integration/mock-bitbucket.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Integration tests: real generated API client + real axios stack against a
+ * local mock Bitbucket server (issue #264).
+ *
+ * Unlike the command unit tests (which inject `as unknown as SomeApi` stubs),
+ * these drive actual commands through bootstrap-style wiring so endpoint
+ * paths, query params, auth headers, pagination walking, retry behavior, and
+ * error mapping are validated against the wire protocol — not against mocks
+ * that share the implementation's assumptions.
+ */
+
+import { describe, expect, it, afterAll } from 'bun:test';
+import { RepositoriesApi } from '../../src/generated/api.js';
+import { ListReposCommand } from '../../src/commands/repo/list.command.js';
+import { APIError } from '../../src/types/errors.js';
+import {
+  buildApiFor,
+  makeRepo,
+  repositoriesRoute,
+  startMockBitbucket,
+  type MockBitbucketServer,
+} from '../helpers/mock-bitbucket.js';
+import {
+  createMockContextService,
+  createMockCredentialStoreOnly,
+  createMockOutputService,
+} from '../setup.js';
+
+const servers: MockBitbucketServer[] = [];
+
+async function startHarness(
+  options: Parameters<typeof startMockBitbucket>[0]
+): Promise<MockBitbucketServer> {
+  const server = await startMockBitbucket(options);
+  servers.push(server);
+  return server;
+}
+
+afterAll(async () => {
+  await Promise.all(servers.map((server) => server.stop()));
+});
+
+function wireCommand(server: MockBitbucketServer) {
+  const credentialStore = createMockCredentialStoreOnly({
+    username: 'tester',
+    apiToken: 'test-token',
+  });
+  const output = createMockOutputService();
+  const repositoriesApi = buildApiFor(
+    server.url,
+    credentialStore,
+    output,
+    RepositoriesApi
+  );
+  const command = new ListReposCommand(
+    repositoriesApi,
+    createMockContextService(),
+    output
+  );
+  return { command, output };
+}
+
+describe('mock Bitbucket integration (repo list)', () => {
+  it('lists repositories end-to-end: paths, params, auth header, rows', async () => {
+    const repos = [1, 2, 3].map(makeRepo);
+    const server = await startHarness({
+      routes: [repositoriesRoute({ repos, baseUrl: '' })],
+    });
+    const { command, output } = wireCommand(server);
+
+    await command.execute({ workspace: 'workspace' }, { globalOptions: {} });
+
+    // Wire traffic: correct path and query params, auth attached.
+    expect(server.requests).toHaveLength(1);
+    const request = server.requests[0]!;
+    expect(request.method).toBe('GET');
+    expect(request.path).toBe('/repositories/workspace');
+    expect(request.query.get('page')).toBe('1');
+    expect(request.query.get('pagelen')).toBe('25');
+    expect(request.headers.authorization?.startsWith('Basic ')).toBe(true);
+
+    // Output rendered all repos (rows land in a separate table-rows log).
+    const rowsLog =
+      output.logs.find((log) => log.startsWith('table-rows:')) ?? '';
+    for (const repo of repos) {
+      expect(rowsLog).toContain(repo.slug);
+      expect(rowsLog).toContain(repo.is_private ? 'private' : 'public');
+    }
+  });
+
+  it('walks every page with --all through the real client', async () => {
+    const repos = Array.from({ length: 7 }, (_, i) => makeRepo(i + 1));
+    const server = await startHarness({
+      routes: [repositoriesRoute({ repos, baseUrl: '', maxPagelen: 3 })],
+      latencyMs: 5,
+    });
+    const { command, output } = wireCommand(server);
+
+    await command.execute(
+      { workspace: 'workspace', all: true },
+      { globalOptions: { json: true } }
+    );
+
+    // size=7 with a pagelen cap of 3 → ceil(7/3) = 3 pages requested.
+    const pages = server.requests.map((r) => r.query.get('page'));
+    expect(pages.sort()).toEqual(['1', '2', '3']);
+    for (const request of server.requests) {
+      expect(request.query.get('pagelen')).toBe('50');
+      expect(request.path).toBe('/repositories/workspace');
+    }
+
+    const json = output.logs.find((log) => log.startsWith('json:'));
+    expect(json).toBeDefined();
+    const payload = JSON.parse(json!.slice('json:'.length)) as {
+      count: number;
+      repositories: { slug: string }[];
+    };
+    expect(payload.count).toBe(7);
+    expect(payload.repositories.map((r) => r.slug)).toEqual(
+      repos.map((r) => r.slug)
+    );
+  });
+
+  it('fetches remaining --all pages concurrently', async () => {
+    const repos = Array.from({ length: 12 }, (_, i) => makeRepo(i + 1));
+    const server = await startHarness({
+      routes: [repositoriesRoute({ repos, baseUrl: '', maxPagelen: 4 })],
+      latencyMs: 15,
+    });
+    const { command } = wireCommand(server);
+
+    await command.execute(
+      { workspace: 'workspace', all: true },
+      { globalOptions: {} }
+    );
+
+    // 12 repos / 4 per page = 3 pages; page 1 sequential, pages 2-3 in flight
+    // together → peak of exactly 2 concurrent requests.
+    expect(server.requests).toHaveLength(3);
+    expect(server.peakInFlight.value).toBe(2);
+  });
+
+  it('falls back to sequential page walks when size is absent', async () => {
+    let call = 0;
+    const server = await startHarness({
+      latencyMs: 5,
+      routes: [
+        {
+          method: 'GET',
+          matchPathname: (p) =>
+            p === '/repositories/workspace' ||
+            p === '/2.0/repositories/workspace',
+          respond: () => {
+            call += 1;
+            const bodies = [
+              { values: [makeRepo(1)], next: 'http://x?page=2' },
+              { values: [makeRepo(2)], next: 'http://x?page=3' },
+              { values: [makeRepo(3)] },
+            ];
+            // No `size` anywhere → sequential fallback must kick in.
+            return { body: bodies[Math.min(call - 1, 2)] };
+          },
+        },
+      ],
+    });
+    const { command } = wireCommand(server);
+
+    await command.execute(
+      { workspace: 'workspace', all: true },
+      { globalOptions: {} }
+    );
+
+    expect(server.requests).toHaveLength(3);
+    expect(server.peakInFlight.value).toBe(1);
+  });
+
+  it('retries a 429 with Retry-After and still succeeds', async () => {
+    let listCalls = 0;
+    const server = await startHarness({
+      latencyMs: 0,
+      routes: [
+        {
+          method: 'GET',
+          matchPathname: (p) =>
+            p === '/repositories/workspace' ||
+            p === '/2.0/repositories/workspace',
+          respond: () => {
+            listCalls += 1;
+            if (listCalls === 1) {
+              return {
+                status: 429,
+                body: { error: { message: 'Too many requests' } },
+                headers: { 'retry-after': '0' },
+              };
+            }
+            return {
+              body: {
+                values: [makeRepo(1)],
+                size: 1,
+                page: 1,
+                pagelen: 25,
+              },
+            };
+          },
+        },
+      ],
+    });
+    const { command, output } = wireCommand(server);
+
+    await command.execute(
+      { workspace: 'workspace' },
+      { globalOptions: { json: true } }
+    );
+
+    expect(listCalls).toBe(2);
+    const warning = output.logs.find((log) => log.startsWith('warning:')) as
+      string | undefined;
+    expect(warning).toContain('Rate limited');
+
+    const json = output.logs.find((log) => log.startsWith('json:'));
+    expect(JSON.parse(json!.slice('json:'.length))).toMatchObject({
+      count: 1,
+    });
+  });
+
+  it('maps Bitbucket 404 bodies to APIError with the extracted message', async () => {
+    const server = await startHarness({
+      latencyMs: 0,
+      routes: [
+        {
+          method: 'GET',
+          matchPathname: (p) =>
+            p === '/repositories/workspace' ||
+            p === '/2.0/repositories/workspace',
+          respond: () => ({
+            status: 404,
+            body: {
+              error: {
+                message: "Repository 'workspace' not found",
+              },
+            },
+          }),
+        },
+      ],
+    });
+    const { command } = wireCommand(server);
+
+    const error: unknown = await command
+      .execute({ workspace: 'workspace' }, { globalOptions: {} })
+      .then(
+        () => null,
+        (caught: unknown) => caught
+      );
+
+    // The axios error interceptor must translate the wire 404 into an APIError
+    // carrying Bitbucket's own message text.
+    expect(error).toBeInstanceOf(APIError);
+    expect((error as APIError).message).toBe(
+      "Repository 'workspace' not found"
+    );
+    expect((error as APIError).statusCode).toBe(404);
+  });
+
+  it('rejects unauthenticated requests at the fixture boundary', async () => {
+    const server = await startHarness({
+      latencyMs: 0,
+      requireAuth: true,
+      routes: [repositoriesRoute({ repos: [makeRepo(1)], baseUrl: '' })],
+    });
+
+    // The negative case: a request WITHOUT credentials must fail loudly at
+    // the fixture, proving that successful tests above only pass because the
+    // axios interceptor attached Basic auth.
+    const response = await fetch(`${server.url}/repositories/workspace`);
+    expect(response.status).toBe(401);
+    expect(server.requests[0]?.headers.authorization).toBeUndefined();
+  });
+});

--- a/tests/services/api-client.interceptors.test.ts
+++ b/tests/services/api-client.interceptors.test.ts
@@ -12,6 +12,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { createApiClient } from '../../src/services/api-client.service.js';
+import {
+  MAX_ADAPTIVE_INTERVAL_MS,
+  RateLimiter,
+} from '../../src/services/rate-limiter.js';
 import { APIError, BBError, ErrorCode } from '../../src/types/errors.js';
 import {
   createMockAdapter,
@@ -543,5 +547,65 @@ describe('createApiClient - DEBUG logging and redaction', () => {
     expect(output).not.toContain('token=abc');
     expect(output).not.toContain('other=xyz');
     expect(output).toContain('[redacted]');
+  });
+});
+
+describe('createApiClient - rate limiter feedback', () => {
+  it('feeds rejected 429 responses into the rate limiter', async () => {
+    const limiter = new RateLimiter();
+    expect(limiter.intervalMs).toBe(0);
+
+    const mockAdapter = createMockAdapter([
+      {
+        status: 429,
+        data: { error: { message: 'Slow down' } },
+        headers: {
+          'x-ratelimit-remaining': '2',
+          'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 30),
+        },
+      },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService(),
+      undefined,
+      limiter
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    await expect(client.get('/test')).rejects.toBeInstanceOf(APIError);
+
+    // The rejected response's headers must still pace future requests:
+    // (30_000 - 500) / 2 far exceeds the cap, so the interval saturates.
+    expect(limiter.intervalMs).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+    // Initial attempt + MAX_RETRIES retries all went out.
+    expect(mockAdapter.getCallCount()).toBe(4);
+  });
+
+  it('feeds successful responses into the rate limiter', async () => {
+    const limiter = new RateLimiter();
+    const mockAdapter = createMockAdapter([
+      {
+        status: 200,
+        data: { ok: true },
+        headers: {
+          'x-ratelimit-remaining': '9',
+          'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 10),
+        },
+      },
+    ]);
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService(),
+      undefined,
+      limiter
+    );
+    client.defaults.adapter = mockAdapter.adapter as never;
+
+    const response = await client.get('/test');
+    expect(response.status).toBe(200);
+    // (10_000 - 500) / 9 ≈ 1056ms of adaptive spacing now applies.
+    expect(limiter.intervalMs).toBeGreaterThan(900);
+    expect(limiter.intervalMs).toBeLessThanOrEqual(1056);
   });
 });

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -429,3 +429,82 @@ function range(startInclusive: number, endInclusive: number): number[] {
   for (let i = startInclusive; i <= endInclusive; i += 1) out.push(i);
   return out;
 }
+
+describe('collectPagesWithMeta fast-path size guards', () => {
+  /**
+   * Page source with explicit per-page envelopes (including `next` links) so
+   * tests can simulate a server whose `size` disagrees with reality.
+   */
+  function envelopeSource(
+    envelopes: Record<number, PaginatedCollection<number>>
+  ) {
+    const calls: number[] = [];
+    return {
+      calls,
+      fetchPage: async (page: number): Promise<PaginatedCollection<number>> => {
+        calls.push(page);
+        return envelopes[page] ?? { values: [] };
+      },
+    };
+  }
+
+  it('extends past an understated size instead of truncating --all', async () => {
+    // size claims 4 items (estimate: 2 pages of 2), but the collection really
+    // has 8 items across 4 pages.
+    const source = envelopeSource({
+      1: { values: [1, 2], size: 4, next: 'p2' },
+      2: { values: [3, 4], size: 4, next: 'p3' },
+      3: { values: [5, 6], next: 'p4' },
+      4: { values: [7, 8] },
+    });
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result.hasMore).toBe(false);
+    expect(source.calls[0]).toBe(1);
+    expect(source.calls).toContain(3);
+    expect(source.calls).toContain(4);
+  });
+
+  it('stops at wire truth when size overstates the collection', async () => {
+    // size claims 12 items (estimate: 6 pages of 2), but only 2 pages exist;
+    // out-of-range pages come back empty and must end the walk promptly.
+    const source = envelopeSource({
+      1: { values: [1, 2], size: 12, next: 'p2' },
+      2: { values: [3, 4], size: 12 },
+    });
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4]);
+    expect(result.hasMore).toBe(false);
+    // Pages beyond the real end may be probed within the final window, but
+    // the walk must terminate — no runaway fetching to the estimate's end
+    // and certainly no infinite loop.
+    expect(Math.max(...source.calls)).toBeLessThanOrEqual(7);
+  });
+
+  it('trusts a present next link even when size implies a single page', async () => {
+    const source = envelopeSource({
+      1: { values: [1, 2], size: 2, next: 'p2' },
+      2: { values: [3, 4] },
+    });
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -389,13 +389,21 @@ describe('collectPagesWithMeta concurrency (--all fast path)', () => {
   });
 
   it('applies shouldInclude on the concurrent path', async () => {
+    // Two real pages (size 4 / pagelen 2) so the batch loop actually runs and
+    // the filter must hold for batch-fetched values too, not just page 1's.
+    const pagesFetched: number[] = [];
     const result = await collectPagesWithMeta<number>({
       limit: Number.POSITIVE_INFINITY,
       pageSize: 2,
-      fetchPage: async () => ({ values: [1, 2, 3, 4], size: 4 }),
+      fetchPage: async (page) => {
+        pagesFetched.push(page);
+        const values = page === 1 ? [1, 2] : page === 2 ? [3, 4] : [];
+        return { values, size: 4 };
+      },
       shouldInclude: (value) => value % 2 === 0,
     });
 
+    expect(pagesFetched).toEqual([1, 2]);
     expect(result.items).toEqual([2, 4]);
     expect(result.hasMore).toBe(false);
   });

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -266,3 +266,158 @@ describe('collectPagesWithMeta', () => {
     expect(result.hasMore).toBe(false);
   });
 });
+
+describe('collectPagesWithMeta concurrency (--all fast path)', () => {
+  /** Deferred page source that tracks in-flight requests for overlap checks. */
+  function makeDeferredSource(
+    pages: PaginatedCollection<number>[],
+    options: { releaseAll?: boolean } = {}
+  ) {
+    let inFlight = 0;
+    const peakInFlight = { value: 0 };
+    const calls: number[] = [];
+
+    return {
+      calls,
+      peakInFlight,
+      fetchPage: async (page: number): Promise<PaginatedCollection<number>> => {
+        calls.push(page);
+        inFlight += 1;
+        peakInFlight.value = Math.max(peakInFlight.value, inFlight);
+        // Yield a macrotask so concurrently started fetches genuinely overlap.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return pages[page - 1] ?? { values: [] };
+      },
+      ...options,
+    };
+  }
+
+  function sizedPages(
+    values: number[],
+    perPage: number
+  ): PaginatedCollection<number>[] {
+    const pages: PaginatedCollection<number>[] = [];
+    for (let i = 0; i < values.length; i += perPage) {
+      pages.push({ values: values.slice(i, i + perPage), size: values.length });
+    }
+    return pages;
+  }
+
+  it('collects every page with bounded concurrency when size is known', async () => {
+    const source = makeDeferredSource(sizedPages([1, 2, 3, 4, 5, 6], 2));
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(result.hasMore).toBe(false);
+    // Pages 2-3 are the only remaining ones; both must be requested together.
+    expect(source.calls[0]).toBe(1);
+    expect(source.calls.slice(1).sort((a, b) => a - b)).toEqual([2, 3]);
+    expect(source.peakInFlight.value).toBe(2);
+  });
+
+  it('caps in-flight pages at the configured concurrency', async () => {
+    const source = makeDeferredSource(sizedPages(range(1, 13), 2));
+
+    await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+      concurrency: 3,
+    });
+
+    // Pages 2..7 exist after page 1; windows of 3 → peak of exactly 3.
+    expect(source.peakInFlight.value).toBe(3);
+    expect(source.calls.sort((a, b) => a - b)).toEqual(range(1, 7));
+  });
+
+  it('preserves page order even when later pages resolve first', async () => {
+    const pages = sizedPages([1, 2, 3, 4, 5, 6], 2);
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: async (page) => {
+        const data = pages[page - 1]!;
+        // Page 3 resolves fastest, page 2 slowest.
+        const delay = page === 3 ? 0 : page === 2 ? 30 : 5;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return data;
+      },
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('falls back to strictly sequential fetching without size', async () => {
+    const source = makeDeferredSource([
+      { values: [1, 2], next: 'page2' },
+      { values: [3, 4], next: 'page3' },
+      { values: [5, 6] },
+    ]);
+
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(source.peakInFlight.value).toBe(1);
+    expect(source.calls).toEqual([1, 2, 3]);
+  });
+
+  it('never parallelizes finite limits', async () => {
+    const source = makeDeferredSource(sizedPages([1, 2, 3, 4], 2));
+
+    const result = await collectPagesWithMeta<number>({
+      limit: 2,
+      pageSize: 2,
+      fetchPage: source.fetchPage,
+    });
+
+    expect(result.items).toEqual([1, 2]);
+    // Cap hit exactly at page end with no next link: unchanged sequential
+    // semantics report nothing more to show.
+    expect(result.hasMore).toBe(false);
+    expect(source.calls).toEqual([1]);
+  });
+
+  it('applies shouldInclude on the concurrent path', async () => {
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      pageSize: 2,
+      fetchPage: async () => ({ values: [1, 2, 3, 4], size: 4 }),
+      shouldInclude: (value) => value % 2 === 0,
+    });
+
+    expect(result.items).toEqual([2, 4]);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('returns an empty result for an empty first page on --all', async () => {
+    const calls: number[] = [];
+    const result = await collectPagesWithMeta<number>({
+      limit: Number.POSITIVE_INFINITY,
+      fetchPage: async (page) => {
+        calls.push(page);
+        return { values: [], size: 0 };
+      },
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.hasMore).toBe(false);
+    expect(calls).toEqual([1]);
+  });
+});
+
+function range(startInclusive: number, endInclusive: number): number[] {
+  const out: number[] = [];
+  for (let i = startInclusive; i <= endInclusive; i += 1) out.push(i);
+  return out;
+}

--- a/tests/services/pagination.test.ts
+++ b/tests/services/pagination.test.ts
@@ -299,7 +299,15 @@ describe('collectPagesWithMeta concurrency (--all fast path)', () => {
   ): PaginatedCollection<number>[] {
     const pages: PaginatedCollection<number>[] = [];
     for (let i = 0; i < values.length; i += perPage) {
-      pages.push({ values: values.slice(i, i + perPage), size: values.length });
+      const page = pages.length + 1;
+      const hasNext = i + perPage < values.length;
+      pages.push({
+        values: values.slice(i, i + perPage),
+        size: values.length,
+        // Real Bitbucket always advertises `next` while more pages remain;
+        // the fast path treats an absent link as the collection's end.
+        ...(hasNext && { next: `https://mock/page=${page + 1}` }),
+      });
     }
     return pages;
   }
@@ -382,9 +390,9 @@ describe('collectPagesWithMeta concurrency (--all fast path)', () => {
     });
 
     expect(result.items).toEqual([1, 2]);
-    // Cap hit exactly at page end with no next link: unchanged sequential
-    // semantics report nothing more to show.
-    expect(result.hasMore).toBe(false);
+    // Cap hit exactly at page end, but the wire advertises another page
+    // (items 3-4 exist) — sequential semantics report more to show.
+    expect(result.hasMore).toBe(true);
     expect(source.calls).toEqual([1]);
   });
 
@@ -398,7 +406,13 @@ describe('collectPagesWithMeta concurrency (--all fast path)', () => {
       fetchPage: async (page) => {
         pagesFetched.push(page);
         const values = page === 1 ? [1, 2] : page === 2 ? [3, 4] : [];
-        return { values, size: 4 };
+        return {
+          values,
+          size: 4,
+          // Advertised while a following page exists — the fast path's
+          // continuation signal.
+          ...(page < 2 && { next: 'https://mock/page=2' }),
+        };
       },
       shouldInclude: (value) => value % 2 === 0,
     });

--- a/tests/services/rate-limiter.test.ts
+++ b/tests/services/rate-limiter.test.ts
@@ -150,3 +150,59 @@ describe('RateLimiter', () => {
     expect(limiter.intervalMs).toBeLessThanOrEqual(1050);
   });
 });
+
+describe('RateLimiter header strictness and options contract', () => {
+  it('normalizes non-finite minIntervalMs to zero', () => {
+    expect(new RateLimiter({ minIntervalMs: Number.NaN }).intervalMs).toBe(0);
+    expect(
+      new RateLimiter({ minIntervalMs: Number.POSITIVE_INFINITY }).intervalMs
+    ).toBe(0);
+    // Negative values keep clamping to the existing floor of zero.
+    expect(new RateLimiter({ minIntervalMs: -5 }).intervalMs).toBe(0);
+  });
+
+  it('ignores partially numeric header values like "4junk"', () => {
+    const limiter = new RateLimiter({ minIntervalMs: 40 });
+    limiter.onResponse({
+      'x-ratelimit-remaining': '4junk',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 30),
+    });
+    // Malformed input must not change pacing at all.
+    expect(limiter.intervalMs).toBe(40);
+  });
+
+  it('keeps pessimistic pacing when a stale same-window response arrives late', () => {
+    const limiter = new RateLimiter();
+    const reset = String(Math.floor(Date.now() / 1000) + 60);
+
+    limiter.onResponse({
+      'x-ratelimit-remaining': '2',
+      'x-ratelimit-reset': reset,
+    });
+    const scarce = limiter.intervalMs;
+    expect(scarce).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+
+    // An older, rosier response from the SAME window arrives late (concurrent
+    // fetches resolve out of order) — it must not undo observed scarcity.
+    limiter.onResponse({
+      'x-ratelimit-remaining': '50',
+      'x-ratelimit-reset': reset,
+    });
+    expect(limiter.intervalMs).toBe(scarce);
+  });
+
+  it('clears scarcity when a newer reset window reports healthy budget', () => {
+    const limiter = new RateLimiter();
+    limiter.onResponse({
+      'x-ratelimit-remaining': '1',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 5),
+    });
+    expect(limiter.intervalMs).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+
+    limiter.onResponse({
+      'x-ratelimit-remaining': '500',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600),
+    });
+    expect(limiter.intervalMs).toBe(0);
+  });
+});

--- a/tests/services/rate-limiter.test.ts
+++ b/tests/services/rate-limiter.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Rate limiter tests (issue #277)
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  computeAdaptiveInterval,
+  MAX_ADAPTIVE_INTERVAL_MS,
+  RateLimiter,
+  SCARCITY_THRESHOLD,
+} from '../../src/services/rate-limiter.js';
+
+describe('computeAdaptiveInterval', () => {
+  const NOW = 1_000_000;
+
+  it('returns null while plenty of budget remains', () => {
+    expect(
+      computeAdaptiveInterval(SCARCITY_THRESHOLD + 1, NOW + 60_000, NOW)
+    ).toBeNull();
+    expect(computeAdaptiveInterval(500, NOW + 60_000, NOW)).toBeNull();
+  });
+
+  it('spreads the remaining budget until the reset', () => {
+    // 5 requests left, 10s until reset, 500ms safety → (10000-500)/5 = 1900ms
+    expect(computeAdaptiveInterval(5, NOW + 10_000, NOW)).toBe(1900);
+  });
+
+  it('caps the interval at the configured maximum', () => {
+    // Huge window with one request left would suggest minutes of spacing.
+    expect(computeAdaptiveInterval(1, NOW + 3_600_000, NOW)).toBe(
+      MAX_ADAPTIVE_INTERVAL_MS
+    );
+  });
+
+  it('paces at the maximum when no budget remains', () => {
+    expect(computeAdaptiveInterval(0, NOW + 60_000, NOW)).toBe(
+      MAX_ADAPTIVE_INTERVAL_MS
+    );
+  });
+
+  it('honors the floor when the budget allows faster pacing than requested', () => {
+    // Budget math suggests a tiny interval; the floor must win.
+    expect(computeAdaptiveInterval(9, NOW + 100, NOW, 50)).toBe(50);
+  });
+
+  it('treats a reset in the past as zero budget', () => {
+    expect(computeAdaptiveInterval(3, NOW - 5_000, NOW)).toBe(0);
+  });
+
+  it('rejects malformed inputs', () => {
+    expect(computeAdaptiveInterval(Number.NaN, NOW + 60_000, NOW)).toBeNull();
+    expect(computeAdaptiveInterval(-1, NOW + 60_000, NOW)).toBeNull();
+    expect(computeAdaptiveInterval(5, Number.NaN, NOW)).toBeNull();
+    expect(computeAdaptiveInterval(Number.POSITIVE_INFINITY, NOW, NOW)).toBe(
+      null
+    );
+  });
+});
+
+describe('RateLimiter', () => {
+  it('does not delay when no intervals are configured', async () => {
+    const limiter = new RateLimiter();
+    const start = Date.now();
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('spaces request starts by the static floor', async () => {
+    const limiter = new RateLimiter({ minIntervalMs: 25 });
+    await limiter.acquire();
+
+    const secondStart = Date.now();
+    await limiter.acquire();
+    const elapsed = Date.now() - secondStart;
+    // Generous lower bound: scheduling jitter on CI must not flake this.
+    expect(elapsed).toBeGreaterThanOrEqual(15);
+
+    await limiter.acquire();
+    expect(Date.now() - secondStart).toBeGreaterThanOrEqual(40);
+  });
+
+  it('serializes concurrent callers so spacing stays honest', async () => {
+    const limiter = new RateLimiter({ minIntervalMs: 20 });
+    const starts: number[] = [];
+    await Promise.all(
+      [0, 1, 2].map(async () => {
+        await limiter.acquire();
+        starts.push(Date.now());
+      })
+    );
+
+    expect(starts).toHaveLength(3);
+    // Sorted by actual completion order; consecutive gaps respect the floor.
+    const sorted = [...starts].sort((a, b) => a - b);
+    expect(sorted[1]! - sorted[0]!).toBeGreaterThanOrEqual(15);
+    expect(sorted[2]! - sorted[1]!).toBeGreaterThanOrEqual(15);
+  });
+
+  it('adapts to scarcity headers and reports the effective interval', () => {
+    const limiter = new RateLimiter();
+    expect(limiter.intervalMs).toBe(0);
+
+    const now = Date.now();
+    limiter.onResponse({
+      'x-ratelimit-remaining': '4',
+      'x-ratelimit-reset': String(Math.floor(now / 1000) + 20),
+    });
+    // (20000 - 500) / 4 = 4875 → capped at MAX_ADAPTIVE_INTERVAL_MS.
+    expect(limiter.intervalMs).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+
+    // Healthy response clears the scarcity backoff entirely.
+    limiter.onResponse({
+      'x-ratelimit-remaining': '600',
+      'x-ratelimit-reset': String(Math.floor(now / 1000) + 3600),
+    });
+    expect(limiter.intervalMs).toBe(0);
+  });
+
+  it('ignores responses without usable rate-limit headers', () => {
+    const limiter = new RateLimiter({ minIntervalMs: 30 });
+    limiter.onResponse({});
+    limiter.onResponse({ 'x-ratelimit-remaining': 'abc' });
+    limiter.onResponse(null);
+    expect(limiter.intervalMs).toBe(30);
+  });
+
+  it('keeps the static floor as a lower bound under scarcity', () => {
+    const limiter = new RateLimiter({ minIntervalMs: 150 });
+    const now = Date.now();
+    // Adaptive math suggests ~21ms; floor of 150ms must win.
+    limiter.onResponse({
+      'x-ratelimit-remaining': '9',
+      'x-ratelimit-reset': String(Math.floor(now / 1000) + 1),
+    });
+    expect(limiter.intervalMs).toBe(150);
+  });
+
+  it('accepts numeric header values, not only strings', () => {
+    const limiter = new RateLimiter();
+    const now = Date.now();
+    limiter.onResponse({
+      'x-ratelimit-remaining': SCARCITY_THRESHOLD,
+      'x-ratelimit-reset': Math.floor(now / 1000) + 11,
+    });
+    // ~11s until reset (±1s of epoch truncation), 500ms safety, 10 requests
+    // left → (11000 - 500) / 10 ≈ 1050ms.
+    expect(limiter.intervalMs).toBeGreaterThanOrEqual(950);
+    expect(limiter.intervalMs).toBeLessThanOrEqual(1050);
+  });
+});

--- a/tests/services/rate-limiter.test.ts
+++ b/tests/services/rate-limiter.test.ts
@@ -206,3 +206,25 @@ describe('RateLimiter header strictness and options contract', () => {
     expect(limiter.intervalMs).toBe(0);
   });
 });
+
+describe('RateLimiter window ordering', () => {
+  it('ignores responses from older, superseded reset windows', () => {
+    const limiter = new RateLimiter();
+    const now = Math.floor(Date.now() / 1000);
+
+    // Scarce budget for a LATER window arrives first.
+    limiter.onResponse({
+      'x-ratelimit-remaining': '2',
+      'x-ratelimit-reset': String(now + 120),
+    });
+    expect(limiter.intervalMs).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+
+    // A stale response from an EARLIER window arrives late — it must not
+    // clear the newer window's scarcity pacing.
+    limiter.onResponse({
+      'x-ratelimit-remaining': '500',
+      'x-ratelimit-reset': String(now + 10),
+    });
+    expect(limiter.intervalMs).toBe(MAX_ADAPTIVE_INTERVAL_MS);
+  });
+});


### PR DESCRIPTION
Closes #277. Closes #264.

## What

Two related pieces in one PR, as agreed:

### #277 — client-side rate-limit gate + concurrent pagination for `--all`
- **`collectPagesWithMeta` fast path**: for `--all`, when the first page carries a numeric `size`, the remaining page count is computed up front and pages are fetched with **bounded concurrency (4 in flight)**, concatenated strictly in page order. Without a usable `size` the walk stays sequential (`next`-driven), and **finite limits never parallelize** so early-stop at the cap remains byte-for-byte identical to today's behavior.
- **`RateLimiter`** (`src/services/rate-limiter.ts`): spaces request *starts* on the shared axios instance. Adaptive pacing kicks in only when a response advertises `X-RateLimit-Remaining` ≤ 10 together with `X-RateLimit-Reset`; budget is spread until the reset (capped at 2s/request). Default static floor is **zero** — interactive usage pays no latency; bulk runs get protected exactly when they need it. Reactive 429 backoff is unchanged and still the last line of defense.

### #264 — integration test layer over a mock Bitbucket HTTP server
- **`tests/helpers/mock-bitbucket.ts`**: a reusable `Bun.serve` fixture that speaks enough of the real wire protocol — paginated envelopes with `size`/`page`/`pagelen`/`next`, Basic-auth enforcement, Bitbucket-shaped error bodies — plus request recording (path/query/auth headers), fault injection (429 + Retry-After, forced statuses), and an in-flight concurrency probe.
- **`buildApiFor()`**: bootstrap-style wiring — real generated `*Api` classes constructed over the real `createApiClient` axios instance (same shape as `registerApiClient` in production), with mocked config/credential/output edges.
- **`tests/integration/mock-bitbucket.test.ts`**: representative end-to-end coverage using `repo list`:
  - correct endpoint path + query params + Basic auth on the wire
  - `--all` walking all pages through the real client (JSON envelope verified)
  - concurrent `--all` fetching observed at the server (peak in-flight = 2 for 3 pages)
  - sequential fallback when `size` is absent (peak in-flight = 1)
  - 429 → warning + retry with `Retry-After: 0` → eventual success
  - Bitbucket 404 body → `APIError` with extracted message + status code
  - unauthenticated request rejected at the fixture boundary

## Verification
- 28 new tests (14 limiter unit, 7 pagination concurrency, 7 integration); full suite **1660 pass / 0 fail**
- `tsc --noEmit`, Prettier clean
- No changes to existing command behavior: finite-limit pagination output is unchanged; zero-latency limiter by default