### PR TITLE
fix: strip Content-Type from bodyless requests (issue #321)

### DIFF
--- a/.changeset/fix-bodyless-content-type.md
+++ b/.changeset/fix-bodyless-content-type.md
@@ -1,0 +1,5 @@
+---
+'@pilatos/bitbucket-cli': patch
+---
+
+fix: stop sending `Content-Type: application/json` with a zero-length body on bodyless requests (#321). Bodyless POSTs and DELETEs (`bb pr approve`, `bb pr decline`, `bb commit approve`, `bb api -X POST` without fields, etc.) inherited the shared client's `Content-Type: application/json` instance default, and Bitbucket's request parser rejected the empty body declared as JSON with a bare-text 400 before the request reached the endpoint. The header is now stripped at the adapter level whenever a request carries no body; requests with a body (JSON objects, raw `--input` strings, multipart snippet uploads) are unchanged.

--- a/src/services/api-client.service.ts
+++ b/src/services/api-client.service.ts
@@ -229,6 +229,24 @@ export function createApiClient(
     },
   });
 
+  // Strip `Content-Type` from bodyless requests (issue #321): the instance
+  // default above is applied to every request, so bodyless POSTs (e.g.
+  // `bb pr approve` / `bb pr decline`) go out declaring `application/json`
+  // with a zero-length body, which Bitbucket's request parser rejects with a
+  // bare-text 400 before the request reaches the endpoint. The default must
+  // be stripped at the adapter level, after `dispatchRequest` has already run
+  // (axios additionally injects `application/x-www-form-urlencoded` for
+  // POST/PUT/PATCH when no Content-Type is set, which would replace anything
+  // removed in a request interceptor). Request and `bb api` bodies are
+  // unaffected: when `data` is present the header stays exactly as resolved.
+  const stockAdapter = axios.getAdapter(instance.defaults.adapter);
+  instance.defaults.adapter = async (config) => {
+    if (config.data == null) {
+      (config.headers as { delete(name: string): void }).delete('Content-Type');
+    }
+    return stockAdapter(config);
+  };
+
   // Request interceptor to add auth header (Basic or Bearer)
   instance.interceptors.request.use(
     async (config) => {

--- a/tests/services/api-client.content-type.test.ts
+++ b/tests/services/api-client.content-type.test.ts
@@ -11,7 +11,7 @@
  * actual wire headers (a mock adapter replaces the wrapper under test).
  */
 
-import { afterAll, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { Server } from 'node:http';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -56,29 +56,34 @@ async function startCaptureServer(): Promise<{
 }
 
 describe('createApiClient - Content-Type on bodyless requests (issue #321)', () => {
-  const captured: Array<{ server: Server }> = [];
+  let server: Server;
+  let client: AxiosInstance;
+  let requests: Map<string, CapturedRequest>;
+  let previousBaseUrl: string | undefined;
 
-  afterAll(() => {
-    for (const { server } of captured) server.close();
+  beforeEach(async () => {
+    // `BB_API_BASE_URL` is process-wide state; save the prior value so it can
+    // be restored in `afterEach`. Leaving it pointed at a server that is
+    // closed below would break later tests in this Bun process.
+    previousBaseUrl = process.env.BB_API_BASE_URL;
+
+    const capture = await startCaptureServer();
+    server = capture.server;
+    requests = capture.requests;
+    process.env.BB_API_BASE_URL = capture.baseUrl;
+    client = createApiClient(mockConfigService(), createMockOutputService());
   });
 
-  async function createClientAgainstCaptureServer(): Promise<{
-    client: AxiosInstance;
-    requests: Map<string, CapturedRequest>;
-  }> {
-    const { server, baseUrl, requests } = await startCaptureServer();
-    captured.push({ server });
-    process.env.BB_API_BASE_URL = baseUrl;
-    const client = createApiClient(
-      mockConfigService(),
-      createMockOutputService()
-    );
-    return { client, requests };
-  }
+  afterEach(() => {
+    server.close();
+    if (previousBaseUrl === undefined) {
+      delete process.env.BB_API_BASE_URL;
+    } else {
+      process.env.BB_API_BASE_URL = previousBaseUrl;
+    }
+  });
 
   it('omits Content-Type on a bodyless POST', async () => {
-    const { client, requests } = await createClientAgainstCaptureServer();
-
     await client.post('/bodyless-post');
 
     const request = requests.get('POST /bodyless-post');
@@ -87,8 +92,6 @@ describe('createApiClient - Content-Type on bodyless requests (issue #321)', () 
   });
 
   it('omits Content-Type on a bodyless DELETE (e.g. unapprove)', async () => {
-    const { client, requests } = await createClientAgainstCaptureServer();
-
     await client.delete('/bodyless-delete');
 
     const request = requests.get('DELETE /bodyless-delete');
@@ -97,8 +100,6 @@ describe('createApiClient - Content-Type on bodyless requests (issue #321)', () 
   });
 
   it('sends application/json when a POST carries a JSON object body', async () => {
-    const { client, requests } = await createClientAgainstCaptureServer();
-
     await client.post('/json-post', { draft: false });
 
     const request = requests.get('POST /json-post');
@@ -108,8 +109,6 @@ describe('createApiClient - Content-Type on bodyless requests (issue #321)', () 
   });
 
   it('sends application/json when a PUT carries a JSON object body (e.g. bb pr ready)', async () => {
-    const { client, requests } = await createClientAgainstCaptureServer();
-
     await client.put('/json-put', { type: 'pullrequest', draft: false });
 
     const request = requests.get('PUT /json-put');
@@ -121,8 +120,6 @@ describe('createApiClient - Content-Type on bodyless requests (issue #321)', () 
   });
 
   it('keeps Content-Type on a raw string body (e.g. bb api --input)', async () => {
-    const { client, requests } = await createClientAgainstCaptureServer();
-
     await client.post('/raw-body', '{"key":"value"}');
 
     const request = requests.get('POST /raw-body');

--- a/tests/services/api-client.content-type.test.ts
+++ b/tests/services/api-client.content-type.test.ts
@@ -1,0 +1,133 @@
+/**
+ * API Client Service tests - Content-Type handling on bodyless requests
+ *
+ * Regression tests for issue #321: the shared axios instance sets
+ * `Content-Type: application/json` as an instance default, which used to leak
+ * onto bodyless POSTs (`bb pr approve` / `bb pr decline`, `bb api -X POST`
+ * without fields). Bitbucket's request parser rejects an empty body declared
+ * as JSON with a bare-text 400 before the request reaches the endpoint. The
+ * fix strips `Content-Type` at the adapter level when the request carries no
+ * body, so these tests assert against a real local HTTP server to capture the
+ * actual wire headers (a mock adapter replaces the wrapper under test).
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test';
+import type { Server } from 'node:http';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createApiClient } from '../../src/services/api-client.service.js';
+import { createMockOutputService, mockConfigService } from '../setup.js';
+import type { AxiosInstance } from 'axios';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  contentType: string | undefined;
+  contentLength: string | undefined;
+  rawBody: string;
+}
+
+/** Start a local server that records one request per path and always replies 200. */
+async function startCaptureServer(): Promise<{
+  server: Server;
+  baseUrl: string;
+  requests: Map<string, CapturedRequest>;
+}> {
+  const requests = new Map<string, CapturedRequest>();
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const key = `${req.method} ${req.url}`;
+      requests.set(key, {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        contentType: req.headers['content-type'],
+        contentLength: req.headers['content-length'],
+        rawBody: Buffer.concat(chunks).toString('utf8'),
+      });
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${port}`, requests };
+}
+
+describe('createApiClient - Content-Type on bodyless requests (issue #321)', () => {
+  const captured: Array<{ server: Server }> = [];
+
+  afterAll(() => {
+    for (const { server } of captured) server.close();
+  });
+
+  async function createClientAgainstCaptureServer(): Promise<{
+    client: AxiosInstance;
+    requests: Map<string, CapturedRequest>;
+  }> {
+    const { server, baseUrl, requests } = await startCaptureServer();
+    captured.push({ server });
+    process.env.BB_API_BASE_URL = baseUrl;
+    const client = createApiClient(
+      mockConfigService(),
+      createMockOutputService()
+    );
+    return { client, requests };
+  }
+
+  it('omits Content-Type on a bodyless POST', async () => {
+    const { client, requests } = await createClientAgainstCaptureServer();
+
+    await client.post('/bodyless-post');
+
+    const request = requests.get('POST /bodyless-post');
+    expect(request).toBeDefined();
+    expect(request?.contentType).toBeUndefined();
+  });
+
+  it('omits Content-Type on a bodyless DELETE (e.g. unapprove)', async () => {
+    const { client, requests } = await createClientAgainstCaptureServer();
+
+    await client.delete('/bodyless-delete');
+
+    const request = requests.get('DELETE /bodyless-delete');
+    expect(request).toBeDefined();
+    expect(request?.contentType).toBeUndefined();
+  });
+
+  it('sends application/json when a POST carries a JSON object body', async () => {
+    const { client, requests } = await createClientAgainstCaptureServer();
+
+    await client.post('/json-post', { draft: false });
+
+    const request = requests.get('POST /json-post');
+    expect(request).toBeDefined();
+    expect(request?.contentType).toBe('application/json');
+    expect(request?.rawBody).toBe(JSON.stringify({ draft: false }));
+  });
+
+  it('sends application/json when a PUT carries a JSON object body (e.g. bb pr ready)', async () => {
+    const { client, requests } = await createClientAgainstCaptureServer();
+
+    await client.put('/json-put', { type: 'pullrequest', draft: false });
+
+    const request = requests.get('PUT /json-put');
+    expect(request).toBeDefined();
+    expect(request?.contentType).toBe('application/json');
+    expect(request?.rawBody).toBe(
+      JSON.stringify({ type: 'pullrequest', draft: false })
+    );
+  });
+
+  it('keeps Content-Type on a raw string body (e.g. bb api --input)', async () => {
+    const { client, requests } = await createClientAgainstCaptureServer();
+
+    await client.post('/raw-body', '{"key":"value"}');
+
+    const request = requests.get('POST /raw-body');
+    expect(request).toBeDefined();
+    expect(request?.contentType).toBe('application/json');
+    expect(request?.rawBody).toBe('{"key":"value"}');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #321. Bodyless POSTs and DELETEs (`bb pr approve`, `bb pr decline`, `bb commit approve`, `bb api -X POST` without fields, …) inherited the shared axios instance's `Content-Type: application/json` default and went out as `Content-Type: application/json` + `Content-Length: 0`. Bitbucket's request parser rejects an empty body declared as JSON with a bare-text 400 before the request reaches the endpoint — confirmed locally by capturing the actual wire requests through `BB_API_BASE_URL`, reproducing the reporter's table exactly.

## Why adapter-level stripping (not the fix suggested in the issue)

The issue's option 1/2 (drop the instance default) is **insufficient on axios 1.19**: `dispatchRequest` hardcodes `setContentType('application/x-www-form-urlencoded', false)` for POST/PUT/PATCH, so bodyless POSTs then declare `application/x-www-form-urlencoded` with an empty body — a variant that was never tested against Bitbucket. A request interceptor also cannot fix it, because it runs *before* `dispatchRequest`. The only reliable hook is the adapter, which runs after all header finalization.

## Changes

- `src/services/api-client.service.ts`: wrap the stock adapter; delete `Content-Type` from the resolved headers when `config.data == null`. Body-carrying requests (JSON objects, raw `--input` strings, multipart snippet uploads) are untouched.
- `tests/services/api-client.content-type.test.ts`: wire-level regression tests against a local capture server (mock adapters would replace the wrapper under test). Verified red/green: the two bodyless cases fail on `main`, all pass with the fix.
- Changeset (patch bump) referencing #321.

## Verification

- Reproduction script through the real generated `PullrequestsApi`: `decline`/`approve` now send no `Content-Type` (identical to the reporter's working curl); `ready` PUT still sends `application/json` with its body.
- Full suite: 1675 pass / 0 fail; `tsc --noEmit` and prettier clean.